### PR TITLE
Support wildcard privilege filtering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
           java-version: "25"
           cache: maven
 
+      - name: Set up Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
       - name: Validate development compose file
         run: docker compose -f docker-compose.dev.yml config
 

--- a/admin-ui/pom.xml
+++ b/admin-ui/pom.xml
@@ -16,5 +16,10 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-webmvc</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin-filter.js
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin-filter.js
@@ -1,0 +1,39 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === "object" && module.exports) {
+    module.exports = api;
+  } else {
+    root.kkrepoAdminFilters = api;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  "use strict";
+
+  function normalizeFilter(filter) {
+    return String(filter ?? "").trim().toLowerCase().replace(/\*+/g, "*");
+  }
+
+  function searchableText(values) {
+    const raw = Array.isArray(values) ? values : [values];
+    return raw.map((value) => String(value ?? "").toLowerCase()).join(" ");
+  }
+
+  function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+
+  function wildcardRegExp(filter) {
+    return new RegExp(filter.split("*").map(escapeRegExp).join(".*"));
+  }
+
+  function matchesFilter(values, filter) {
+    const normalized = normalizeFilter(filter);
+    if (!normalized) return true;
+    const text = searchableText(values);
+    if (!normalized.includes("*")) return text.includes(normalized);
+    return wildcardRegExp(normalized).test(text);
+  }
+
+  return {
+    matchesFilter
+  };
+});

--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js
@@ -1822,6 +1822,9 @@ async function deleteRepository(name) {
 // ---- Security ------------------------------------------------------------
 
 function listContainsFilter(values, filter) {
+  if (window.kkrepoAdminFilters?.matchesFilter) {
+    return window.kkrepoAdminFilters.matchesFilter(values, filter);
+  }
   if (!filter) return true;
   return values.map((value) => lowerOrEmpty(value)).join(" ").includes(filter);
 }
@@ -1880,7 +1883,8 @@ function securityRoleCandidates(excludedRoleId = "") {
     .map((role) => ({
       id: role.roleId,
       label: role.roleId,
-      meta: role.readOnly ? "read-only" : "role"
+      meta: role.readOnly ? "read-only" : "role",
+      filterValues: [role.roleId, role.name, role.description, role.readOnly ? "read-only" : "role"]
     }))
     .sort(compareTransferItems);
 }
@@ -1897,7 +1901,14 @@ function securityPrivilegeCandidates() {
     .map((privilege) => ({
       id: privilege.privilegeId,
       label: privilege.privilegeId,
-      meta: privilege.type || "privilege"
+      meta: privilege.type || "privilege",
+      filterValues: [
+        privilege.privilegeId,
+        privilege.type,
+        privilege.name,
+        privilege.description,
+        privilege.permission
+      ]
     }))
     .sort(compareTransferItems);
 }
@@ -1959,8 +1970,7 @@ function setSecurityTransferSelection(key, values) {
 }
 
 function transferItemMatchesFilter(item, filter) {
-  if (!filter) return true;
-  return `${item.label} ${item.meta || ""}`.toLowerCase().includes(filter);
+  return listContainsFilter(item.filterValues || [item.label, item.meta], filter);
 }
 
 function securityTransferRowHtml(config, item, side) {

--- a/admin-ui/src/main/resources/META-INF/resources/admin/index.html
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/index.html
@@ -900,6 +900,7 @@
     </div>
 
     <script src="/login/assets/ui-i18n.js?v=20260625-ui-i18n-5"></script>
-    <script src="./assets/admin.js?v=20260630-migration-plan-ui-1"></script>
+    <script src="./assets/admin-filter.js?v=20260706-wildcard-filter-1"></script>
+    <script src="./assets/admin.js?v=20260706-wildcard-filter-1"></script>
   </body>
 </html>

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminFilterJavascriptTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminFilterJavascriptTest.java
@@ -1,7 +1,7 @@
 package com.github.klboke.kkrepo.admin.ui;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.IOException;
@@ -21,9 +21,14 @@ class AdminFilterJavascriptTest {
         Path.of("src/test/js/admin-filter.test.js").toString())
         .redirectErrorStream(true)
         .start();
-    String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
 
-    assertTrue(process.waitFor(30, TimeUnit.SECONDS), () -> "Timed out running admin-ui JavaScript tests:\n" + output);
+    if (!process.waitFor(30, TimeUnit.SECONDS)) {
+      process.destroyForcibly();
+      process.waitFor(5, TimeUnit.SECONDS);
+      String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+      fail("Timed out running admin-ui JavaScript tests:\n" + output);
+    }
+    String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
     assertEquals(0, process.exitValue(), () -> output);
   }
 

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminFilterJavascriptTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminFilterJavascriptTest.java
@@ -1,0 +1,48 @@
+package com.github.klboke.kkrepo.admin.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class AdminFilterJavascriptTest {
+  @Test
+  void wildcardFilterJavascriptContract() throws Exception {
+    assumeTrue(nodeIsAvailable(), "Node.js is required for admin-ui JavaScript tests");
+
+    Process process = new ProcessBuilder(
+        "node",
+        "--test",
+        Path.of("src/test/js/admin-filter.test.js").toString())
+        .redirectErrorStream(true)
+        .start();
+    String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+
+    assertTrue(process.waitFor(30, TimeUnit.SECONDS), () -> "Timed out running admin-ui JavaScript tests:\n" + output);
+    assertEquals(0, process.exitValue(), () -> output);
+  }
+
+  private static boolean nodeIsAvailable() {
+    try {
+      Process process = new ProcessBuilder("node", "--version")
+          .redirectErrorStream(true)
+          .start();
+      boolean exited = process.waitFor(5, TimeUnit.SECONDS);
+      if (!exited) {
+        process.destroyForcibly();
+        return false;
+      }
+      return process.exitValue() == 0;
+    } catch (IOException exception) {
+      return false;
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      return false;
+    }
+  }
+}

--- a/admin-ui/src/test/js/admin-filter.test.js
+++ b/admin-ui/src/test/js/admin-filter.test.js
@@ -1,0 +1,88 @@
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const { join } = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const filterScript = join(__dirname, "../../main/resources/META-INF/resources/admin/assets/admin-filter.js");
+const filters = require(filterScript);
+
+test("keeps plain contains matching case insensitive", () => {
+  assert.equal(
+    filters.matchesFilter(["nx-repository-view-maven2-maven-public-read"], "MAVEN-PUBLIC"),
+    true
+  );
+  assert.equal(
+    filters.matchesFilter(["nx-repository-view-maven2-maven-public-read"], "maven-dcmes"),
+    false
+  );
+});
+
+test("uses star as an ordered wildcard between search fragments", () => {
+  assert.equal(
+    filters.matchesFilter(["nx-repository-view-maven2-maven-aiot-add"], "view*aiot"),
+    true
+  );
+  assert.equal(
+    filters.matchesFilter(["nx-repository-view-maven2-maven-aiot-add"], "view**aiot"),
+    true
+  );
+  assert.equal(
+    filters.matchesFilter(["nx-repository-view-maven2-maven-ja-tdd-read"], "view*maven*tdd"),
+    true
+  );
+  assert.equal(
+    filters.matchesFilter(["nx-repository-view-maven2-maven-tdd-ja-read"], "view*maven*ja*tdd"),
+    false
+  );
+});
+
+test("matches Nexus repository privilege examples", () => {
+  assert.equal(
+    filters.matchesFilter(["nx-repository-view-maven2-maven-dcmes-add"], "maven-dcmes-*"),
+    true
+  );
+  assert.equal(
+    filters.matchesFilter(["nx-repository-view-maven2-maven-dcmes-add"], "*add"),
+    true
+  );
+  assert.equal(
+    filters.matchesFilter(["nx-repository-view-maven2-maven-dcmes-delete"], "*add"),
+    false
+  );
+});
+
+test("escapes regexp metacharacters in user input", () => {
+  assert.equal(
+    filters.matchesFilter(["nx-repository-view-maven2-maven.dcmes-add"], "maven.dcmes-*"),
+    true
+  );
+  assert.equal(
+    filters.matchesFilter(["nx-repository-view-maven2-mavenXdcmes-add"], "maven.dcmes-*"),
+    false
+  );
+});
+
+test("joins all searchable fields before wildcard matching", () => {
+  assert.equal(
+    filters.matchesFilter(
+      [
+        "nx-repository-view-maven2-team-dcmes-maven-group-*",
+        "All privileges for team-dcmes-maven-group repository views"
+      ],
+      "view*team*group"
+    ),
+    true
+  );
+});
+
+test("exports the same browser global API", () => {
+  const source = readFileSync(filterScript, "utf8");
+  const context = {};
+  vm.runInNewContext(source, context);
+
+  assert.equal(
+    context.kkrepoAdminFilters.matchesFilter(["nx-repository-view-maven2-maven-aiot-read"], "view*aiot"),
+    true
+  );
+});


### PR DESCRIPTION
## Summary

- Add Nexus-style `*` wildcard matching for admin UI security filters.
- Apply the shared matcher to role privilege selection and existing security list filters while preserving plain contains matching.
- Add JS contract tests and a Maven/JUnit wrapper so the behavior runs under the existing server `-am` test path.
- Set up Node.js 24 in CI so the wrapped JS tests are executed consistently.

Fixes #68

## Validation

- `git diff --check`
- `node --test admin-ui/src/test/js/admin-filter.test.js`
- `mvn -pl server -am -Dtest=AdminFilterJavascriptTest -Dsurefire.failIfNoSpecifiedTests=false test`