### PR TITLE
[codex] Fix admin signout menu layer

### DIFF
--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
@@ -37,7 +37,9 @@ select {
 }
 
 .nx-topbar {
+  position: relative;
   grid-column: 1 / -1;
+  z-index: 80;
   display: flex;
   align-items: center;
   min-width: 0;

--- a/admin-ui/src/main/resources/META-INF/resources/admin/index.html
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>nexus-plus administration</title>
     <link rel="icon" type="image/svg+xml" href="/admin/assets/favicon.svg?v=20260609-kl-logo-1">
-    <link rel="stylesheet" href="./assets/admin.css?v=20260612-sticky-heading-1">
+    <link rel="stylesheet" href="./assets/admin.css?v=20260615-user-menu-layer-1">
   </head>
   <body>
     <div class="nx-shell">


### PR DESCRIPTION
## Summary
- Raise the admin top bar stacking context above sticky page headings.
- Refresh the admin CSS cache-buster so the running UI loads the corrected stylesheet.

## Root Cause
The user menu popover used the same z-index layer as sticky page headings, while the top bar did not create a higher stacking context. The sticky heading could paint over the Sign out menu.

## Validation
- `mvn -pl admin-ui process-resources -q`
- `git diff --check`
- Verified the live `http://127.0.0.1:18090/admin/` page with headless Chrome/CDP: the expanded Sign out menu hit-tests to `#signout-button`, with the top bar z-index above the sticky heading.