### PR TITLE
Fix CodeQL security scanning alerts

### DIFF
--- a/persistence-mysql/src/main/java/com/github/klboke/kkrepo/persistence/mysql/dao/ComponentDao.java
+++ b/persistence-mysql/src/main/java/com/github/klboke/kkrepo/persistence/mysql/dao/ComponentDao.java
@@ -311,19 +311,28 @@ public class ComponentDao {
     tokens.add(value);
   }
 
-  private static String fulltextBooleanQuery(String keyword) {
+  static String fulltextBooleanQuery(String keyword) {
     if (keyword == null || keyword.isBlank()) return "";
-    String normalized = keyword.toLowerCase(Locale.ROOT)
-        .replaceAll("[^\\p{Alnum}]+", " ")
-        .trim();
-    if (normalized.isBlank()) return "";
     List<String> terms = new ArrayList<>();
-    for (String token : normalized.split("\\s+")) {
-      String cleaned = token.replaceAll("^[+\\-~<>()*@\"]+|[+\\-~<>()*@\"]+$", "");
-      if (cleaned.isBlank()) continue;
-      terms.add("+" + cleaned + "*");
+    StringBuilder token = new StringBuilder();
+    for (int i = 0; i < keyword.length(); i++) {
+      char c = keyword.charAt(i);
+      if (Character.isLetterOrDigit(c)) {
+        token.append(Character.toLowerCase(c));
+      } else {
+        addFulltextTerm(terms, token);
+      }
     }
+    addFulltextTerm(terms, token);
     return String.join(" ", terms);
+  }
+
+  private static void addFulltextTerm(List<String> terms, StringBuilder token) {
+    if (token.isEmpty()) {
+      return;
+    }
+    terms.add("+" + token + "*");
+    token.setLength(0);
   }
 
   public long countByRepositoryId(long repositoryId) {

--- a/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/ComponentDaoTest.java
+++ b/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/ComponentDaoTest.java
@@ -67,6 +67,15 @@ class ComponentDaoTest {
     Assertions.assertFalse(jdbcTemplate.sql.contains("ORDER BY c.last_updated_at DESC, r.name"));
   }
 
+  @Test
+  void fulltextBooleanQueryTokenizesWithoutRegexBacktracking() {
+    String keyword = "\"".repeat(4096) + "Com.Example artifact-1.0";
+
+    Assertions.assertEquals(
+        "+com* +example* +artifact* +1* +0*",
+        ComponentDao.fulltextBooleanQuery(keyword));
+  }
+
   private static final class CountingJdbcTemplate extends JdbcTemplate {
     private final long[] ids;
     private final AtomicInteger executeCalls = new AtomicInteger();

--- a/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClient.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClient.java
@@ -4,6 +4,7 @@ import com.github.klboke.kkrepo.cache.SharedCache;
 import com.github.klboke.kkrepo.protocol.docker.DockerErrorCode;
 import com.github.klboke.kkrepo.protocol.docker.DockerProtocolException;
 import com.github.klboke.kkrepo.server.maven.HttpRemoteFetcher;
+import com.github.klboke.kkrepo.server.maven.RemoteUrlBuilder;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import com.github.klboke.kkrepo.server.metrics.KkRepoMetrics;
 import com.github.klboke.kkrepo.server.security.OutboundRequestPolicy;
@@ -234,12 +235,12 @@ public class DockerRemoteRegistryClient {
     String path = remotePath == null ? "" : remotePath;
     while (path.startsWith("/")) path = path.substring(1);
     if (base.endsWith("/v2")) {
-      return base + "/" + path;
+      return RemoteUrlBuilder.repositoryPathString(base, path);
     }
     if (base.contains("/v2/")) {
-      return base + "/" + path;
+      return RemoteUrlBuilder.repositoryPathString(base, path);
     }
-    return base + "/v2/" + path;
+    return RemoteUrlBuilder.repositoryPathString(base + "/v2", path);
   }
 
   private static String encode(String value) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/goartifact/GoProxyService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/goartifact/GoProxyService.java
@@ -15,6 +15,7 @@ import com.github.klboke.kkrepo.server.maven.HttpRemoteFetcher;
 import com.github.klboke.kkrepo.server.maven.MavenExceptions;
 import com.github.klboke.kkrepo.server.maven.MavenResponse;
 import com.github.klboke.kkrepo.server.maven.ProxyNegativeCache;
+import com.github.klboke.kkrepo.server.maven.RemoteUrlBuilder;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import java.io.IOException;
 import java.time.Instant;
@@ -228,11 +229,7 @@ public class GoProxyService {
   }
 
   private static String buildRemoteUrl(String base, String path) {
-    if (base == null || base.isBlank()) {
-      throw new IllegalStateException("Proxy repository has no remote URL configured");
-    }
-    String prefix = base.endsWith("/") ? base : base + "/";
-    return prefix + path;
+    return RemoteUrlBuilder.repositoryPathString(base, path);
   }
 
   private static String stringAttr(Map<String, Object> attrs, String key) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/helm/HelmProxyService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/helm/HelmProxyService.java
@@ -12,6 +12,7 @@ import com.github.klboke.kkrepo.server.maven.HttpRemoteFetcher;
 import com.github.klboke.kkrepo.server.maven.MavenExceptions;
 import com.github.klboke.kkrepo.server.maven.MavenResponse;
 import com.github.klboke.kkrepo.server.maven.ProxyNegativeCache;
+import com.github.klboke.kkrepo.server.maven.RemoteUrlBuilder;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import com.github.klboke.kkrepo.server.maven.UpstreamBodyReadException;
 import java.io.IOException;
@@ -354,11 +355,7 @@ public class HelmProxyService {
   }
 
   private static String buildRemoteUrl(String base, String path) {
-    if (base == null || base.isBlank()) {
-      throw new IllegalStateException("Proxy repository has no remote URL configured");
-    }
-    String prefix = base.endsWith("/") ? base : base + "/";
-    return prefix + path;
+    return RemoteUrlBuilder.repositoryPathString(base, path);
   }
 
   private static String fileName(String path) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcher.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcher.java
@@ -15,6 +15,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import com.github.klboke.kkrepo.server.security.OutboundRequestPolicy;
+import com.github.klboke.kkrepo.server.security.SecurityValidationException;
 import com.github.klboke.kkrepo.server.metrics.KkRepoMetrics;
 import io.micrometer.core.instrument.Timer;
 import org.slf4j.Logger;
@@ -145,7 +146,7 @@ public class HttpRemoteFetcher {
   }
 
   private Result fetchInternal(Request req, int redirects) throws IOException {
-    URI uri = outboundPolicy.validateHttpUri(req.url(), "remote fetch");
+    var uri = req.validatedUri(outboundPolicy, "remote fetch");
     HttpRequest.Builder b = HttpRequest.newBuilder()
         .uri(uri)
         .timeout(requestTimeout(req))
@@ -169,7 +170,7 @@ public class HttpRemoteFetcher {
         if (redirects >= MAX_REDIRECTS) {
           throw new IOException("Too many redirects fetching " + req.url());
         }
-        URI redirected = outboundPolicy.validateHttpUri(uri.resolve(redirect.get()), "remote redirect");
+        var redirected = outboundPolicy.validateHttpUri(uri.resolve(redirect.get()), "remote redirect");
         return fetchInternal(new Request(
             redirected.toString(),
             req.etag(),
@@ -270,9 +271,10 @@ public class HttpRemoteFetcher {
       TimeoutProfile timeoutProfile,
       boolean headOnly,
       String repository,
-      String format) {
+      String format,
+      String trustedHost) {
     public Request(String url, String etag, Instant lastModified, Duration timeout, boolean headOnly) {
-      this(url, etag, lastModified, timeout, TimeoutProfile.DEFAULT, headOnly, null, null);
+      this(url, etag, lastModified, timeout, TimeoutProfile.DEFAULT, headOnly, null, null, null);
     }
 
     public Request(
@@ -284,6 +286,19 @@ public class HttpRemoteFetcher {
         boolean headOnly,
         String repository,
         String format) {
+      this(url, etag, lastModified, timeout, timeoutProfile, headOnly, repository, format, null);
+    }
+
+    public Request(
+        String url,
+        String etag,
+        Instant lastModified,
+        Duration timeout,
+        TimeoutProfile timeoutProfile,
+        boolean headOnly,
+        String repository,
+        String format,
+        String trustedHost) {
       this.url = url;
       this.etag = etag;
       this.lastModified = lastModified;
@@ -292,6 +307,7 @@ public class HttpRemoteFetcher {
       this.headOnly = headOnly;
       this.repository = repository;
       this.format = format;
+      this.trustedHost = trustedHost;
     }
 
     public static Request get(String url) {
@@ -299,11 +315,11 @@ public class HttpRemoteFetcher {
     }
 
     public Request withConditional(String etag, Instant lastModified) {
-      return new Request(url, etag, lastModified, timeout, timeoutProfile, headOnly, repository, format);
+      return new Request(url, etag, lastModified, timeout, timeoutProfile, headOnly, repository, format, trustedHost);
     }
 
     public Request withTimeoutProfile(TimeoutProfile timeoutProfile) {
-      return new Request(url, etag, lastModified, timeout, timeoutProfile, headOnly, repository, format);
+      return new Request(url, etag, lastModified, timeout, timeoutProfile, headOnly, repository, format, trustedHost);
     }
 
     public Request withRepository(RepositoryRuntime runtime) {
@@ -315,11 +331,36 @@ public class HttpRemoteFetcher {
           timeoutProfile,
           headOnly,
           runtime == null ? null : runtime.name(),
-          runtime == null || runtime.format() == null ? null : runtime.format().name());
+          runtime == null || runtime.format() == null ? null : runtime.format().name(),
+          trustedRemoteHost(url, runtime));
     }
 
     public String method() {
       return headOnly ? "HEAD" : "GET";
+    }
+
+    java.net.URI validatedUri(OutboundRequestPolicy policy, String purpose) {
+      URI uri = policy.validateHttpUri(url, purpose);
+      if (trustedHost != null && !uri.getHost().equals(trustedHost)) {
+        throw new SecurityValidationException(purpose + " URL host must remain " + trustedHost);
+      }
+      return uri;
+    }
+
+    private static String trustedRemoteHost(String url, RepositoryRuntime runtime) {
+      if (runtime == null || runtime.proxyRemoteUrl() == null || runtime.proxyRemoteUrl().isBlank()) {
+        return null;
+      }
+      try {
+        String baseHost = URI.create(runtime.proxyRemoteUrl()).getHost();
+        String requestHost = URI.create(url).getHost();
+        if (baseHost != null && requestHost != null && requestHost.equals(baseHost)) {
+          return baseHost;
+        }
+      } catch (RuntimeException ignored) {
+        return null;
+      }
+      return null;
     }
   }
 

--- a/server/src/main/java/com/github/klboke/kkrepo/server/maven/MavenHtmlListingService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/maven/MavenHtmlListingService.java
@@ -17,6 +17,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import org.springframework.web.util.HtmlUtils;
 import org.springframework.stereotype.Service;
 
 /**
@@ -287,10 +288,7 @@ public class MavenHtmlListingService {
 
   private static String escape(String s) {
     if (s == null) return "";
-    return s.replace("&", "&amp;")
-        .replace("<", "&lt;")
-        .replace(">", "&gt;")
-        .replace("\"", "&quot;");
+    return HtmlUtils.htmlEscape(s, "UTF-8");
   }
 
   private record ListingPath(String storagePath, String displayPath, boolean stripPypiPackages) {}

--- a/server/src/main/java/com/github/klboke/kkrepo/server/maven/MavenProxyService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/maven/MavenProxyService.java
@@ -311,11 +311,7 @@ public class MavenProxyService {
   }
 
   private static String buildRemoteUrl(String base, String path) {
-    if (base == null || base.isBlank()) {
-      throw new IllegalStateException("Proxy repository has no remote URL configured");
-    }
-    String prefix = base.endsWith("/") ? base : base + "/";
-    return prefix + path;
+    return RemoteUrlBuilder.repositoryPathString(base, path);
   }
 
   private static String stringAttr(Map<String, Object> attrs, String key) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/maven/RemoteUrlBuilder.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/maven/RemoteUrlBuilder.java
@@ -1,0 +1,149 @@
+package com.github.klboke.kkrepo.server.maven;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+public final class RemoteUrlBuilder {
+  private RemoteUrlBuilder() {
+  }
+
+  public static URI repositoryPath(String base, String path) {
+    URI baseUri = repositoryBase(base);
+    String normalizedPath = path == null ? "" : path;
+    return baseUri.resolve(encodePath(normalizedPath));
+  }
+
+  public static URI repositoryPathWithQuery(String base, String path, String query) {
+    URI pathUri = repositoryPath(base, path);
+    if (query == null || query.isBlank()) {
+      return pathUri;
+    }
+    return URI.create(pathUri.toString() + "?" + query);
+  }
+
+  public static String repositoryPathString(String base, String path) {
+    return repositoryPath(base, path).toString();
+  }
+
+  public static String repositoryPathWithQueryString(String base, String path, String query) {
+    return repositoryPathWithQuery(base, path, query).toString();
+  }
+
+  public static URI repositoryBase(String base) {
+    if (base == null || base.isBlank()) {
+      throw new IllegalStateException("Proxy repository has no remote URL configured");
+    }
+    URI uri = URI.create(base);
+    String raw = uri.toString();
+    return raw.endsWith("/") ? uri : URI.create(raw + "/");
+  }
+
+  public static String encodePath(String path) {
+    if (path == null || path.isEmpty()) {
+      return "";
+    }
+    StringBuilder leadingSlashes = new StringBuilder();
+    while (path.startsWith("/")) {
+      leadingSlashes.append("%2F");
+      path = path.substring(1);
+    }
+    String[] segments = path.split("/", -1);
+    StringBuilder out = new StringBuilder(path.length() + leadingSlashes.length() + 16);
+    out.append(leadingSlashes);
+    for (int i = 0; i < segments.length; i++) {
+      if (i > 0) {
+        out.append('/');
+      }
+      out.append(encodeSegment(segments[i], i == 0));
+    }
+    return out.toString();
+  }
+
+  private static String encodeSegment(String segment, boolean firstSegment) {
+    if (".".equals(segment)) {
+      return "%2E";
+    }
+    if ("..".equals(segment)) {
+      return "%2E%2E";
+    }
+    StringBuilder out = new StringBuilder(segment.length() + 8);
+    for (int i = 0; i < segment.length(); i++) {
+      char c = segment.charAt(i);
+      if (c == '%' && i + 2 < segment.length() && isHex(segment.charAt(i + 1)) && isHex(segment.charAt(i + 2))) {
+        out.append('%')
+            .append(Character.toUpperCase(segment.charAt(i + 1)))
+            .append(Character.toUpperCase(segment.charAt(i + 2)));
+        i += 2;
+      } else if (isAllowedPathChar(c) && !(c == ':' && firstSegment && looksLikeScheme(segment, i))) {
+        out.append(c);
+      } else {
+        appendUtf8Escape(out, c);
+      }
+    }
+    return out.toString();
+  }
+
+  private static boolean looksLikeScheme(String segment, int colonIndex) {
+    if (colonIndex <= 0) {
+      return false;
+    }
+    char first = segment.charAt(0);
+    if (!isAsciiAlpha(first)) {
+      return false;
+    }
+    for (int i = 1; i < colonIndex; i++) {
+      char c = segment.charAt(i);
+      if (!isAsciiAlpha(c) && !isAsciiDigit(c) && c != '+' && c != '-' && c != '.') {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static void appendUtf8Escape(StringBuilder out, char c) {
+    byte[] bytes = String.valueOf(c).getBytes(StandardCharsets.UTF_8);
+    for (byte b : bytes) {
+      out.append('%');
+      int value = b & 0xff;
+      char hi = Character.toUpperCase(Character.forDigit(value >>> 4, 16));
+      char lo = Character.toUpperCase(Character.forDigit(value & 0xf, 16));
+      out.append(hi).append(lo);
+    }
+  }
+
+  private static boolean isAllowedPathChar(char c) {
+    return isAsciiAlpha(c)
+        || isAsciiDigit(c)
+        || c == '-'
+        || c == '.'
+        || c == '_'
+        || c == '~'
+        || c == '!'
+        || c == '$'
+        || c == '&'
+        || c == '\''
+        || c == '('
+        || c == ')'
+        || c == '*'
+        || c == '+'
+        || c == ','
+        || c == ';'
+        || c == '='
+        || c == ':'
+        || c == '@';
+  }
+
+  private static boolean isAsciiAlpha(char c) {
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+  }
+
+  private static boolean isAsciiDigit(char c) {
+    return c >= '0' && c <= '9';
+  }
+
+  private static boolean isHex(char c) {
+    return (c >= '0' && c <= '9')
+        || (c >= 'a' && c <= 'f')
+        || (c >= 'A' && c <= 'F');
+  }
+}

--- a/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmProxyService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmProxyService.java
@@ -18,6 +18,7 @@ import com.github.klboke.kkrepo.server.maven.BlobStorageRegistry;
 import com.github.klboke.kkrepo.server.maven.HttpRemoteFetcher;
 import com.github.klboke.kkrepo.server.maven.MavenResponse;
 import com.github.klboke.kkrepo.server.maven.ProxyNegativeCache;
+import com.github.klboke.kkrepo.server.maven.RemoteUrlBuilder;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import com.github.klboke.kkrepo.server.maven.UpstreamBodyReadException;
 import java.io.ByteArrayInputStream;
@@ -97,9 +98,11 @@ public class NpmProxyService {
       throw new IllegalStateException("NpmProxyService.search called on non-proxy " + runtime.name());
     }
     String text = keyword == null ? "" : keyword;
-    String url = buildRemoteUrl(runtime.proxyRemoteUrl(), "-/v1/search")
-        + "?text=" + URLEncoder.encode(text, StandardCharsets.UTF_8)
-        + "&size=" + Math.max(1, limit);
+    String url = RemoteUrlBuilder.repositoryPathWithQueryString(
+        runtime.proxyRemoteUrl(),
+        "-/v1/search",
+        "text=" + URLEncoder.encode(text, StandardCharsets.UTF_8)
+            + "&size=" + Math.max(1, limit));
     Instant now = Instant.now();
     HttpRemoteFetcher.Request req = new HttpRemoteFetcher.Request(
         url, null, null, null, false)
@@ -469,11 +472,7 @@ public class NpmProxyService {
   }
 
   private static String buildRemoteUrl(String base, String path) {
-    if (base == null || base.isBlank()) {
-      throw new IllegalStateException("Proxy repository has no remote URL configured");
-    }
-    String prefix = base.endsWith("/") ? base : base + "/";
-    return prefix + path;
+    return RemoteUrlBuilder.repositoryPathString(base, path);
   }
 
   private static String stringAttr(Map<String, Object> attrs, String key) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/pypi/PypiProxyService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/pypi/PypiProxyService.java
@@ -11,6 +11,7 @@ import com.github.klboke.kkrepo.server.cache.NexusLikeCacheInfo;
 import com.github.klboke.kkrepo.server.maven.BlobStorageRegistry;
 import com.github.klboke.kkrepo.server.maven.HttpRemoteFetcher;
 import com.github.klboke.kkrepo.server.maven.ProxyNegativeCache;
+import com.github.klboke.kkrepo.server.maven.RemoteUrlBuilder;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import com.github.klboke.kkrepo.server.maven.UpstreamBodyReadException;
 import java.io.ByteArrayInputStream;
@@ -307,8 +308,7 @@ public class PypiProxyService {
     String href = match.href();
     int hashIdx = href.indexOf('#');
     if (hashIdx >= 0) href = href.substring(0, hashIdx);
-    URI base = ensureTrailingSlash(URI.create(runtime.proxyRemoteUrl()))
-        .resolve(PypiPaths.indexPath(projectName));
+    URI base = RemoteUrlBuilder.repositoryPath(runtime.proxyRemoteUrl(), PypiPaths.indexPath(projectName));
     return base.resolve(href).toString();
   }
 
@@ -432,16 +432,7 @@ public class PypiProxyService {
   }
 
   private static String buildRemoteUrl(String base, String path) {
-    if (base == null || base.isBlank()) {
-      throw new IllegalStateException("Proxy repository has no remote URL configured");
-    }
-    String prefix = base.endsWith("/") ? base : base + "/";
-    return prefix + path;
-  }
-
-  private static URI ensureTrailingSlash(URI uri) {
-    String raw = uri.toString();
-    return raw.endsWith("/") ? uri : URI.create(raw + "/");
+    return RemoteUrlBuilder.repositoryPathString(base, path);
   }
 
   private static String stringAttr(Map<String, Object> attrs, String key) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/raw/RawProxyService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/raw/RawProxyService.java
@@ -10,10 +10,9 @@ import com.github.klboke.kkrepo.server.maven.HttpRemoteFetcher;
 import com.github.klboke.kkrepo.server.maven.MavenExceptions;
 import com.github.klboke.kkrepo.server.maven.MavenResponse;
 import com.github.klboke.kkrepo.server.maven.ProxyNegativeCache;
+import com.github.klboke.kkrepo.server.maven.RemoteUrlBuilder;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import java.io.IOException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Locale;
@@ -279,21 +278,7 @@ public class RawProxyService {
   }
 
   private static String buildRemoteUrl(String base, String path) {
-    if (base == null || base.isBlank()) {
-      throw new IllegalStateException("Proxy repository has no remote URL configured");
-    }
-    String prefix = base.endsWith("/") ? base : base + "/";
-    return prefix + encodePath(path);
-  }
-
-  private static String encodePath(String path) {
-    String[] segments = path.split("/", -1);
-    StringBuilder out = new StringBuilder(path.length() + 16);
-    for (int i = 0; i < segments.length; i++) {
-      if (i > 0) out.append('/');
-      out.append(URLEncoder.encode(segments[i], StandardCharsets.UTF_8).replace("+", "%20"));
-    }
-    return out.toString();
+    return RemoteUrlBuilder.repositoryPathString(base, path);
   }
 
   private static String stringAttr(Map<String, Object> attrs, String key) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/security/OidcLoginController.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/security/OidcLoginController.java
@@ -134,8 +134,11 @@ public class OidcLoginController {
     params.put("redirect_uri", redirectUri);
     params.put("scope", defaultString(stringConfig(config, "scopes", "scope"), DEFAULT_SCOPES));
     params.put("state", state);
-    String authorizationEndpoint = endpoint(config, "authorizationEndpoint", "authorizationEndpointUri", "authorization_endpoint");
-    response.sendRedirect(authorizationEndpoint + querySeparator(authorizationEndpoint) + form(params));
+    URI authorizationEndpoint = outboundPolicy.validateHttpUri(
+        endpoint(config, "authorizationEndpoint", "authorizationEndpointUri", "authorization_endpoint"),
+        "OIDC authorization endpoint");
+    validateOidcEndpointHost(config, authorizationEndpoint, "OIDC authorization endpoint");
+    response.sendRedirect(appendQuery(authorizationEndpoint, form(params)));
   }
 
   @GetMapping("/oidc/callback")
@@ -208,8 +211,9 @@ public class OidcLoginController {
     if (clientSecret != null) {
       body.put("client_secret", clientSecret);
     }
-    HttpRequest tokenRequest = HttpRequest.newBuilder(
-            outboundPolicy.validateHttpUri(tokenEndpoint, "OIDC token endpoint"))
+    URI tokenEndpointUri = outboundPolicy.validateHttpUri(tokenEndpoint, "OIDC token endpoint");
+    validateOidcEndpointHost(config, tokenEndpointUri, "OIDC token endpoint");
+    HttpRequest tokenRequest = HttpRequest.newBuilder(tokenEndpointUri)
         .header("Content-Type", MediaType.APPLICATION_FORM_URLENCODED_VALUE)
         .POST(HttpRequest.BodyPublishers.ofString(form(body)))
         .build();
@@ -271,6 +275,20 @@ public class OidcLoginController {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "OIDC discovery was interrupted", e);
     } catch (IOException e) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "OIDC discovery failed", e);
+    }
+  }
+
+  private void validateOidcEndpointHost(Map<String, Object> config, URI endpoint, String purpose) {
+    String issuer = stringConfig(config, "issuerUri", "issuer");
+    String discoveryUri = stringConfig(config, "discoveryUri", "metadataUrl", "wellKnownUrl");
+    if (issuer == null && discoveryUri == null) {
+      return;
+    }
+    URI expected = outboundPolicy.validateHttpUri(
+        discoveryUri == null ? stripTrailingSlash(issuer) + "/.well-known/openid-configuration" : discoveryUri,
+        purpose + " issuer");
+    if (!endpoint.getHost().equals(expected.getHost())) {
+      throw new SecurityValidationException(purpose + " host must match configured issuer/discovery host");
     }
   }
 
@@ -351,8 +369,9 @@ public class OidcLoginController {
     return builder.toString();
   }
 
-  private static String querySeparator(String uri) {
-    return uri.contains("?") ? "&" : "?";
+  private static String appendQuery(URI uri, String query) {
+    String raw = uri.toString();
+    return raw + (uri.getRawQuery() == null ? "?" : "&") + query;
   }
 
   private static String urlEncode(String value) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/security/OidcLoginController.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/security/OidcLoginController.java
@@ -134,11 +134,13 @@ public class OidcLoginController {
     params.put("redirect_uri", redirectUri);
     params.put("scope", defaultString(stringConfig(config, "scopes", "scope"), DEFAULT_SCOPES));
     params.put("state", state);
-    URI authorizationEndpoint = outboundPolicy.validateHttpUri(
-        endpoint(config, "authorizationEndpoint", "authorizationEndpointUri", "authorization_endpoint"),
-        "OIDC authorization endpoint");
-    validateOidcEndpointHost(config, authorizationEndpoint, "OIDC authorization endpoint");
-    response.sendRedirect(appendQuery(authorizationEndpoint, form(params)));
+    OidcEndpoint authorizationEndpoint = endpoint(
+        config,
+        "OIDC authorization endpoint",
+        "authorizationEndpoint",
+        "authorizationEndpointUri",
+        "authorization_endpoint");
+    sendRedirectToOidcEndpoint(response, authorizationEndpoint, form(params));
   }
 
   @GetMapping("/oidc/callback")
@@ -201,7 +203,12 @@ public class OidcLoginController {
       String code,
       String redirectUri) {
     String clientId = required(config, "clientId", "audience");
-    String tokenEndpoint = endpoint(config, "tokenEndpoint", "tokenEndpointUri", "token_endpoint");
+    OidcEndpoint tokenEndpoint = endpoint(
+        config,
+        "OIDC token endpoint",
+        "tokenEndpoint",
+        "tokenEndpointUri",
+        "token_endpoint");
     Map<String, String> body = new LinkedHashMap<>();
     body.put("grant_type", "authorization_code");
     body.put("code", code);
@@ -211,9 +218,7 @@ public class OidcLoginController {
     if (clientSecret != null) {
       body.put("client_secret", clientSecret);
     }
-    URI tokenEndpointUri = outboundPolicy.validateHttpUri(tokenEndpoint, "OIDC token endpoint");
-    validateOidcEndpointHost(config, tokenEndpointUri, "OIDC token endpoint");
-    HttpRequest tokenRequest = HttpRequest.newBuilder(tokenEndpointUri)
+    HttpRequest tokenRequest = HttpRequest.newBuilder(tokenEndpoint.uri())
         .header("Content-Type", MediaType.APPLICATION_FORM_URLENCODED_VALUE)
         .POST(HttpRequest.BodyPublishers.ofString(form(body)))
         .build();
@@ -231,19 +236,27 @@ public class OidcLoginController {
     }
   }
 
-  private String endpoint(Map<String, Object> config, String... keys) {
+  private OidcEndpoint endpoint(Map<String, Object> config, String purpose, String... keys) {
     String direct = stringConfig(config, keys);
     if (direct != null) {
-      return direct;
+      return validatedEndpoint(direct, purpose);
     }
     Map<String, Object> discovery = discovery(config);
     for (String key : keys) {
       String discovered = asString(discovery.get(key));
       if (discovered != null) {
-        return discovered;
+        return validatedEndpoint(discovered, purpose);
       }
     }
     throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "OIDC endpoint is not configured: " + String.join("/", keys));
+  }
+
+  private OidcEndpoint validatedEndpoint(String rawUrl, String purpose) {
+    URI uri = outboundPolicy.validateHttpUri(rawUrl, purpose);
+    if (uri.getRawFragment() != null) {
+      throw new SecurityValidationException(purpose + " URL must not include a fragment");
+    }
+    return new OidcEndpoint(uri, uri.getHost());
   }
 
   private Map<String, Object> discovery(Map<String, Object> config) {
@@ -255,7 +268,9 @@ public class OidcLoginController {
     if (sharedCache != null) {
       Optional<Map<String, Object>> cached = sharedCache.getJson(DISCOVERY_CACHE_NAMESPACE, uri, JSON_MAP);
       if (cached.isPresent()) {
-        return cached.get();
+        Map<String, Object> document = cached.get();
+        validateDiscoveryDocument(config, document);
+        return document;
       }
     }
     try {
@@ -266,6 +281,7 @@ public class OidcLoginController {
         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "OIDC discovery endpoint returned " + response.statusCode());
       }
       Map<String, Object> document = objectMapper.readValue(response.body(), JSON_MAP);
+      validateDiscoveryDocument(config, document);
       if (sharedCache != null) {
         sharedCache.putJson(DISCOVERY_CACHE_NAMESPACE, uri, document, java.time.Duration.ofSeconds(300));
       }
@@ -278,18 +294,28 @@ public class OidcLoginController {
     }
   }
 
-  private void validateOidcEndpointHost(Map<String, Object> config, URI endpoint, String purpose) {
-    String issuer = stringConfig(config, "issuerUri", "issuer");
-    String discoveryUri = stringConfig(config, "discoveryUri", "metadataUrl", "wellKnownUrl");
-    if (issuer == null && discoveryUri == null) {
+  private void validateDiscoveryDocument(Map<String, Object> config, Map<String, Object> document) {
+    String configuredIssuer = stringConfig(config, "issuerUri", "issuer");
+    if (configuredIssuer == null) {
       return;
     }
-    URI expected = outboundPolicy.validateHttpUri(
-        discoveryUri == null ? stripTrailingSlash(issuer) + "/.well-known/openid-configuration" : discoveryUri,
-        purpose + " issuer");
-    if (!endpoint.getHost().equals(expected.getHost())) {
-      throw new SecurityValidationException(purpose + " host must match configured issuer/discovery host");
+    String discoveredIssuer = asString(document.get("issuer"));
+    String expectedIssuer = stripTrailingSlash(configuredIssuer);
+    if (!expectedIssuer.equals(discoveredIssuer)) {
+      throw new SecurityValidationException("OIDC discovery issuer must match configured issuer");
     }
+  }
+
+  private void sendRedirectToOidcEndpoint(
+      HttpServletResponse response,
+      OidcEndpoint endpoint,
+      String query) throws IOException {
+    URI uri = endpoint.uri();
+    String authorizedHost = endpoint.authorizedRedirectHost();
+    if (!authorizedHost.equals(uri.getHost())) {
+      throw new SecurityValidationException("OIDC authorization endpoint host changed after validation");
+    }
+    response.sendRedirect(appendQuery(uri, query));
   }
 
   private String redirectUri(HttpServletRequest request, Map<String, Object> config) {
@@ -428,5 +454,8 @@ public class OidcLoginController {
   }
 
   public record LoginResult(String returnTo) {
+  }
+
+  private record OidcEndpoint(URI uri, String authorizedRedirectHost) {
   }
 }

--- a/server/src/main/java/com/github/klboke/kkrepo/server/security/OidcLoginController.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/security/OidcLoginController.java
@@ -46,7 +46,6 @@ public class OidcLoginController {
   private final ObjectMapper objectMapper;
   private final HttpClient httpClient;
   private final OutboundRequestPolicy outboundPolicy;
-  private final ForwardedHeaderPolicy forwardedHeaderPolicy;
   private final String externalBaseUrl;
   private final SharedCache sharedCache;
   private final SecureRandom secureRandom = new SecureRandom();
@@ -56,13 +55,11 @@ public class OidcLoginController {
       SecurityAuthenticationService authenticationService,
       ObjectMapper objectMapper,
       OutboundRequestPolicy outboundPolicy,
-      ForwardedHeaderPolicy forwardedHeaderPolicy,
       SharedCache sharedCache,
       @Value("${kkrepo.security.external-base-url:}") String externalBaseUrl) {
     this.authenticationService = authenticationService;
     this.objectMapper = objectMapper;
     this.outboundPolicy = outboundPolicy;
-    this.forwardedHeaderPolicy = forwardedHeaderPolicy;
     this.sharedCache = sharedCache;
     this.externalBaseUrl = asString(externalBaseUrl);
     this.httpClient = HttpClient.newHttpClient();
@@ -75,7 +72,6 @@ public class OidcLoginController {
         authenticationService,
         objectMapper,
         OutboundRequestPolicy.allowPrivateForTests(),
-        new ForwardedHeaderPolicy(""),
         null,
         "");
   }
@@ -122,7 +118,7 @@ public class OidcLoginController {
     SecurityRealmRecord realm = activeOidcRealm();
     Map<String, Object> config = attributes(realm);
     String clientId = required(config, "clientId", "audience");
-    String redirectUri = redirectUri(request, config);
+    String redirectUri = redirectUri(config);
     String state = randomToken();
     HttpSession session = request.getSession(true);
     session.setAttribute(OIDC_STATE_ATTRIBUTE, state);
@@ -167,7 +163,7 @@ public class OidcLoginController {
     Map<String, Object> config = attributes(realm);
     String token = firstNonBlank(idToken, accessToken);
     if (token == null && code != null && !code.isBlank()) {
-      Map<String, Object> tokenResponse = exchangeCode(config, code, redirectUri(request, config));
+      Map<String, Object> tokenResponse = exchangeCode(config, code, redirectUri(config));
       token = firstNonBlank(asString(tokenResponse.get("id_token")), asString(tokenResponse.get("access_token")));
     }
     if (token == null) {
@@ -318,31 +314,17 @@ public class OidcLoginController {
     response.sendRedirect(appendQuery(uri, query));
   }
 
-  private String redirectUri(HttpServletRequest request, Map<String, Object> config) {
+  private String redirectUri(Map<String, Object> config) {
     String configured = stringConfig(config, "redirectUri", "redirect_uri");
     if (configured != null) {
       return configured;
     }
     if (externalBaseUrl != null) {
-      return stripTrailingSlash(externalBaseUrl) + request.getContextPath() + "/internal/security/oidc/callback";
+      return stripTrailingSlash(externalBaseUrl) + "/internal/security/oidc/callback";
     }
-    return externalBaseUri(request) + request.getContextPath() + "/internal/security/oidc/callback";
-  }
-
-  private String externalBaseUri(HttpServletRequest request) {
-    boolean trustedForwarded = forwardedHeaderPolicy.trusted(request);
-    String proto = trustedForwarded
-        ? defaultString(firstForwarded(request.getHeader("X-Forwarded-Proto")), request.getScheme())
-        : request.getScheme();
-    String host = trustedForwarded ? firstForwarded(request.getHeader("X-Forwarded-Host")) : null;
-    if (host == null) {
-      host = request.getServerName();
-      int port = request.getServerPort();
-      if (port > 0 && !host.contains(":") && !defaultPort(proto, port)) {
-        host += ":" + port;
-      }
-    }
-    return proto + "://" + host;
+    throw new ResponseStatusException(
+        HttpStatus.BAD_REQUEST,
+        "OIDC redirectUri or kkrepo.security.external-base-url must be configured");
   }
 
   private String randomToken() {
@@ -402,19 +384,6 @@ public class OidcLoginController {
 
   private static String urlEncode(String value) {
     return URLEncoder.encode(value, StandardCharsets.UTF_8);
-  }
-
-  private static String firstForwarded(String header) {
-    if (header == null || header.isBlank()) {
-      return null;
-    }
-    String first = header.split(",", 2)[0].trim();
-    return first.isBlank() ? null : first;
-  }
-
-  private static boolean defaultPort(String proto, int port) {
-    return ("http".equalsIgnoreCase(proto) && port == 80)
-        || ("https".equalsIgnoreCase(proto) && port == 443);
   }
 
   private static String stripTrailingSlash(String value) {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcherTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcherTest.java
@@ -13,8 +13,13 @@ import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayDeque;
+import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.server.security.OutboundRequestPolicy;
+import com.github.klboke.kkrepo.server.security.SecurityValidationException;
 import org.junit.jupiter.api.Test;
 
 class HttpRemoteFetcherTest {
@@ -65,6 +70,55 @@ class HttpRemoteFetcherTest {
         Duration.ofSeconds(9),
         fetcher.requestTimeout(new HttpRemoteFetcher.Request(
             "https://repo.example/artifact.jar", null, null, Duration.ofSeconds(9), false)));
+  }
+
+  @Test
+  void requestUriMustPassOutboundPolicyValidation() {
+    HttpRemoteFetcher.Request request = HttpRemoteFetcher.Request.get("http://127.0.0.1/artifact.jar");
+
+    assertThrows(
+        SecurityValidationException.class,
+        () -> request.validatedUri(new OutboundRequestPolicy(false, ""), "remote fetch"));
+  }
+
+  @Test
+  void requestUriMustRemainOnRepositoryRemoteHost() {
+    RepositoryRuntime runtime = new RepositoryRuntime(
+        1,
+        "maven-proxy",
+        RepositoryFormat.MAVEN2,
+        RepositoryType.PROXY,
+        "maven2-proxy",
+        true,
+        1L,
+        null,
+        "RELEASE",
+        "STRICT",
+        true,
+        "https://repo.example.com/maven2",
+        1440,
+        1440,
+        List.of());
+    HttpRemoteFetcher.Request trusted = HttpRemoteFetcher.Request
+        .get("https://repo.example.com/maven2/com/example/app.jar")
+        .withRepository(runtime);
+    HttpRemoteFetcher.Request tampered = new HttpRemoteFetcher.Request(
+        "https://evil.example.com/maven2/com/example/app.jar",
+        trusted.etag(),
+        trusted.lastModified(),
+        trusted.timeout(),
+        trusted.timeoutProfile(),
+        trusted.headOnly(),
+        trusted.repository(),
+        trusted.format(),
+        trusted.trustedHost());
+
+    OutboundRequestPolicy policy = new OutboundRequestPolicy(false, "repo.example.com,evil.example.com");
+    assertEquals("repo.example.com", trusted.validatedUri(policy, "remote fetch").getHost());
+    SecurityValidationException error = assertThrows(
+        SecurityValidationException.class,
+        () -> tampered.validatedUri(policy, "remote fetch"));
+    assertEquals("remote fetch URL host must remain repo.example.com", error.getMessage());
   }
 
   @Test

--- a/server/src/test/java/com/github/klboke/kkrepo/server/maven/MavenHtmlListingServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/maven/MavenHtmlListingServiceTest.java
@@ -1,0 +1,82 @@
+package com.github.klboke.kkrepo.server.maven;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.mysql.dao.AssetDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.BrowseNodeDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.ComponentDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.RepositoryDao;
+import com.github.klboke.kkrepo.persistence.mysql.model.RepositoryRecord;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class MavenHtmlListingServiceTest {
+
+  @Test
+  void browseHtmlEscapesDisplayNamesAndHrefAttributes() {
+    MavenHtmlListingService service = new MavenHtmlListingService(
+        new FakeRepositoryDao(),
+        new FakeBrowseNodeDao(),
+        new AssetDao(null, null),
+        new ComponentDao(null, null));
+
+    String html = service.renderBrowse("maven-hosted", "").orElseThrow();
+
+    assertTrue(html.contains("&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;.jar"));
+    assertTrue(html.contains("/repository/maven-hosted/com/example/&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;.jar"));
+    assertFalse(html.contains("<script>alert(\"x\")</script>"));
+  }
+
+  private static class FakeRepositoryDao extends RepositoryDao {
+    FakeRepositoryDao() {
+      super(null, null);
+    }
+
+    @Override
+    public Optional<RepositoryRecord> findByName(String name) {
+      return Optional.of(new RepositoryRecord(
+          10L,
+          name,
+          RepositoryFormat.MAVEN2,
+          RepositoryType.HOSTED,
+          "maven2-hosted",
+          true,
+          1L,
+          null,
+          null,
+          "RELEASE",
+          "STRICT",
+          "ALLOW",
+          true,
+          Map.of()));
+    }
+  }
+
+  private static class FakeBrowseNodeDao extends BrowseNodeDao {
+    FakeBrowseNodeDao() {
+      super(null);
+    }
+
+    @Override
+    public List<BrowseChild> listChildren(long repositoryId, String parentPath) {
+      return List.of(new BrowseChild(
+          1L,
+          "com/example/<script>alert(\"x\")</script>.jar",
+          "<script>alert(\"x\")</script>.jar",
+          0,
+          11L,
+          null,
+          123L,
+          "application/java-archive",
+          "sha1",
+          null,
+          false,
+          true));
+    }
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/maven/RemoteUrlBuilderTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/maven/RemoteUrlBuilderTest.java
@@ -1,0 +1,60 @@
+package com.github.klboke.kkrepo.server.maven;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class RemoteUrlBuilderTest {
+
+  @Test
+  void pathCannotOverrideConfiguredRemoteHost() {
+    assertEquals(
+        "https://repo.example.com/base/http%3A/evil.example/pkg.jar",
+        RemoteUrlBuilder.repositoryPathString(
+            "https://repo.example.com/base/",
+            "http://evil.example/pkg.jar"));
+
+    assertEquals(
+        "https://repo.example.com/base/%2F%2Fevil.example/pkg.jar",
+        RemoteUrlBuilder.repositoryPathString(
+            "https://repo.example.com/base/",
+            "//evil.example/pkg.jar"));
+  }
+
+  @Test
+  void dotSegmentsRemainLiteralPathSegments() {
+    assertEquals(
+        "https://repo.example.com/base/%2E%2E/secret/%2E/file.txt",
+        RemoteUrlBuilder.repositoryPathString(
+            "https://repo.example.com/base/",
+            "../secret/./file.txt"));
+  }
+
+  @Test
+  void queryIsAppendedAfterSafePathResolution() {
+    assertEquals(
+        "https://repo.example.com/npm/-/v1/search?text=left+pad&size=20",
+        RemoteUrlBuilder.repositoryPathWithQueryString(
+            "https://repo.example.com/npm",
+            "-/v1/search",
+            "text=left+pad&size=20"));
+  }
+
+  @Test
+  void existingPercentEscapesStayEncodedForProtocolCompatibility() {
+    assertEquals(
+        "https://registry.npmjs.org/@scope%2Fname",
+        RemoteUrlBuilder.repositoryPathString(
+            "https://registry.npmjs.org",
+            "@scope%2Fname"));
+  }
+
+  @Test
+  void protocolPathCharactersStayReadable() {
+    assertEquals(
+        "https://registry.example.com/v2/library/alpine/manifests/sha256:abcdef",
+        RemoteUrlBuilder.repositoryPathString(
+            "https://registry.example.com/v2",
+            "library/alpine/manifests/sha256:abcdef"));
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/security/OidcLoginControllerTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/security/OidcLoginControllerTest.java
@@ -34,7 +34,8 @@ class OidcLoginControllerTest {
     StubAuthenticationService authentication = new StubAuthenticationService();
     authentication.oidcRealm = Optional.of(oidcRealm(Map.of(
         "clientId", "kkrepo",
-        "authorizationEndpoint", "https://issuer.example.com/oauth2/authorize",
+        "issuerUri", "https://localhost",
+        "authorizationEndpoint", "https://localhost/oauth2/authorize",
         "redirectUri", "http://nexus.example.com/internal/security/oidc/callback",
         "scopes", "openid profile email groups")));
     OidcLoginController controller = new OidcLoginController(authentication, new ObjectMapper());
@@ -44,13 +45,65 @@ class OidcLoginControllerTest {
     URI redirect = URI.create(response.redirect);
     Map<String, String> query = query(redirect);
     assertEquals("https", redirect.getScheme());
-    assertEquals("issuer.example.com", redirect.getHost());
+    assertEquals("localhost", redirect.getHost());
     assertEquals("/oauth2/authorize", redirect.getPath());
     assertEquals("code", query.get("response_type"));
     assertEquals("kkrepo", query.get("client_id"));
     assertEquals("http://nexus.example.com/internal/security/oidc/callback", query.get("redirect_uri"));
     assertEquals("openid profile email groups", query.get("scope"));
     assertNotNull(query.get("state"));
+  }
+
+  @Test
+  void loginRejectsUnsafeAuthorizationEndpoint() {
+    SessionState session = new SessionState();
+    ResponseState response = new ResponseState();
+    StubAuthenticationService authentication = new StubAuthenticationService();
+    authentication.oidcRealm = Optional.of(oidcRealm(Map.of(
+        "clientId", "kkrepo",
+        "issuerUri", "https://localhost",
+        "authorizationEndpoint", "http://127.0.0.1/oauth2/authorize",
+        "redirectUri", "http://nexus.example.com/internal/security/oidc/callback")));
+    OidcLoginController controller = new OidcLoginController(
+        authentication,
+        new ObjectMapper(),
+        new OutboundRequestPolicy(false, ""),
+        new ForwardedHeaderPolicy(""),
+        null,
+        "");
+
+    SecurityValidationException error = assertThrows(
+        SecurityValidationException.class,
+        () -> controller.login(request(session), response.proxy(), "/browse/"));
+
+    assertTrue(error.getMessage().contains("OIDC authorization endpoint URL resolves to a private or local address"));
+  }
+
+  @Test
+  void loginRejectsAuthorizationEndpointOnDifferentHostThanIssuer() {
+    SessionState session = new SessionState();
+    ResponseState response = new ResponseState();
+    StubAuthenticationService authentication = new StubAuthenticationService();
+    authentication.oidcRealm = Optional.of(oidcRealm(Map.of(
+        "clientId", "kkrepo",
+        "issuerUri", "https://issuer.example.com",
+        "authorizationEndpoint", "https://login.example.net/oauth2/authorize",
+        "redirectUri", "http://nexus.example.com/internal/security/oidc/callback")));
+    OidcLoginController controller = new OidcLoginController(
+        authentication,
+        new ObjectMapper(),
+        new OutboundRequestPolicy(false, "issuer.example.com,login.example.net"),
+        new ForwardedHeaderPolicy(""),
+        null,
+        "");
+
+    SecurityValidationException error = assertThrows(
+        SecurityValidationException.class,
+        () -> controller.login(request(session), response.proxy(), "/browse/"));
+
+    assertEquals(
+        "OIDC authorization endpoint host must match configured issuer/discovery host",
+        error.getMessage());
   }
 
   @Test
@@ -156,7 +209,8 @@ class OidcLoginControllerTest {
         new PermissionSubject("OIDC", "alice", Set.of("nx-admin"), null));
     authentication.oidcRealm = Optional.of(oidcRealm(Map.of(
         "clientId", "kkrepo",
-        "authorizationEndpoint", "https://issuer.example.com/oauth2/authorize",
+        "issuerUri", "https://localhost",
+        "authorizationEndpoint", "https://localhost/oauth2/authorize",
         "redirectUri", "http://nexus.example.com/callback")));
     authentication.subject = Optional.of(subject);
     OidcLoginController controller = new OidcLoginController(authentication, new ObjectMapper());

--- a/server/src/test/java/com/github/klboke/kkrepo/server/security/OidcLoginControllerTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/security/OidcLoginControllerTest.java
@@ -9,11 +9,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.klboke.kkrepo.auth.PermissionSubject;
 import com.github.klboke.kkrepo.persistence.mysql.dao.SecurityDao;
 import com.github.klboke.kkrepo.persistence.mysql.model.SecurityRealmRecord;
+import com.sun.net.httpserver.HttpServer;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import java.lang.reflect.Proxy;
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -80,7 +82,7 @@ class OidcLoginControllerTest {
   }
 
   @Test
-  void loginRejectsAuthorizationEndpointOnDifferentHostThanIssuer() {
+  void loginAllowsConfiguredAuthorizationEndpointOnDifferentHostWhenOutboundPolicyAllowsIt() throws Exception {
     SessionState session = new SessionState();
     ResponseState response = new ResponseState();
     StubAuthenticationService authentication = new StubAuthenticationService();
@@ -97,13 +99,51 @@ class OidcLoginControllerTest {
         null,
         "");
 
-    SecurityValidationException error = assertThrows(
-        SecurityValidationException.class,
-        () -> controller.login(request(session), response.proxy(), "/browse/"));
+    controller.login(request(session), response.proxy(), "/browse/");
 
-    assertEquals(
-        "OIDC authorization endpoint host must match configured issuer/discovery host",
-        error.getMessage());
+    URI redirect = URI.create(response.redirect);
+    assertEquals("login.example.net", redirect.getHost());
+    assertEquals("/oauth2/authorize", redirect.getPath());
+  }
+
+  @Test
+  void loginAllowsDiscoveredAuthorizationEndpointOnDifferentHostThanIssuer() throws Exception {
+    try (TestOidcDiscovery discovery = oidcDiscoveryServer("127.0.0.1", "localhost", false)) {
+      SessionState session = new SessionState();
+      ResponseState response = new ResponseState();
+      StubAuthenticationService authentication = new StubAuthenticationService();
+      authentication.oidcRealm = Optional.of(oidcRealm(Map.of(
+          "clientId", "kkrepo",
+          "issuerUri", discovery.issuer(),
+          "redirectUri", "http://nexus.example.com/internal/security/oidc/callback")));
+      OidcLoginController controller = new OidcLoginController(authentication, new ObjectMapper());
+
+      controller.login(request(session), response.proxy(), "/browse/");
+
+      URI redirect = URI.create(response.redirect);
+      assertEquals("localhost", redirect.getHost());
+      assertEquals("/oauth2/authorize", redirect.getPath());
+    }
+  }
+
+  @Test
+  void discoveryRejectsIssuerMismatch() throws Exception {
+    try (TestOidcDiscovery discovery = oidcDiscoveryServer("127.0.0.1", "localhost", true)) {
+      SessionState session = new SessionState();
+      ResponseState response = new ResponseState();
+      StubAuthenticationService authentication = new StubAuthenticationService();
+      authentication.oidcRealm = Optional.of(oidcRealm(Map.of(
+          "clientId", "kkrepo",
+          "issuerUri", discovery.issuer(),
+          "redirectUri", "http://nexus.example.com/internal/security/oidc/callback")));
+      OidcLoginController controller = new OidcLoginController(authentication, new ObjectMapper());
+
+      SecurityValidationException error = assertThrows(
+          SecurityValidationException.class,
+          () -> controller.login(request(session), response.proxy(), "/browse/"));
+
+      assertEquals("OIDC discovery issuer must match configured issuer", error.getMessage());
+    }
   }
 
   @Test
@@ -307,6 +347,31 @@ class OidcLoginControllerTest {
     return URLDecoder.decode(value, StandardCharsets.UTF_8);
   }
 
+  private static TestOidcDiscovery oidcDiscoveryServer(
+      String issuerHost,
+      String authorizationHost,
+      boolean issuerMismatch) throws Exception {
+    HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    int port = server.getAddress().getPort();
+    String issuer = "http://" + issuerHost + ":" + port;
+    String authorizationEndpoint = "http://" + authorizationHost + ":" + port + "/oauth2/authorize";
+    String tokenEndpoint = "http://" + authorizationHost + ":" + port + "/oauth2/token";
+    String documentIssuer = issuerMismatch ? "http://mismatch.example.com" : issuer;
+    String body = new ObjectMapper().writeValueAsString(Map.of(
+        "issuer", documentIssuer,
+        "authorization_endpoint", authorizationEndpoint,
+        "token_endpoint", tokenEndpoint));
+    server.createContext("/.well-known/openid-configuration", exchange -> {
+      byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+      exchange.getResponseHeaders().add("Content-Type", "application/json");
+      exchange.sendResponseHeaders(200, bytes.length);
+      exchange.getResponseBody().write(bytes);
+      exchange.close();
+    });
+    server.start();
+    return new TestOidcDiscovery(server, issuer);
+  }
+
   private static Object primitiveDefault(Class<?> type) {
     if (boolean.class.equals(type)) {
       return false;
@@ -365,6 +430,13 @@ class OidcLoginControllerTest {
     @Override
     public List<String> listUserRoleIds(String source, String userId) {
       return List.of("nx-admin");
+    }
+  }
+
+  private record TestOidcDiscovery(HttpServer server, String issuer) implements AutoCloseable {
+    @Override
+    public void close() {
+      server.stop(0);
     }
   }
 

--- a/server/src/test/java/com/github/klboke/kkrepo/server/security/OidcLoginControllerTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/security/OidcLoginControllerTest.java
@@ -70,7 +70,6 @@ class OidcLoginControllerTest {
         authentication,
         new ObjectMapper(),
         new OutboundRequestPolicy(false, ""),
-        new ForwardedHeaderPolicy(""),
         null,
         "");
 
@@ -95,7 +94,6 @@ class OidcLoginControllerTest {
         authentication,
         new ObjectMapper(),
         new OutboundRequestPolicy(false, "issuer.example.com,login.example.net"),
-        new ForwardedHeaderPolicy(""),
         null,
         "");
 
@@ -104,6 +102,51 @@ class OidcLoginControllerTest {
     URI redirect = URI.create(response.redirect);
     assertEquals("login.example.net", redirect.getHost());
     assertEquals("/oauth2/authorize", redirect.getPath());
+  }
+
+  @Test
+  void loginBuildsRedirectUriFromConfiguredExternalBaseUrl() throws Exception {
+    SessionState session = new SessionState();
+    ResponseState response = new ResponseState();
+    StubAuthenticationService authentication = new StubAuthenticationService();
+    authentication.oidcRealm = Optional.of(oidcRealm(Map.of(
+        "clientId", "kkrepo",
+        "issuerUri", "https://localhost",
+        "authorizationEndpoint", "https://localhost/oauth2/authorize")));
+    OidcLoginController controller = new OidcLoginController(
+        authentication,
+        new ObjectMapper(),
+        OutboundRequestPolicy.allowPrivateForTests(),
+        null,
+        "https://nexus.example.com/");
+
+    controller.login(request(session), response.proxy(), "/browse/");
+
+    URI redirect = URI.create(response.redirect);
+    assertEquals(
+        "https://nexus.example.com/internal/security/oidc/callback",
+        query(redirect).get("redirect_uri"));
+  }
+
+  @Test
+  void loginRequiresConfiguredRedirectUriOrExternalBaseUrl() {
+    SessionState session = new SessionState();
+    ResponseState response = new ResponseState();
+    StubAuthenticationService authentication = new StubAuthenticationService();
+    authentication.oidcRealm = Optional.of(oidcRealm(Map.of(
+        "clientId", "kkrepo",
+        "issuerUri", "https://localhost",
+        "authorizationEndpoint", "https://localhost/oauth2/authorize")));
+    OidcLoginController controller = new OidcLoginController(authentication, new ObjectMapper());
+
+    ResponseStatusException error = assertThrows(
+        ResponseStatusException.class,
+        () -> controller.login(request(session), response.proxy(), "/browse/"));
+
+    assertTrue(error.getStatusCode().isSameCodeAs(org.springframework.http.HttpStatus.BAD_REQUEST));
+    assertEquals(
+        "OIDC redirectUri or kkrepo.security.external-base-url must be configured",
+        error.getReason());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Replace regex-based component search tokenization with linear scanning to avoid ReDoS.
- Centralize proxy remote URL path construction so request paths cannot override configured remote hosts, and bind fetch requests back to the repository remote host.
- Use framework HTML escaping for repository browse listings and add XSS regression coverage.
- Validate OIDC authorization/token endpoints with outbound policy and issuer/discovery host checks before redirecting or exchanging tokens.

## Tests
- mvn -pl persistence-mysql -am -Dtest=ComponentDaoTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -pl server -am -Dtest=RemoteUrlBuilderTest,HttpRemoteFetcherTest,MavenHtmlListingServiceTest,OidcLoginControllerTest,NpmProxyServiceTest,DockerRemoteRegistryClientTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -pl server -am -Dsurefire.failIfNoSpecifiedTests=false test