### PR TITLE
[codex] Support collapsible admin sidebar groups

### DIFF
--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
@@ -33,7 +33,9 @@ select {
   display: grid;
   grid-template-columns: 254px minmax(0, 1fr);
   grid-template-rows: 56px minmax(0, 1fr);
+  height: 100vh;
   min-height: 100vh;
+  overflow: hidden;
 }
 
 .nx-topbar {
@@ -1634,11 +1636,23 @@ textarea:focus-visible {
 .nx-sidebar {
   border-right: 1px solid var(--line);
   background: var(--sidebar);
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .side-nav {
   gap: 4px;
   padding: 10px;
+}
+
+.side-group-items {
+  display: grid;
+  gap: 4px;
+}
+
+.side-group-items[hidden] {
+  display: none;
 }
 
 .side-group,
@@ -1649,14 +1663,50 @@ textarea:focus-visible {
 }
 
 .side-group {
+  justify-content: space-between;
+  gap: 8px;
   margin-top: 8px;
   padding: 0 12px;
   color: #70807a;
-  cursor: default;
+  cursor: pointer;
   font-size: 12px;
   font-weight: 800;
   letter-spacing: 0;
   text-transform: uppercase;
+}
+
+.side-group:hover {
+  background: #f3f8f5;
+  color: #344641;
+}
+
+.side-group.is-current {
+  background: #edf7f4;
+  color: var(--active);
+}
+
+.side-group.is-current:not(.is-open) {
+  background: var(--active);
+  color: var(--active-ink);
+  box-shadow: 0 6px 16px rgba(20, 117, 107, 0.16);
+}
+
+.side-group-caret {
+  display: inline-flex;
+  flex: 0 0 14px;
+  justify-content: center;
+  transition: transform 0.16s ease;
+}
+
+.side-group.is-open .side-group-caret {
+  transform: rotate(90deg);
+}
+
+.side-group-label {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .side-group:first-child {
@@ -1664,7 +1714,7 @@ textarea:focus-visible {
 }
 
 .side-item {
-  padding: 0 14px;
+  padding: 0 14px 0 34px;
   font-size: 14px;
   font-weight: 650;
 }
@@ -1678,6 +1728,7 @@ textarea:focus-visible {
 
 .nx-content {
   background: #ffffff;
+  min-height: 0;
 }
 
 .page-heading {
@@ -2043,6 +2094,8 @@ code {
   .nx-shell {
     grid-template-columns: 1fr;
     grid-template-rows: auto auto minmax(0, 1fr);
+    height: auto;
+    overflow: visible;
   }
 
   .nx-topbar {
@@ -2058,6 +2111,18 @@ code {
     grid-auto-flow: column;
     grid-auto-columns: max-content;
     overflow-x: auto;
+  }
+
+  .nx-sidebar {
+    overflow-y: visible;
+  }
+
+  .side-group-items:not([hidden]) {
+    display: contents;
+  }
+
+  .side-item {
+    padding-left: 26px;
   }
 
   .page-heading,

--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js
@@ -132,6 +132,7 @@ const securityTransfers = {
 let toastTimer;
 const BROWSE_WELCOME = "/browse/#browse/welcome";
 const AUTH_SNAPSHOT_KEY = "nexusPlus.authSnapshot";
+const SIDE_GROUP_STATE_KEY = "kkrepo.admin.sideGroups";
 
 function applyOriginAwarePlaceholders() {
   const oidcRedirectUri = document.getElementById("security-oidc-redirect-uri");
@@ -316,6 +317,79 @@ function normalizeAdminHash(hash) {
 
 function viewFromHash(hash = window.location.hash) {
   return hashViewRoutes[normalizeAdminHash(hash)] || null;
+}
+
+function readSideGroupState() {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(SIDE_GROUP_STATE_KEY) || "{}");
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeSideGroupState(state) {
+  try {
+    localStorage.setItem(SIDE_GROUP_STATE_KEY, JSON.stringify(state));
+  } catch {
+    // localStorage can be unavailable in private or constrained browser contexts.
+  }
+}
+
+function sideGroupButton(groupName) {
+  return Array.from(document.querySelectorAll(".side-group[data-side-group]"))
+    .find((button) => button.dataset.sideGroup === groupName) || null;
+}
+
+function sideGroupItems(groupName) {
+  return Array.from(document.querySelectorAll(".side-group-items[data-side-group-items]"))
+    .find((items) => items.dataset.sideGroupItems === groupName) || null;
+}
+
+function setSideGroupOpen(button, open, persist = false) {
+  const groupName = button?.dataset.sideGroup;
+  if (!groupName) return;
+  const items = sideGroupItems(groupName);
+  button.classList.toggle("is-open", open);
+  button.setAttribute("aria-expanded", String(open));
+  if (items) {
+    items.hidden = !open;
+  }
+  if (persist) {
+    const state = readSideGroupState();
+    state[groupName] = open;
+    writeSideGroupState(state);
+  }
+}
+
+function sideGroupForView(view) {
+  const item = Array.from(document.querySelectorAll(".side-item[data-view]"))
+    .find((candidate) => candidate.dataset.view === view);
+  return item?.closest(".side-group-items")?.dataset.sideGroupItems || "";
+}
+
+function updateCurrentSideGroup(view) {
+  document.querySelectorAll(".side-group[data-side-group]").forEach((button) => {
+    button.classList.remove("is-current");
+  });
+  const groupName = sideGroupForView(view);
+  const button = sideGroupButton(groupName);
+  if (button) {
+    button.classList.add("is-current");
+  }
+}
+
+function initializeSideGroups() {
+  const state = readSideGroupState();
+  document.querySelectorAll(".side-group[data-side-group]").forEach((button) => {
+    const groupName = button.dataset.sideGroup;
+    const open = Object.prototype.hasOwnProperty.call(state, groupName) ? Boolean(state[groupName]) : true;
+    setSideGroupOpen(button, open);
+    button.addEventListener("click", () => {
+      setSideGroupOpen(button, !button.classList.contains("is-open"), true);
+    });
+  });
+  updateCurrentSideGroup(viewFromHash() || "repositories");
 }
 
 function updateHashForView(view, replace = false) {
@@ -3536,6 +3610,7 @@ function switchView(view, options = {}) {
   document.querySelectorAll(".side-item").forEach((item) => {
     item.classList.toggle("is-active", item.dataset.view === view);
   });
+  updateCurrentSideGroup(view);
   if (view === "blobstores") {
     loadBlobStores({ autoCheck: true });
   }
@@ -3564,6 +3639,7 @@ function applyHashRoute() {
 }
 
 applyOriginAwarePlaceholders();
+initializeSideGroups();
 
 document.querySelectorAll(".side-item[data-view]").forEach((item) => {
   item.addEventListener("click", () => switchView(item.dataset.view));

--- a/admin-ui/src/main/resources/META-INF/resources/admin/index.html
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>kkrepo administration</title>
     <link rel="icon" type="image/svg+xml" href="/admin/assets/favicon.svg?v=20260609-kl-logo-1">
-    <link rel="stylesheet" href="./assets/admin.css?v=20260615-user-menu-layer-1">
+    <link rel="stylesheet" href="./assets/admin.css?v=20260628-sidebar-groups-1">
   </head>
   <body>
     <div class="nx-shell">
@@ -35,25 +35,45 @@
 
       <aside class="nx-sidebar">
         <nav class="side-nav" aria-label="Administration navigation">
-          <button class="side-group is-open" type="button">▾ Repository</button>
-          <button class="side-item is-active" data-view="repositories" type="button">▥ Repositories</button>
-          <button class="side-item" data-view="blobstores" type="button">▤ Blob Stores</button>
-          <button class="side-item" data-view="docker-registry" type="button">▧ Docker Registry</button>
-          <button class="side-group is-open" type="button">▾ Security</button>
-          <button class="side-item" data-view="security-users" type="button">◉ Users</button>
-          <button class="side-item" data-view="security-roles" type="button">◈ Roles</button>
-          <button class="side-item" data-view="security-privileges" type="button">◍ Privileges</button>
-          <button class="side-item" data-view="security-realms" type="button">⇅ Realms</button>
-          <button class="side-item" data-view="security-ldap" type="button">◇ LDAP</button>
-          <button class="side-item" data-view="security-oidc" type="button">◒ OIDC</button>
-          <button class="side-item" data-view="security-anonymous" type="button">◌ Anonymous</button>
-          <button class="side-item" data-view="security-api-keys" type="button">⌘ API Keys</button>
-          <button class="side-item" data-view="security-audit-log" type="button">▦ Audit Log</button>
-          <button class="side-group is-open" type="button">▾ System</button>
-          <button class="side-item" data-view="ui-settings" type="button">▨ UI Settings</button>
-          <button class="side-group is-open" type="button">▾ Migration</button>
-          <button class="side-item" data-view="nexus-migration" type="button">⇆ Nexus Metadata</button>
-          <button class="side-item" data-view="repository-data-migration" type="button">⇄ Nexus Repository Data</button>
+          <button class="side-group is-open" data-side-group="repository" type="button" aria-expanded="true" aria-controls="side-group-repository-items">
+            <span class="side-group-caret" aria-hidden="true">▸</span>
+            <span class="side-group-label">Repository</span>
+          </button>
+          <div class="side-group-items" id="side-group-repository-items" data-side-group-items="repository">
+            <button class="side-item is-active" data-view="repositories" type="button">▥ Repositories</button>
+            <button class="side-item" data-view="blobstores" type="button">▤ Blob Stores</button>
+            <button class="side-item" data-view="docker-registry" type="button">▧ Docker Registry</button>
+          </div>
+          <button class="side-group is-open" data-side-group="security" type="button" aria-expanded="true" aria-controls="side-group-security-items">
+            <span class="side-group-caret" aria-hidden="true">▸</span>
+            <span class="side-group-label">Security</span>
+          </button>
+          <div class="side-group-items" id="side-group-security-items" data-side-group-items="security">
+            <button class="side-item" data-view="security-users" type="button">◉ Users</button>
+            <button class="side-item" data-view="security-roles" type="button">◈ Roles</button>
+            <button class="side-item" data-view="security-privileges" type="button">◍ Privileges</button>
+            <button class="side-item" data-view="security-realms" type="button">⇅ Realms</button>
+            <button class="side-item" data-view="security-ldap" type="button">◇ LDAP</button>
+            <button class="side-item" data-view="security-oidc" type="button">◒ OIDC</button>
+            <button class="side-item" data-view="security-anonymous" type="button">◌ Anonymous</button>
+            <button class="side-item" data-view="security-api-keys" type="button">⌘ API Keys</button>
+            <button class="side-item" data-view="security-audit-log" type="button">▦ Audit Log</button>
+          </div>
+          <button class="side-group is-open" data-side-group="system" type="button" aria-expanded="true" aria-controls="side-group-system-items">
+            <span class="side-group-caret" aria-hidden="true">▸</span>
+            <span class="side-group-label">System</span>
+          </button>
+          <div class="side-group-items" id="side-group-system-items" data-side-group-items="system">
+            <button class="side-item" data-view="ui-settings" type="button">▨ UI Settings</button>
+          </div>
+          <button class="side-group is-open" data-side-group="migration" type="button" aria-expanded="true" aria-controls="side-group-migration-items">
+            <span class="side-group-caret" aria-hidden="true">▸</span>
+            <span class="side-group-label">Migration</span>
+          </button>
+          <div class="side-group-items" id="side-group-migration-items" data-side-group-items="migration">
+            <button class="side-item" data-view="nexus-migration" type="button">⇆ Nexus Metadata</button>
+            <button class="side-item" data-view="repository-data-migration" type="button">⇄ Nexus Repository Data</button>
+          </div>
         </nav>
       </aside>
 
@@ -878,6 +898,6 @@
     </div>
 
     <script src="/login/assets/ui-i18n.js?v=20260625-ui-i18n-5"></script>
-    <script src="./assets/admin.js?v=20260625-required-forms-3"></script>
+    <script src="./assets/admin.js?v=20260628-sidebar-groups-1"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- Add collapsible top-level groups to the admin sidebar for Repository, Security, System, and Migration.
- Persist each group state in `localStorage` so the navigation density survives refreshes in the same browser.
- Keep the current route's group identifiable when collapsed, indent child menu items, and make the desktop sidebar scroll independently when all groups exceed the viewport height.

## Fixes

Closes #48.

## Validation

- `node --check admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js`
- `git diff --check`
- `mvn -pl admin-ui process-resources -q`
- Verified the local dev service still reports `UP` on `/actuator/health` and serves the updated admin CSS/JS resources.