### PR TITLE
[codex] Fix Nexus ALL action permission matching

### DIFF
--- a/server/src/main/java/com/github/klboke/kkrepo/server/security/SecurityManagementService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/security/SecurityManagementService.java
@@ -1457,8 +1457,15 @@ public class SecurityManagementService implements AccessDecisionService {
 
   private static boolean actionPartMatches(String grantedPart, String requestedPart) {
     String requested = normalizeActionPart(requestedPart);
+    boolean requestedWildcard = "*".equals(defaultString(requestedPart, "*").trim());
     for (String option : defaultString(grantedPart, "*").split(",")) {
       String normalized = normalizeActionPart(option);
+      if (requestedWildcard) {
+        if ("*".equals(option.trim())) {
+          return true;
+        }
+        continue;
+      }
       if ("*".equals(normalized) || normalized.equals(requested)) {
         return true;
       }

--- a/server/src/main/java/com/github/klboke/kkrepo/server/security/SecurityManagementService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/security/SecurityManagementService.java
@@ -1395,9 +1395,14 @@ public class SecurityManagementService implements AccessDecisionService {
     for (int i = 0; i < max; i++) {
       String grantedPart = i < grantedParts.length ? grantedParts[i] : "*";
       String requestedPart = i < requestedParts.length ? requestedParts[i] : "*";
-      boolean matches = isFormatSegment(grantedParts, requestedParts, i)
-          ? formatPartMatches(grantedPart, requestedPart)
-          : partMatches(grantedPart, requestedPart);
+      boolean matches;
+      if (isFormatSegment(grantedParts, requestedParts, i)) {
+        matches = formatPartMatches(grantedPart, requestedPart);
+      } else if (isActionSegment(grantedParts, requestedParts, i)) {
+        matches = actionPartMatches(grantedPart, requestedPart);
+      } else {
+        matches = partMatches(grantedPart, requestedPart);
+      }
       if (!matches) {
         return false;
       }
@@ -1413,6 +1418,18 @@ public class SecurityManagementService implements AccessDecisionService {
       case "repository-view", "repository-admin" -> index == 2;
       case "repository-content-selector" -> index == 3;
       default -> false;
+    };
+  }
+
+  private static boolean isActionSegment(String[] grantedParts, String[] requestedParts, int index) {
+    String grantedDomain = grantedParts.length > 1 ? grantedParts[1] : "";
+    String requestedDomain = requestedParts.length > 1 ? requestedParts[1] : "";
+    String domain = grantedDomain.equals(requestedDomain) ? grantedDomain : requestedDomain;
+    return switch (domain) {
+      case "repository-view", "repository-admin" -> index == 4;
+      case "repository-content-selector" -> index == 5;
+      default -> index == 2 && "nexus".equals(grantedParts.length > 0 ? grantedParts[0] : "")
+          && "nexus".equals(requestedParts.length > 0 ? requestedParts[0] : "");
     };
   }
 
@@ -1436,6 +1453,27 @@ public class SecurityManagementService implements AccessDecisionService {
       }
     }
     return false;
+  }
+
+  private static boolean actionPartMatches(String grantedPart, String requestedPart) {
+    String requested = normalizeActionPart(requestedPart);
+    for (String option : defaultString(grantedPart, "*").split(",")) {
+      String normalized = normalizeActionPart(option);
+      if ("*".equals(normalized) || normalized.equals(requested)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String normalizeActionPart(String action) {
+    String normalized = defaultString(action, "*").trim().toLowerCase(Locale.ROOT);
+    return switch (normalized) {
+      case "all" -> "*";
+      case "create" -> "add";
+      case "update" -> "edit";
+      default -> normalized;
+    };
   }
 
   private static boolean globMatches(String pattern, String value) {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/security/SecurityManagementServicePermissionTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/security/SecurityManagementServicePermissionTest.java
@@ -97,6 +97,28 @@ class SecurityManagementServicePermissionTest {
   }
 
   @Test
+  void nexusAllActionDoesNotSatisfyRequestedWildcardActions() {
+    FakeSecurityDao dao = new FakeSecurityDao();
+    dao.assign("Local", "alice", "nx-scoped-all");
+    dao.grant("nx-scoped-all", privilege(
+        "nx-privileges-all",
+        "application",
+        Map.of("domain", "privileges", "actions", List.of("ALL"))));
+    dao.grant("nx-scoped-all", privilege(
+        "nx-repository-view-maven2-releases-all",
+        "repository-view",
+        Map.of("format", "maven2", "repository", "releases", "actions", List.of("ALL"))));
+    SecurityManagementService service = new SecurityManagementService(dao);
+
+    assertTrue(service.decide(subject("alice"), "nexus:privileges:delete").allowed());
+    assertTrue(service.decide(subject("alice"), repositoryPermission("releases", "com/acme/app/1.0/app-1.0.pom", PermissionAction.ADD))
+        .allowed());
+    assertFalse(service.decide(subject("alice"), "nexus:privileges:*").allowed());
+    assertFalse(service.decide(subject("alice"), "nexus:repository-view:maven2:releases:*").allowed());
+    assertFalse(service.decide(subject("alice"), "nexus:*").allowed());
+  }
+
+  @Test
   void repositoryTargetPrivilegesDoNotGrantRepositoryAccess() {
     FakeSecurityDao dao = new FakeSecurityDao();
     dao.assign("Local", "alice", "nx-target-reader");

--- a/server/src/test/java/com/github/klboke/kkrepo/server/security/SecurityManagementServicePermissionTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/security/SecurityManagementServicePermissionTest.java
@@ -53,6 +53,50 @@ class SecurityManagementServicePermissionTest {
   }
 
   @Test
+  void repositoryViewPrivilegeTreatsNexusAllActionAsWildcard() {
+    FakeSecurityDao dao = new FakeSecurityDao();
+    dao.assign("Local", "alice", "nx-repository-writer");
+    dao.grant("nx-repository-writer", privilege(
+        "nx-repository-view-maven2-releases-all",
+        "repository-view",
+        Map.of("format", "maven2", "repository", "releases", "actions", List.of("ALL"))));
+    SecurityManagementService service = new SecurityManagementService(dao);
+
+    assertTrue(service.decide(subject("alice"), repositoryPermission("releases", "com/acme/app/1.0/app-1.0.pom", PermissionAction.ADD))
+        .allowed());
+    assertTrue(service.decide(subject("alice"), repositoryPermission("releases", "com/acme/app/1.0/app-1.0.pom", PermissionAction.EDIT))
+        .allowed());
+    assertTrue(service.decide(subject("alice"), repositoryPermission("releases", "com/acme/app/1.0/app-1.0.pom", PermissionAction.DELETE))
+        .allowed());
+    assertFalse(service.decide(subject("alice"), repositoryPermission("snapshots", "com/acme/app/1.0/app-1.0.pom", PermissionAction.ADD))
+        .allowed());
+  }
+
+  @Test
+  void applicationPrivilegeAcceptsNexusActionAliases() {
+    FakeSecurityDao dao = new FakeSecurityDao();
+    dao.assign("Local", "alice", "nx-role-manager");
+    dao.grant("nx-role-manager", privilege(
+        "nx-roles-create",
+        "application",
+        Map.of("domain", "roles", "actions", List.of("ADD"))));
+    dao.grant("nx-role-manager", privilege(
+        "nx-privileges-all",
+        "application",
+        Map.of("domain", "privileges", "actions", List.of("ALL"))));
+    dao.grant("nx-role-manager", privilege(
+        "nx-settings-update",
+        "application",
+        Map.of("domain", "settings", "actions", List.of("EDIT"))));
+    SecurityManagementService service = new SecurityManagementService(dao);
+
+    assertTrue(service.decide(subject("alice"), "nexus:roles:create").allowed());
+    assertTrue(service.decide(subject("alice"), "nexus:privileges:delete").allowed());
+    assertTrue(service.decide(subject("alice"), "nexus:settings:update").allowed());
+    assertFalse(service.decide(subject("alice"), "nexus:users:create").allowed());
+  }
+
+  @Test
   void repositoryTargetPrivilegesDoNotGrantRepositoryAccess() {
     FakeSecurityDao dao = new FakeSecurityDao();
     dao.assign("Local", "alice", "nx-target-reader");


### PR DESCRIPTION
## Summary

- Treat Nexus repository privilege action `ALL` as a wildcard during permission matching.
- Normalize Nexus action aliases only in the permission action segment: `ALL -> *`, `create -> add`, and `update -> edit`.
- Add regression coverage for migrated Nexus repository-view privileges and application action aliases.

## Root Cause

Nexus exposes generated `nx-repository-view-<format>-<repo>-*` privileges with action `ALL`. kkRepo normalized newly created REST privileges to `*`, but existing or migrated records that still stored `ALL` were compared literally, so write/delete permissions could be denied even though Nexus grants them.

## Validation

- `mvn -pl server -am -Dtest=SecurityManagementServicePermissionTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`
- Live checked local Nexus `28090`: `nx-repository-view-maven2-maven-dcmes-*` and `nx-repository-view-maven2-team-dcmes-maven-group-*` use `ALL` and cover the concrete actions.
- Live checked kkRepo `18090`: a temp user with only an existing `actions: "ALL"` repository-view privilege could `PUT`, `GET`, browse, and `DELETE` Maven content.

Fixes #67