### PR TITLE
docs: add public image quickstart

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -13,6 +13,22 @@
 - `/admin/` 下的轻量运维管理控制台
 - `/browse/` 下的用户侧仓库浏览器
 
+## 快速开始
+
+使用公开发行镜像和 MySQL 在本地启动一个试用环境：
+
+```bash
+mkdir -p nexus-plus-quickstart && cd nexus-plus-quickstart && curl -fsSLO https://raw.githubusercontent.com/klboke/nexus-plus/main/docker-compose.quickstart.yml && docker compose -f docker-compose.quickstart.yml up -d
+```
+
+启动后访问：
+
+- 管理控制台：`http://127.0.0.1:19090/admin/`
+- 用户侧浏览器：`http://127.0.0.1:19090/browse/`
+- 健康检查：`http://127.0.0.1:19091/actuator/health`
+
+首次进入页面时，在 UI 中创建初始 `Local/admin` 管理员密码。quickstart 使用 File blob storage 作为本地试用存储；生产环境请改用 OSS/S3，并替换为自己的加密密钥。
+
 ## 构建和部署
 
 本地快速启动、Spring Boot 可执行 jar、Docker 镜像、压缩包、生产部署架构、资源规格和升级流程见 [构建部署指南](docs/zh/build-deployment-guide.md)。

--- a/README.md
+++ b/README.md
@@ -15,6 +15,22 @@ The project keeps Nexus-compatible client protocols, the Nexus permission/authen
 - Lightweight operations console under `/admin/`
 - User-facing repository browser under `/browse/`
 
+## Quick Start
+
+Start a local trial environment with the public release image and MySQL:
+
+```bash
+mkdir -p nexus-plus-quickstart && cd nexus-plus-quickstart && curl -fsSLO https://raw.githubusercontent.com/klboke/nexus-plus/main/docker-compose.quickstart.yml && docker compose -f docker-compose.quickstart.yml up -d
+```
+
+Open:
+
+- Admin console: `http://127.0.0.1:19090/admin/`
+- User browser: `http://127.0.0.1:19090/browse/`
+- Health check: `http://127.0.0.1:19091/actuator/health`
+
+On the first visit, create the initial `Local/admin` administrator password in the UI. The quickstart uses File blob storage for local trials; use OSS/S3 and your own encryption secrets for production.
+
 ## Build And Deployment
 
 Local quick start, Spring Boot executable jar, Docker image, archive package, production deployment architecture, resource sizing, and upgrade flow are documented in the [Build And Deployment Guide](docs/es/build-deployment-guide.md).

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -1,0 +1,51 @@
+name: nexus-plus-quickstart
+
+services:
+  mysql:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: nexus_plus_root
+      MYSQL_DATABASE: nexus_plus
+      MYSQL_USER: nexus_plus
+      MYSQL_PASSWORD: nexus_plus
+      TZ: Asia/Shanghai
+    volumes:
+      - mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -uroot -p$${MYSQL_ROOT_PASSWORD} --silent"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+
+  app-data-perms:
+    image: alpine:3.20
+    user: root
+    volumes:
+      - nexus-plus-data:/data
+    command: ["sh", "-c", "mkdir -p /data/blobs && chown -R 999:999 /data"]
+
+  nexus-plus:
+    image: ghcr.io/klboke/nexus-plus:0.1.0
+    depends_on:
+      mysql:
+        condition: service_healthy
+      app-data-perms:
+        condition: service_completed_successfully
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/nexus_plus?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=Asia/Shanghai&allowPublicKeyRetrieval=true
+      SPRING_DATASOURCE_USERNAME: nexus_plus
+      SPRING_DATASOURCE_PASSWORD: nexus_plus
+      NEXUS_PLUS_CREDENTIAL_SECRET: quickstart-credential-secret-change-me-0123456789
+      NEXUS_PLUS_API_KEY_PAYLOAD_SECRET: quickstart-api-key-payload-secret-change-me-0123456789
+      NEXUS_PLUS_FILE_BASE_DIR: /var/lib/nexus-plus/blobs
+    ports:
+      - "19090:8080"
+      - "19091:8081"
+    volumes:
+      - nexus-plus-data:/var/lib/nexus-plus
+    restart: unless-stopped
+
+volumes:
+  mysql-data:
+  nexus-plus-data:

--- a/docs/es/build-deployment-guide.md
+++ b/docs/es/build-deployment-guide.md
@@ -11,7 +11,44 @@ This document covers local startup, release builds, archive package deployment, 
 
 The service requires MySQL at runtime. For local trials, the blob store can use File storage. For production, OSS/S3 is recommended.
 
-## Local Quick Start
+## Docker Compose Quick Trial
+
+For a quick local trial, start nexus-plus and MySQL with the public release image:
+
+```bash
+mkdir -p nexus-plus-quickstart && cd nexus-plus-quickstart && curl -fsSLO https://raw.githubusercontent.com/klboke/nexus-plus/main/docker-compose.quickstart.yml && docker compose -f docker-compose.quickstart.yml up -d
+```
+
+This command downloads `docker-compose.quickstart.yml` and starts:
+
+- `ghcr.io/klboke/nexus-plus:0.1.0`
+- MySQL 8.0
+- Persistent MySQL and File blob storage volumes for local trials
+
+After startup, open:
+
+- Admin console: `http://127.0.0.1:19090/admin/`
+- User browser: `http://127.0.0.1:19090/browse/`
+- Health check: `http://127.0.0.1:19091/actuator/health`
+- Prometheus metrics: `http://127.0.0.1:19091/actuator/prometheus`
+
+On the first visit, create the initial `Local/admin` administrator password in the UI. After entering the admin console, create a blob store named `default`. File is fine for local trials; OSS/S3 is recommended for production.
+
+Stop the trial environment:
+
+```bash
+docker compose -f docker-compose.quickstart.yml down
+```
+
+Remove all trial data:
+
+```bash
+docker compose -f docker-compose.quickstart.yml down -v
+```
+
+The encryption secrets bundled in the quickstart compose file are only for local trials. For externally reachable deployments, replace `NEXUS_PLUS_CREDENTIAL_SECRET` and `NEXUS_PLUS_API_KEY_PAYLOAD_SECRET`, and use an independent MySQL instance plus OSS/S3 blob storage.
+
+## Source Local Quick Start
 
 Create a local database and account:
 
@@ -63,6 +100,18 @@ server/target/nexus-plus-server-<version>.jar
 Note: a normal `server` module jar does not contain a Spring Boot executable entrypoint. Before copying or deploying `server/target/nexus-plus-server-*.jar`, run `spring-boot:repackage`.
 
 ## Docker Image
+
+Pull the first public release image:
+
+```bash
+docker pull ghcr.io/klboke/nexus-plus:0.1.0
+```
+
+You can also use `latest` to follow the latest public release:
+
+```bash
+docker pull ghcr.io/klboke/nexus-plus:latest
+```
 
 Build the default image:
 

--- a/docs/zh/build-deployment-guide.md
+++ b/docs/zh/build-deployment-guide.md
@@ -11,7 +11,44 @@
 
 服务运行时依赖 MySQL。blob store 本地试用可以使用 File，生产环境建议使用 OSS/S3。
 
-## 本地快速启动
+## Docker Compose 快速试用
+
+如果只是想快速体验，可以用公开发行镜像一条命令拉起 nexus-plus 和 MySQL：
+
+```bash
+mkdir -p nexus-plus-quickstart && cd nexus-plus-quickstart && curl -fsSLO https://raw.githubusercontent.com/klboke/nexus-plus/main/docker-compose.quickstart.yml && docker compose -f docker-compose.quickstart.yml up -d
+```
+
+该命令会下载 `docker-compose.quickstart.yml`，启动：
+
+- `ghcr.io/klboke/nexus-plus:0.1.0`
+- MySQL 8.0
+- 用于本地试用的持久化 MySQL volume 和 File blob storage volume
+
+启动后访问：
+
+- 管理控制台：`http://127.0.0.1:19090/admin/`
+- 用户侧浏览器：`http://127.0.0.1:19090/browse/`
+- 健康检查：`http://127.0.0.1:19091/actuator/health`
+- Prometheus 指标：`http://127.0.0.1:19091/actuator/prometheus`
+
+首次进入页面时，在 UI 中创建初始 `Local/admin` 管理员密码。进入管理控制台后，先创建名为 `default` 的 blob store；本地试用可以选择 File，生产环境建议使用 OSS/S3。
+
+停止试用环境：
+
+```bash
+docker compose -f docker-compose.quickstart.yml down
+```
+
+清空试用数据：
+
+```bash
+docker compose -f docker-compose.quickstart.yml down -v
+```
+
+quickstart compose 内置的加密密钥仅用于本地试用。对外部署时必须替换 `NEXUS_PLUS_CREDENTIAL_SECRET` 和 `NEXUS_PLUS_API_KEY_PAYLOAD_SECRET`，并使用独立 MySQL 与 OSS/S3 blob store。
+
+## 源码本地快速启动
 
 创建本地数据库和账号：
 
@@ -63,6 +100,18 @@ server/target/nexus-plus-server-<version>.jar
 注意：普通 `server` 模块 jar 没有 Spring Boot 可执行入口。需要复制或部署 `server/target/nexus-plus-server-*.jar` 时，必须先执行 `spring-boot:repackage`。
 
 ## Docker 镜像
+
+拉取首个公开发行镜像：
+
+```bash
+docker pull ghcr.io/klboke/nexus-plus:0.1.0
+```
+
+也可以使用 `latest` 跟随最新公开发行版本：
+
+```bash
+docker pull ghcr.io/klboke/nexus-plus:latest
+```
 
 构建默认镜像：
 


### PR DESCRIPTION
## Summary

- add `docker-compose.quickstart.yml` using the public GHCR release image and MySQL
- document a one-command local trial flow in README and README.cn
- update zh/en build deployment guides with quickstart, public image pull commands, stop and cleanup commands

## Validation

- `docker compose -f docker-compose.quickstart.yml config`
- `git diff --check`
- `docker compose -f docker-compose.quickstart.yml up -d`
- `curl http://127.0.0.1:19091/actuator/health` returned `UP`
- `/browse/` returned `200`, `/admin/` redirected to login/bootstrap flow, `/actuator/prometheus` returned `200`
- quickstart MySQL applied 24 successful Flyway migrations, latest version 24
- `docker compose -f docker-compose.quickstart.yml down -v`