### PR TITLE
[codex] Upgrade core runtime dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre-jammy
+FROM eclipse-temurin:25-jre-jammy
 
 WORKDIR /app
 

--- a/compat-test/pom.xml
+++ b/compat-test/pom.xml
@@ -27,7 +27,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.26.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -35,12 +35,14 @@
 
   <properties>
     <java.version>21</java.version>
-    <spring.boot.version>3.3.7</spring.boot.version>
+    <spring.boot.version>4.1.0</spring.boot.version>
     <apollo.client.version>2.5.0</apollo.client.version>
     <guava.version>33.6.0-jre</guava.version>
-    <guice.version>5.0.1</guice.version>
+    <guice.version>7.0.0</guice.version>
     <maven.artifact.version>3.9.16</maven.artifact.version>
-    <aws.sdk.version>2.33.5</aws.sdk.version>
+    <aws.sdk.version>2.46.11</aws.sdk.version>
+    <commons.compress.version>1.28.0</commons.compress.version>
+    <commons.lang3.version>3.18.0</commons.lang3.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <nexus.plus.dist.version>${project.version}</nexus.plus.dist.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -89,6 +91,16 @@
         <groupId>com.google.inject</groupId>
         <artifactId>guice</artifactId>
         <version>${guice.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>${commons.compress.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${commons.lang3.version}</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>

--- a/protocol-helm/pom.xml
+++ b/protocol-helm/pom.xml
@@ -19,7 +19,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.26.2</version>
     </dependency>
     <dependency>
       <groupId>org.yaml</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -47,6 +47,10 @@
       <artifactId>flyway-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-flyway</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.flywaydb</groupId>
       <artifactId>flyway-mysql</artifactId>
     </dependency>
@@ -119,7 +123,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.26.2</version>
     </dependency>
     <dependency>
       <groupId>com.github.klboke</groupId>

--- a/server/src/main/java/com/github/klboke/nexusplus/server/Jackson2Configuration.java
+++ b/server/src/main/java/com/github/klboke/nexusplus/server/Jackson2Configuration.java
@@ -1,0 +1,27 @@
+package com.github.klboke.nexusplus.server;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.util.TimeZone;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class Jackson2Configuration {
+
+  @Bean
+  @ConditionalOnMissingBean(ObjectMapper.class)
+  ObjectMapper jackson2ObjectMapper(@Value("${spring.jackson.time-zone:Asia/Shanghai}") String timeZone) {
+    return new ObjectMapper()
+        .registerModule(new JavaTimeModule())
+        .setTimeZone(TimeZone.getTimeZone(timeZone))
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+  }
+}

--- a/server/src/main/java/com/github/klboke/nexusplus/server/TomcatRepositoryPathConfiguration.java
+++ b/server/src/main/java/com/github/klboke/nexusplus/server/TomcatRepositoryPathConfiguration.java
@@ -2,7 +2,7 @@ package com.github.klboke.nexusplus.server;
 
 import org.apache.catalina.connector.Connector;
 import org.apache.tomcat.util.buf.EncodedSolidusHandling;
-import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.tomcat.servlet.TomcatServletWebServerFactory;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -40,6 +40,7 @@ spring.session.jdbc.flush-mode=on_save
 spring.servlet.multipart.max-file-size=${NEXUS_PLUS_MULTIPART_MAX_FILE_SIZE:1024MB}
 spring.servlet.multipart.max-request-size=${NEXUS_PLUS_MULTIPART_MAX_REQUEST_SIZE:1024MB}
 spring.jackson.default-property-inclusion=non_null
+spring.http.converters.preferred-json-mapper=jackson2
 spring.jackson.time-zone=Asia/Shanghai
 spring.lifecycle.timeout-per-shutdown-phase=30s
 spring.task.scheduling.pool.size=${NEXUS_PLUS_TASK_SCHEDULING_POOL_SIZE:4}


### PR DESCRIPTION
## Summary
- Upgrade Spring Boot to 4.1.0, Guice to 7.0.0, AWS SDK BOM to 2.46.11, and Docker runtime to Eclipse Temurin 25.
- Align commons-compress through dependency management at 1.28.0 and pin commons-lang3 at 3.18.0 to avoid the runtime NoSuchMethodError seen in Helm archive handling.
- Add Boot 4 compatibility wiring for Tomcat, Jackson 2 HTTP/internal ObjectMapper usage, and Flyway auto-configuration.

## Runtime notes
- Spring Boot 4 defaults to the Jackson 3 mapper; nexus-plus still uses Jackson 2 annotations/API internally, so this PR explicitly selects `spring.http.converters.preferred-json-mapper=jackson2` and provides a Jackson 2 `ObjectMapper`.
- Boot 4 requires the Flyway starter/auto-config module for startup migrations; the container smoke verified 24 migrations applied on a fresh MySQL schema.

## Validation
- `mvn -B -ntp -pl protocol-helm -am test`
- `mvn -B -ntp -pl server -am -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -B -ntp -pl compat-test -am -Dtest=MavenMetadataMergeCompatibilityTest,MavenWritePolicyCompatibilityTest,NpmProtocolCompatibilityTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -B -ntp -pl server -am -DskipTests package spring-boot:repackage`
- `scripts/build-docker-image.sh nexus-plus:dependency-upgrade-wave`
- Docker smoke on Java 25 image with a fresh MySQL schema: `/actuator/health` returned `UP`, Flyway applied 24 migrations, `/admin/` returned the expected login redirect.
- `git diff --check`