### PR TITLE
Configure async request timeout

### DIFF
--- a/server/src/dist/conf/application.properties
+++ b/server/src/dist/conf/application.properties
@@ -29,6 +29,7 @@ server.tomcat.threads.min-spare=10
 server.tomcat.max-connections=2000
 server.tomcat.accept-count=200
 server.tomcat.connection-timeout=30s
+spring.mvc.async.request-timeout=10m
 
 server.servlet.session.timeout=24h
 server.servlet.session.cookie.max-age=-1

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -7,6 +7,7 @@ server.tomcat.threads.min-spare=${KKREPO_TOMCAT_THREADS_MIN_SPARE:10}
 server.tomcat.max-connections=${KKREPO_TOMCAT_MAX_CONNECTIONS:2000}
 server.tomcat.accept-count=${KKREPO_TOMCAT_ACCEPT_COUNT:200}
 server.tomcat.connection-timeout=${KKREPO_TOMCAT_CONNECTION_TIMEOUT:30s}
+spring.mvc.async.request-timeout=10m
 server.servlet.context-path=/
 server.servlet.session.timeout=${KKREPO_SESSION_TIMEOUT:24h}
 server.servlet.session.cookie.max-age=${KKREPO_SESSION_COOKIE_MAX_AGE:-1}


### PR DESCRIPTION
## Summary
- Set Spring MVC async request timeout to 10 minutes in the packaged default configuration.
- Mirror the same timeout in the archive distribution config template.

## Verification
- git diff --check
- JAVA_HOME=/opt/homebrew/Cellar/openjdk@25/25.0.3/libexec/openjdk.jdk/Contents/Home mvn -pl server -am -DskipTests compile