### PR TITLE
[codex] Fix RubyGems dependency migration size validation

### DIFF
--- a/server/src/main/java/com/github/klboke/kkrepo/server/migration/RepositoryDataMigrationWorker.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/migration/RepositoryDataMigrationWorker.java
@@ -276,9 +276,13 @@ class RepositoryDataMigrationWorker {
         .orElse(DEFAULT_CONCURRENCY);
   }
 
-  private static boolean shouldValidateDownloadedSize(AssetClaim claim) {
+  static boolean shouldValidateDownloadedSize(AssetClaim claim) {
     if (claim.repositoryFormat() == RepositoryFormat.NPM
         && !claim.asset().sourcePath().toLowerCase().endsWith(".tgz")) {
+      return false;
+    }
+    if (claim.repositoryFormat() == RepositoryFormat.RUBYGEMS
+        && isRubygemsDependencyIndex(claim.asset().sourcePath())) {
       return false;
     }
     return true;
@@ -300,6 +304,17 @@ class RepositoryDataMigrationWorker {
       normalized = normalized.substring(1);
     }
     return "config.json".equals(normalized);
+  }
+
+  private static boolean isRubygemsDependencyIndex(String path) {
+    if (path == null) {
+      return false;
+    }
+    String normalized = path.trim();
+    while (normalized.startsWith("/")) {
+      normalized = normalized.substring(1);
+    }
+    return normalized.startsWith("dependencies/") && normalized.endsWith(".ruby");
   }
 
   private static boolean changedSince(RepositoryAssetMetadata asset, Instant since) {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/migration/RepositoryDataMigrationWorkerTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/migration/RepositoryDataMigrationWorkerTest.java
@@ -38,7 +38,28 @@ class RepositoryDataMigrationWorkerTest {
     assertTrue(RepositoryDataMigrationWorker.shouldMigrateSourceAsset(RepositoryFormat.NPM, "config.json"));
   }
 
+  @Test
+  void rubygemsDependencyIndexUsesDownloadedBytesInsteadOfSourceMetadataSize() {
+    assertFalse(RepositoryDataMigrationWorker.shouldValidateDownloadedSize(
+        claim(10L, 100L, RepositoryFormat.RUBYGEMS, "dependencies/demo.ruby")));
+    assertFalse(RepositoryDataMigrationWorker.shouldValidateDownloadedSize(
+        claim(10L, 100L, RepositoryFormat.RUBYGEMS, "/dependencies/demo.ruby")));
+
+    assertTrue(RepositoryDataMigrationWorker.shouldValidateDownloadedSize(
+        claim(10L, 100L, RepositoryFormat.RUBYGEMS, "gems/demo-1.0.0.gem")));
+    assertTrue(RepositoryDataMigrationWorker.shouldValidateDownloadedSize(
+        claim(10L, 100L, RepositoryFormat.MAVEN2, "dependencies/demo.ruby")));
+  }
+
   private static AssetClaim claim(long repositoryJobId, long migrationJobId, String path) {
+    return claim(repositoryJobId, migrationJobId, RepositoryFormat.MAVEN2, path);
+  }
+
+  private static AssetClaim claim(
+      long repositoryJobId,
+      long migrationJobId,
+      RepositoryFormat format,
+      String path) {
     RepositoryDataMigrationAssetRecord asset = new RepositoryDataMigrationAssetRecord(
         null,
         repositoryJobId,
@@ -46,7 +67,7 @@ class RepositoryDataMigrationWorkerTest {
         null,
         path,
         null,
-        RepositoryFormat.MAVEN2,
+        format,
         "com.acme",
         "app",
         "1.0",
@@ -76,7 +97,7 @@ class RepositoryDataMigrationWorkerTest {
         "source",
         "target",
         1L,
-        RepositoryFormat.MAVEN2,
+        format,
         "http://nexus.example",
         Map.of());
   }


### PR DESCRIPTION
## Summary
- skip strict downloaded-size validation for RubyGems dependency index assets under dependencies/*.ruby
- keep strict size validation for real RubyGems package blobs and other formats
- add focused migration worker coverage for the RubyGems dependency index case

## Root Cause
Nexus serves RubyGems dependency index entries from dependencies/*.ruby as generated index payloads. Their downloaded byte count can differ from the source metadata size, so migration treated otherwise successful downloads as failed validations.

## Validation
- mvn -pl server -am -Dtest=RepositoryDataMigrationWorkerTest -Dsurefire.failIfNoSpecifiedTests=false test