### PR TITLE
docs: add Telegram support link

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -138,6 +138,10 @@ AI agent 和贡献者的开发说明见 [AGENTS.md](AGENTS.md)。
 
 本地开发和测试说明见 [中文开发指南](docs/zh/development-guide.md)；构建部署说明见 [构建部署指南](docs/zh/build-deployment-guide.md)；AI agent 和贡献者约束见 [AGENTS.md](AGENTS.md)。
 
+## 支持
+
+加入 [nexus-plus Telegram 群](https://t.me/+M6prtFUGnF9kYTU1) 获取社区支持和使用交流。
+
 ## Security
 
 如果发现安全问题，请按 [SECURITY.md](SECURITY.md) 说明优先通过 GitHub Security Advisory 报告，避免在公开 issue 中直接披露可利用细节。普通 bug、兼容性问题和功能建议可以直接提交 issue。

--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ Issues and pull requests are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for
 
 Local development and testing are documented in the [Development Guide](docs/es/development-guide.md). Build and deployment are documented in the [Build And Deployment Guide](docs/es/build-deployment-guide.md). AI agent and contributor constraints are in [AGENTS.md](AGENTS.md).
 
+## Support
+
+Join the [nexus-plus Telegram group](https://t.me/+M6prtFUGnF9kYTU1) for community support and usage discussion.
+
 ## Security
 
 If you find a security issue, follow [SECURITY.md](SECURITY.md) and report it through GitHub Security Advisory first. Avoid disclosing exploitable details in public issues. Regular bugs, compatibility issues, and feature requests can be submitted as public issues.


### PR DESCRIPTION
## Summary

- add a Support section to README with the Telegram group link
- add a Chinese 支持 section to README.cn with the same support channel

## Validation

- `git diff --check`