### PR TITLE
[codex] Fix group cache member max age

### DIFF
--- a/server/src/main/java/com/github/klboke/kkrepo/server/maven/MavenGroupService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/maven/MavenGroupService.java
@@ -137,7 +137,7 @@ public class MavenGroupService {
       MavenPath path,
       CachedAssetMetadata snapshot,
       Instant now) {
-    int ttl = group.contentMaxAgeMinutesOrDefault();
+    int ttl = group.effectiveContentMaxAgeMinutesOrDefault();
     Optional<NexusLikeCacheInfo> cacheInfo = NexusLikeCacheInfo.fromAttributes(snapshot.attributes());
     if (cacheController != null && cacheInfo.isPresent()) {
       return !cacheController.isStale(group.id(), NexusCacheType.CONTENT, cacheInfo.get(), ttl, now);
@@ -181,14 +181,13 @@ public class MavenGroupService {
   private MavenResponse serveMergedMetadata(
       RepositoryRuntime group, MavenPath path, boolean headOnly, DispatchedRepositories dispatched) {
     Instant now = Instant.now();
-    int ttl = group.metadataMaxAgeMinutesOrDefault();
+    int ttl = group.effectiveMetadataMaxAgeMinutesOrDefault();
     Optional<CachedAssetMetadata> cached = assetMetadataCache.find(
         group.id(),
         path.path(),
         () -> AssetMetadataCache.Loaded.from(
             assetDao.findAssetByPath(group.id(), path.path()), assetDao));
-    if (cached.isPresent() && ttl >= 0 && cached.get().lastUpdatedAt() != null
-        && cached.get().lastUpdatedAt().plusSeconds(ttl * 60L).isAfter(now)) {
+    if (cached.isPresent() && isGroupMetadataFresh(group, cached.get(), ttl, now)) {
       return serveCached(cached.get(), headOnly, path);
     }
     List<byte[]> members = collectMemberMetadata(group, path, dispatched);
@@ -216,6 +215,24 @@ public class MavenGroupService {
             BlobReferenceCodec.reference(blob.blobRef(), blob.objectKey(), blob.sha256(), blob.size()))
             .orElseThrow(() -> new MavenExceptions.MavenNotFoundException(path.path())),
         blob.size(), asset.contentType(), blob.sha1(), asset.lastUpdatedAt());
+  }
+
+  private boolean isGroupMetadataFresh(
+      RepositoryRuntime group,
+      CachedAssetMetadata snapshot,
+      int ttl,
+      Instant now) {
+    Optional<NexusLikeCacheInfo> cacheInfo = NexusLikeCacheInfo.fromAttributes(snapshot.attributes());
+    if (cacheController != null && cacheInfo.isPresent()) {
+      return !cacheController.isStale(group.id(), NexusCacheType.METADATA, cacheInfo.get(), ttl, now);
+    }
+    if (snapshot.lastUpdatedAt() == null) {
+      return false;
+    }
+    if (ttl < 0) {
+      return true;
+    }
+    return snapshot.lastUpdatedAt().plusSeconds(ttl * 60L).isAfter(now);
   }
 
   private List<byte[]> collectMemberMetadata(

--- a/server/src/main/java/com/github/klboke/kkrepo/server/maven/RepositoryRuntime.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/maven/RepositoryRuntime.java
@@ -2,7 +2,9 @@ package com.github.klboke.kkrepo.server.maven;
 
 import com.github.klboke.kkrepo.core.RepositoryFormat;
 import com.github.klboke.kkrepo.core.RepositoryType;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Immutable per-request snapshot of a repository's configuration relevant to serving Maven
@@ -239,6 +241,51 @@ public record RepositoryRuntime(
 
   public int metadataMaxAgeMinutesOrDefault() {
     return metadataMaxAgeMinutes == null ? 1440 : metadataMaxAgeMinutes;
+  }
+
+  public int effectiveContentMaxAgeMinutesOrDefault() {
+    return effectiveMaxAgeMinutes(false, new HashSet<>());
+  }
+
+  public int effectiveMetadataMaxAgeMinutesOrDefault() {
+    return effectiveMaxAgeMinutes(true, new HashSet<>());
+  }
+
+  private int effectiveMaxAgeMinutes(boolean metadata, Set<Long> resolvingGroups) {
+    boolean addedGroup = false;
+    if (isGroup()) {
+      if (!resolvingGroups.add(id)) {
+        return -1;
+      }
+      addedGroup = true;
+    }
+    try {
+      int effective = metadata ? metadataMaxAgeMinutesOrDefault() : contentMaxAgeMinutesOrDefault();
+      if (isGroup() && members != null) {
+        for (RepositoryRuntime member : members) {
+          if (member != null) {
+            effective = shortestFiniteMaxAge(
+                effective,
+                member.effectiveMaxAgeMinutes(metadata, resolvingGroups));
+          }
+        }
+      }
+      return effective;
+    } finally {
+      if (addedGroup) {
+        resolvingGroups.remove(id);
+      }
+    }
+  }
+
+  private static int shortestFiniteMaxAge(int left, int right) {
+    if (left < 0) {
+      return right;
+    }
+    if (right < 0) {
+      return left;
+    }
+    return Math.min(left, right);
   }
 
   public boolean autoBlockOrDefault() {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmGroupPackumentCache.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmGroupPackumentCache.java
@@ -104,7 +104,7 @@ public class NpmGroupPackumentCache {
         group.id(),
         NexusCacheType.METADATA,
         cacheInfo,
-        group.metadataMaxAgeMinutesOrDefault(),
+        group.effectiveMetadataMaxAgeMinutesOrDefault(),
         now)) {
       return Optional.empty();
     }

--- a/server/src/main/java/com/github/klboke/kkrepo/server/pypi/PypiGroupSimpleIndexCache.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/pypi/PypiGroupSimpleIndexCache.java
@@ -95,7 +95,7 @@ public class PypiGroupSimpleIndexCache {
         group.id(),
         NexusCacheType.METADATA,
         cacheInfo,
-        group.metadataMaxAgeMinutesOrDefault(),
+        group.effectiveMetadataMaxAgeMinutesOrDefault(),
         now)) {
       return Optional.empty();
     }

--- a/server/src/test/java/com/github/klboke/kkrepo/server/maven/MavenGroupServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/maven/MavenGroupServiceTest.java
@@ -105,6 +105,27 @@ class MavenGroupServiceTest {
   }
 
   @Test
+  void cachedGroupArtifactExpiresUsingShortestMemberContentMaxAge() throws IOException {
+    InMemorySharedCache shared = new InMemorySharedCache();
+    AssetMetadataCache cache = new AssetMetadataCache(shared, true, 120, 5);
+    MavenPath path = markerJar();
+    warmCache(cache, 1L, path.path(),
+        snapshot(100L, 1L, path.path(), blob(900L), Instant.now().minusSeconds(120)));
+    MavenGroupService service = new MavenGroupService(
+        new MissingHostedService(),
+        new SuccessfulProxyService(),
+        new EmptyAssetDao(),
+        new FixedBlobStorageRegistry(new BytesBlobStorage("cached-group")),
+        null,
+        cache);
+
+    MavenResponse response = service.get(group(1L, "maven-public", List.of(proxy(1, 1440))), path, false);
+
+    assertEquals(200, response.status());
+    assertEquals("module-ok", new String(response.body().readAllBytes(), StandardCharsets.UTF_8));
+  }
+
+  @Test
   void memberHitWritesGroupArtifactReferenceCache() {
     InMemorySharedCache shared = new InMemorySharedCache();
     AssetMetadataCache cache = new AssetMetadataCache(shared, true, 120, 5);
@@ -207,6 +228,10 @@ class MavenGroupServiceTest {
   }
 
   private static RepositoryRuntime proxy() {
+    return proxy(1440, 1440);
+  }
+
+  private static RepositoryRuntime proxy(int contentMaxAgeMinutes, int metadataMaxAgeMinutes) {
     return new RepositoryRuntime(
         3,
         "nexus-dev",
@@ -220,12 +245,21 @@ class MavenGroupServiceTest {
         "PERMISSIVE",
         true,
         "http://127.0.0.1:8080/repository/maven-public/",
-        1440,
-        1440,
+        contentMaxAgeMinutes,
+        metadataMaxAgeMinutes,
         true, null, List.of());
   }
 
   private static CachedAssetMetadata snapshot(long assetId, long repositoryId, String path, AssetBlobRecord blob) {
+    return snapshot(assetId, repositoryId, path, blob, Instant.now().minusSeconds(60));
+  }
+
+  private static CachedAssetMetadata snapshot(
+      long assetId,
+      long repositoryId,
+      String path,
+      AssetBlobRecord blob,
+      Instant lastUpdatedAt) {
     return CachedAssetMetadata.of(new AssetRecord(
         assetId,
         repositoryId,
@@ -239,7 +273,7 @@ class MavenGroupServiceTest {
         "application/java-archive",
         blob.size(),
         null,
-        Instant.now().minusSeconds(60),
+        lastUpdatedAt,
         Map.of()),
         blob);
   }

--- a/server/src/test/java/com/github/klboke/kkrepo/server/maven/RepositoryRuntimeTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/maven/RepositoryRuntimeTest.java
@@ -1,0 +1,88 @@
+package com.github.klboke.kkrepo.server.maven;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RepositoryRuntimeTest {
+
+  @Test
+  void effectiveMaxAgeUsesShortestFiniteMemberValue() {
+    RepositoryRuntime proxy = repository(2L, RepositoryType.PROXY, 1, 5, List.of());
+    RepositoryRuntime hosted = repository(3L, RepositoryType.HOSTED, null, null, List.of());
+    RepositoryRuntime group = repository(1L, RepositoryType.GROUP, 1440, 1440, List.of(proxy, hosted));
+
+    assertEquals(1, group.effectiveContentMaxAgeMinutesOrDefault());
+    assertEquals(5, group.effectiveMetadataMaxAgeMinutesOrDefault());
+  }
+
+  @Test
+  void effectiveMaxAgeWalksNestedGroups() {
+    RepositoryRuntime proxy = repository(3L, RepositoryType.PROXY, 3, 2, List.of());
+    RepositoryRuntime inner = repository(2L, RepositoryType.GROUP, 60, 60, List.of(proxy));
+    RepositoryRuntime outer = repository(1L, RepositoryType.GROUP, 1440, 1440, List.of(inner));
+
+    assertEquals(3, outer.effectiveContentMaxAgeMinutesOrDefault());
+    assertEquals(2, outer.effectiveMetadataMaxAgeMinutesOrDefault());
+  }
+
+  @Test
+  void disabledAgeDoesNotMaskFiniteMemberValue() {
+    RepositoryRuntime proxy = repository(2L, RepositoryType.PROXY, 1, 1, List.of());
+    RepositoryRuntime group = repository(1L, RepositoryType.GROUP, -1, -1, List.of(proxy));
+
+    assertEquals(1, group.effectiveContentMaxAgeMinutesOrDefault());
+    assertEquals(1, group.effectiveMetadataMaxAgeMinutesOrDefault());
+  }
+
+  @Test
+  void allDisabledAgesRemainDisabled() {
+    RepositoryRuntime proxy = repository(2L, RepositoryType.PROXY, -1, -1, List.of());
+    RepositoryRuntime group = repository(1L, RepositoryType.GROUP, -1, -1, List.of(proxy));
+
+    assertEquals(-1, group.effectiveContentMaxAgeMinutesOrDefault());
+    assertEquals(-1, group.effectiveMetadataMaxAgeMinutesOrDefault());
+  }
+
+  @Test
+  void groupCycleDoesNotRecurseForever() {
+    List<RepositoryRuntime> rootMembers = new ArrayList<>();
+    List<RepositoryRuntime> nestedMembers = new ArrayList<>();
+    RepositoryRuntime root = repository(1L, RepositoryType.GROUP, 1440, 1440, rootMembers);
+    RepositoryRuntime nested = repository(2L, RepositoryType.GROUP, -1, -1, nestedMembers);
+    rootMembers.add(nested);
+    nestedMembers.add(root);
+    nestedMembers.add(repository(3L, RepositoryType.PROXY, 10, 8, List.of()));
+
+    assertEquals(10, root.effectiveContentMaxAgeMinutesOrDefault());
+    assertEquals(8, root.effectiveMetadataMaxAgeMinutesOrDefault());
+  }
+
+  private static RepositoryRuntime repository(
+      long id,
+      RepositoryType type,
+      Integer contentMaxAgeMinutes,
+      Integer metadataMaxAgeMinutes,
+      List<RepositoryRuntime> members) {
+    return new RepositoryRuntime(
+        id,
+        "repo-" + id,
+        RepositoryFormat.MAVEN2,
+        type,
+        "maven2-" + type.name().toLowerCase(),
+        true,
+        1L,
+        null,
+        "MIXED",
+        "PERMISSIVE",
+        true,
+        type == RepositoryType.PROXY ? "http://example.invalid/repository/repo-" + id + "/" : null,
+        contentMaxAgeMinutes,
+        metadataMaxAgeMinutes,
+        members);
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmGroupPackumentCacheTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmGroupPackumentCacheTest.java
@@ -75,6 +75,18 @@ class NpmGroupPackumentCacheTest {
   }
 
   @Test
+  void memberMetadataMaxAgeExpiresPackageRootAsset() {
+    Fixture fixture = fixture(true);
+    RepositoryRuntime proxy = proxyRuntime(10L, "npm-proxy", 1);
+    RepositoryRuntime group = runtime(99L, "npm-group", 1440, List.of(proxy));
+    fixture.assets.putAsset(group.id(), PACKAGE_ID.id(),
+        fixture.cache.freshAttributes(group, NOW), NOW);
+
+    assertTrue(fixture.cache.findFresh(group, PACKAGE_ID, NOW.plusSeconds(59)).isPresent());
+    assertTrue(fixture.cache.findFresh(group, PACKAGE_ID, NOW.plusSeconds(60)).isEmpty());
+  }
+
+  @Test
   void memberPackageInvalidationMarksMatchingGroupAssetsAndAncestorsInvalidated() {
     Fixture fixture = fixture(true);
     RepositoryRuntime inner = runtime(20L, "inner", 60);
@@ -151,10 +163,25 @@ class NpmGroupPackumentCacheTest {
   }
 
   private static RepositoryRuntime runtime(long id, String name, int metadataMaxAgeMinutes) {
+    return runtime(id, name, metadataMaxAgeMinutes, List.of());
+  }
+
+  private static RepositoryRuntime runtime(
+      long id,
+      String name,
+      int metadataMaxAgeMinutes,
+      List<RepositoryRuntime> members) {
     return new RepositoryRuntime(
         id, name, RepositoryFormat.NPM, RepositoryType.GROUP, "npm-group",
         true, 1L, "ALLOW", null, null, true, null, null, metadataMaxAgeMinutes,
-        null, null, List.of());
+        null, null, members);
+  }
+
+  private static RepositoryRuntime proxyRuntime(long id, String name, int metadataMaxAgeMinutes) {
+    return new RepositoryRuntime(
+        id, name, RepositoryFormat.NPM, RepositoryType.PROXY, "npm-proxy",
+        true, 1L, "ALLOW", null, null, true, "http://example.invalid/registry/", null,
+        metadataMaxAgeMinutes, null, null, List.of());
   }
 
   private static RepositoryRecord record(long id, String name) {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiGroupSimpleIndexCacheTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiGroupSimpleIndexCacheTest.java
@@ -65,6 +65,20 @@ class PypiGroupSimpleIndexCacheTest {
   }
 
   @Test
+  void memberMetadataMaxAgeExpiresGroupIndexAsset() {
+    Fixture fixture = fixture(true);
+    RepositoryRuntime proxy = proxyRuntime(10L, "pypi-proxy", 1);
+    RepositoryRuntime group = runtime(99L, "pypi-group", 1440, List.of(proxy));
+    fixture.assets.putAsset(group.id(), PypiPaths.indexPath("demo"),
+        PypiGroupSimpleIndexCache.INDEX, fixture.cache.freshAttributes(group, "demo", NOW), NOW);
+
+    assertTrue(fixture.cache.findFresh(
+        group, PypiPaths.indexPath("demo"), PypiGroupSimpleIndexCache.INDEX, NOW.plusSeconds(59)).isPresent());
+    assertTrue(fixture.cache.findFresh(
+        group, PypiPaths.indexPath("demo"), PypiGroupSimpleIndexCache.INDEX, NOW.plusSeconds(60)).isEmpty());
+  }
+
+  @Test
   void memberProjectInvalidationMarksRootAndProjectIndexesAndAncestorsInvalidated() {
     Fixture fixture = fixture(true);
     RepositoryRuntime inner = runtime(20L, "inner", 60);
@@ -148,10 +162,25 @@ class PypiGroupSimpleIndexCacheTest {
   }
 
   private static RepositoryRuntime runtime(long id, String name, int metadataMaxAgeMinutes) {
+    return runtime(id, name, metadataMaxAgeMinutes, List.of());
+  }
+
+  private static RepositoryRuntime runtime(
+      long id,
+      String name,
+      int metadataMaxAgeMinutes,
+      List<RepositoryRuntime> members) {
     return new RepositoryRuntime(
         id, name, RepositoryFormat.PYPI, RepositoryType.GROUP, "pypi-group",
         true, 1L, "ALLOW", null, null, true, null, null, metadataMaxAgeMinutes,
-        null, null, List.of());
+        null, null, members);
+  }
+
+  private static RepositoryRuntime proxyRuntime(long id, String name, int metadataMaxAgeMinutes) {
+    return new RepositoryRuntime(
+        id, name, RepositoryFormat.PYPI, RepositoryType.PROXY, "pypi-proxy",
+        true, 1L, "ALLOW", null, null, true, "http://example.invalid/simple/", null,
+        metadataMaxAgeMinutes, null, null, List.of());
   }
 
   private static RepositoryRecord record(long id, String name) {


### PR DESCRIPTION
## Summary

- Add recursive effective cache max-age calculation for repository runtime snapshots.
- Use the shortest finite member TTL for PyPI group simple indexes, npm group packuments, and Maven group metadata/content caches.
- Cover -1 semantics so a disabled age does not hide a finite member TTL.

Fixes #66

## Root Cause

Group-level cached metadata/content was being checked against the group repository own max-age. When a group kept the default long TTL, a proxy member with a shorter metadata/content TTL could remain hidden behind stale merged or selected group cache entries.

## Validation

- mvn -pl server -am -Dtest=RepositoryRuntimeTest,PypiGroupSimpleIndexCacheTest,NpmGroupPackumentCacheTest,MavenGroupServiceTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -pl server -am test