### PR TITLE
[codex] Add Nginx reverse proxy docs

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -40,6 +40,8 @@ curl -fsSL https://raw.githubusercontent.com/klboke/kkrepo/main/scripts/quicksta
 
 本地快速启动、Spring Boot 可执行 jar、Docker 镜像、压缩包、生产部署架构、资源规格和升级流程见 [构建部署指南](docs/zh/build-deployment-guide.md)。
 
+如果 kkRepo 部署在 Nginx 或其他 HTTPS 反向代理后面，请参考 [Nginx 反向代理配置注意事项](docs/zh/nginx-reverse-proxy.md)，确保 npm `dist.tarball` 等生成的仓库 URL 保持公网 `https://` scheme 和 host。
+
 本地开发热重载和测试说明见 [中文开发指南](docs/zh/development-guide.md)。
 
 ## 支持能力
@@ -172,6 +174,7 @@ kkRepo 使用 [Apache License 2.0](LICENSE) 开源。
 
 - [中文开发指南](docs/zh/development-guide.md)
 - [构建部署指南](docs/zh/build-deployment-guide.md)
+- [Nginx 反向代理配置注意事项](docs/zh/nginx-reverse-proxy.md)
 - [客户端配置示例](docs/zh/client-recipes.md)
 - [架构说明](docs/zh/architecture.md)
 - [兼容性矩阵](docs/zh/compatibility-matrix.md)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ If you prefer to inspect the script before running it, download `scripts/quickst
 
 Local quick start, Spring Boot executable jar, Docker image, archive package, production deployment architecture, resource sizing, and upgrade flow are documented in the [Build And Deployment Guide](docs/en/build-deployment-guide.md).
 
+If kkRepo is deployed behind Nginx or another HTTPS reverse proxy, follow the [Nginx Reverse Proxy Notes](docs/en/nginx-reverse-proxy.md) so generated repository URLs, such as npm `dist.tarball`, keep the public `https://` scheme and host.
+
 Local hot-reload development and testing are documented in the [Development Guide](docs/en/development-guide.md).
 
 ## Supported Capabilities
@@ -174,6 +176,7 @@ kkRepo is open sourced under the [Apache License 2.0](LICENSE).
 
 - [Development Guide](docs/en/development-guide.md)
 - [Build And Deployment Guide](docs/en/build-deployment-guide.md)
+- [Nginx Reverse Proxy Notes](docs/en/nginx-reverse-proxy.md)
 - [Client Recipes](docs/en/client-recipes.md)
 - [Architecture](docs/en/architecture.md)
 - [Compatibility Matrix](docs/en/compatibility-matrix.md)

--- a/docs/en/nginx-reverse-proxy.md
+++ b/docs/en/nginx-reverse-proxy.md
@@ -1,0 +1,101 @@
+# Nginx Reverse Proxy Notes
+
+This note covers the common deployment shape where Nginx terminates HTTPS and forwards traffic to the kkRepo application port over HTTP.
+
+## Why Forwarded Headers Matter
+
+kkRepo generates some client-visible absolute URLs from the incoming request. For example, npm package metadata rewrites `dist.tarball` to the public repository URL returned to `npm view` and `npm install`.
+
+If Nginx receives `https://nexus.example.com` but forwards to kkRepo as plain HTTP, kkRepo must receive trusted forwarded headers. Otherwise generated URLs may use the backend view of the request, such as `http://...` or a backend port.
+
+`KKREPO_EXTERNAL_BASE_URL` is used for OIDC redirect URL generation. It does not replace forwarded-header configuration for repository metadata URLs.
+
+## Nginx Example
+
+```nginx
+upstream kkrepo_app {
+    server 127.0.0.1:8080;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name nexus.example.com;
+
+    ssl_certificate /etc/nginx/tls/nexus.example.com.crt;
+    ssl_certificate_key /etc/nginx/tls/nexus.example.com.key;
+
+    client_max_body_size 0;
+    proxy_connect_timeout 30s;
+    proxy_send_timeout 600s;
+    proxy_read_timeout 600s;
+
+    location / {
+        proxy_pass http://kkrepo_app;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Port 443;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Authorization $http_authorization;
+    }
+}
+```
+
+Preserve the original path. Do not rewrite `/repository/<repo>/...`, `/admin/`, `/browse/`, `/service/rest/`, or Docker `/v2/...` paths unless the application context path is configured consistently on the kkRepo side.
+
+Keep the management port, usually `8081`, private. The public reverse proxy should route to the application port, usually `8080`.
+
+## kkRepo Settings
+
+Set `KKREPO_TRUSTED_PROXIES` to the Nginx address as seen by kkRepo. The value must match `request.getRemoteAddr()` for the proxy connection. Use exact IP addresses or names that resolve to the actual proxy address; CIDR ranges and client IP ranges are not matched by this setting.
+
+Examples:
+
+```bash
+# Nginx and kkRepo on the same host.
+KKREPO_TRUSTED_PROXIES=127.0.0.1
+
+# If the backend connection uses IPv6 loopback.
+KKREPO_TRUSTED_PROXIES=::1
+
+# Two proxy instances in front of kkRepo.
+KKREPO_TRUSTED_PROXIES=10.0.12.34,10.0.12.35
+```
+
+For HTTPS deployments, also enable secure browser cookies and HSTS when appropriate:
+
+```bash
+KKREPO_SESSION_COOKIE_SECURE=true
+KKREPO_CSRF_COOKIE_SECURE=true
+KKREPO_HSTS_ENABLED=true
+```
+
+If OIDC is enabled and the provider needs a stable public callback URL, set:
+
+```bash
+KKREPO_EXTERNAL_BASE_URL=https://nexus.example.com
+```
+
+## Verification
+
+After starting kkRepo behind Nginx, verify a real client-visible URL:
+
+```bash
+npm view --registry=https://nexus.example.com/repository/npm-group/ is-number dist.tarball
+```
+
+The returned tarball URL should start with:
+
+```text
+https://nexus.example.com/repository/npm-group/
+```
+
+If it starts with `http://`, contains `:8080`, or uses an internal host name, check:
+
+- Nginx sends `X-Forwarded-Proto`, `X-Forwarded-Host`, and `X-Forwarded-Port`.
+- `KKREPO_TRUSTED_PROXIES` matches the proxy address seen by kkRepo.
+- The public request is routed to the application port, not the management port.
+- Nginx preserves the original repository path.

--- a/docs/en/production-hardening.md
+++ b/docs/en/production-hardening.md
@@ -94,11 +94,13 @@ Reverse proxy checklist:
 - Configure client abort logging so disconnected downloads do not look like server faults.
 - Set `X-Forwarded-*` headers consistently.
 
-Set external URL/trusted proxy settings when required by your deployment:
+For exact Nginx settings and generated repository URL verification, see the [Nginx Reverse Proxy Notes](nginx-reverse-proxy.md).
+
+Set OIDC external URL and trusted proxy settings when required by your deployment:
 
 ```bash
 KKREPO_EXTERNAL_BASE_URL=https://nexus.example.com
-KKREPO_TRUSTED_PROXIES=10.0.0.0/8,192.168.0.0/16
+KKREPO_TRUSTED_PROXIES=10.0.12.34,10.0.12.35
 ```
 
 ## Session And Cookie Security

--- a/docs/zh/nginx-reverse-proxy.md
+++ b/docs/zh/nginx-reverse-proxy.md
@@ -1,0 +1,101 @@
+# Nginx 反向代理配置注意事项
+
+本文说明一种常见部署形态：Nginx 在外层终止 HTTPS，再通过 HTTP 转发到 kkRepo 应用端口。
+
+## 为什么需要 Forwarded Header
+
+kkRepo 会基于当前请求生成部分客户端可见的绝对 URL。例如 npm package metadata 中的 `dist.tarball` 会被重写成返回给 `npm view` 和 `npm install` 的公开仓库 URL。
+
+如果 Nginx 对外接收的是 `https://nexus.example.com`，但转发到 kkRepo 时变成后端 HTTP 请求，kkRepo 必须收到可信的 forwarded header。否则生成的 URL 可能会使用后端看到的请求信息，例如 `http://...` 或后端端口。
+
+`KKREPO_EXTERNAL_BASE_URL` 用于生成 OIDC redirect URL。它不能替代 repository metadata URL 所需的 forwarded header 配置。
+
+## Nginx 示例
+
+```nginx
+upstream kkrepo_app {
+    server 127.0.0.1:8080;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name nexus.example.com;
+
+    ssl_certificate /etc/nginx/tls/nexus.example.com.crt;
+    ssl_certificate_key /etc/nginx/tls/nexus.example.com.key;
+
+    client_max_body_size 0;
+    proxy_connect_timeout 30s;
+    proxy_send_timeout 600s;
+    proxy_read_timeout 600s;
+
+    location / {
+        proxy_pass http://kkrepo_app;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Port 443;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Authorization $http_authorization;
+    }
+}
+```
+
+需要保留原始 path。除非 kkRepo 侧也一致配置了 application context path，否则不要改写 `/repository/<repo>/...`、`/admin/`、`/browse/`、`/service/rest/` 或 Docker `/v2/...` 路径。
+
+管理端口通常是 `8081`，应保持内网可见。公网反向代理应转发到应用端口，通常是 `8080`。
+
+## kkRepo 配置
+
+把 `KKREPO_TRUSTED_PROXIES` 设置成 kkRepo 看到的 Nginx 来源地址。该值必须匹配代理连接上的 `request.getRemoteAddr()`。请使用精确 IP，或能解析到实际代理地址的名称；这个配置不会匹配 CIDR 网段或客户端 IP 网段。
+
+示例：
+
+```bash
+# Nginx 和 kkRepo 在同一台机器。
+KKREPO_TRUSTED_PROXIES=127.0.0.1
+
+# 如果后端连接使用 IPv6 loopback。
+KKREPO_TRUSTED_PROXIES=::1
+
+# 两个代理实例转发到 kkRepo。
+KKREPO_TRUSTED_PROXIES=10.0.12.34,10.0.12.35
+```
+
+HTTPS 部署建议同时启用浏览器 secure cookie 和 HSTS：
+
+```bash
+KKREPO_SESSION_COOKIE_SECURE=true
+KKREPO_CSRF_COOKIE_SECURE=true
+KKREPO_HSTS_ENABLED=true
+```
+
+如果启用了 OIDC，并且身份提供方需要稳定的公网 callback URL，可设置：
+
+```bash
+KKREPO_EXTERNAL_BASE_URL=https://nexus.example.com
+```
+
+## 验证方式
+
+kkRepo 通过 Nginx 启动后，用真实客户端可见 URL 验证：
+
+```bash
+npm view --registry=https://nexus.example.com/repository/npm-group/ is-number dist.tarball
+```
+
+返回的 tarball URL 应该以如下地址开头：
+
+```text
+https://nexus.example.com/repository/npm-group/
+```
+
+如果返回值以 `http://` 开头、包含 `:8080`，或使用了内部 host，检查：
+
+- Nginx 是否发送了 `X-Forwarded-Proto`、`X-Forwarded-Host` 和 `X-Forwarded-Port`。
+- `KKREPO_TRUSTED_PROXIES` 是否匹配 kkRepo 看到的代理来源地址。
+- 公网请求是否转发到了应用端口，而不是管理端口。
+- Nginx 是否保留了原始 repository path。

--- a/docs/zh/production-hardening.md
+++ b/docs/zh/production-hardening.md
@@ -94,11 +94,13 @@ KKREPO_FILE_SHARED_FILESYSTEM=true
 - 对客户端主动断开下载做合理日志分类，避免误判为服务端故障。
 - 一致设置 `X-Forwarded-*` header。
 
-需要时设置外部 URL 和可信代理：
+详细 Nginx 配置和生成仓库 URL 验证方式见 [Nginx 反向代理配置注意事项](nginx-reverse-proxy.md)。
+
+需要时设置 OIDC 外部 URL 和可信代理：
 
 ```bash
 KKREPO_EXTERNAL_BASE_URL=https://nexus.example.com
-KKREPO_TRUSTED_PROXIES=10.0.0.0/8,192.168.0.0/16
+KKREPO_TRUSTED_PROXIES=10.0.12.34,10.0.12.35
 ```
 
 ## Session 和 Cookie 安全


### PR DESCRIPTION
## Summary

- Add English and Chinese Nginx reverse proxy notes for HTTPS termination in front of kkRepo.
- Document the required `X-Forwarded-*` headers, exact `KKREPO_TRUSTED_PROXIES` matching behavior, secure-cookie settings, and npm `dist.tarball` verification.
- Link the new docs from both READMEs and from the production hardening guides.

## Why

When Nginx forwards HTTPS traffic to kkRepo over backend HTTP without trusted forwarded headers, generated repository metadata URLs can expose `http://`, backend ports, or internal hosts. The docs now make the expected proxy and kkRepo settings explicit.

## Validation

- `git diff --check HEAD~1..HEAD`
- Staged and committed only the six documentation files in this change.