### PR TITLE
feat: 新增横幅消息功能与界面设置品牌标识配置

### DIFF
--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
@@ -84,6 +84,78 @@ select {
   color: #a12622;
 }
 
+.banner-region {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  padding: 0;
+}
+
+.banner-content {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 20px;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.banner-icon {
+  flex-shrink: 0;
+  font-size: 16px;
+}
+
+.banner-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.banner-close {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 16px;
+  padding: 2px 6px;
+  opacity: 0.7;
+}
+
+.banner-close:hover {
+  opacity: 1;
+}
+
+.banner-info {
+  background: #1e3a5f;
+  color: #ffffff;
+}
+
+.banner-success {
+  background: #1e4d2b;
+  color: #ffffff;
+}
+
+.banner-warning {
+  background: #7a6200;
+  color: #ffffff;
+}
+
+.banner-danger {
+  background: #7a1f1f;
+  color: #ffffff;
+}
+
+.form-section-title {
+  font-weight: 600;
+  font-size: 14px;
+  color: #333;
+  margin: 16px 0 8px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #e0e0e0;
+}
+
 .migration-result {
   margin: 12px 10px 24px;
   border-top: 1px solid var(--line);

--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js
@@ -124,6 +124,53 @@ function createTransferState() {
   };
 }
 
+const BANNER_ICONS = { info: "ⓘ", success: "", warning: "ⓘ", danger: "" };
+const BANNER_STORAGE_KEY = "kkrepo-banner-dismissed";
+
+function renderBanner() {
+  const settings = window.kkrepoI18n?.settings?.();
+  const region = document.getElementById("banner-region");
+  const textEl = document.getElementById("banner-text");
+  const iconEl = document.getElementById("banner-icon");
+  const closeBtn = document.getElementById("banner-close");
+  if (!region || !settings) return;
+  if (!settings.bannerEnabled || !settings.bannerMessage) {
+    region.hidden = true;
+    document.body.style.paddingTop = "";
+    return;
+  }
+  const dismissedKey = `${BANNER_STORAGE_KEY}:${settings.bannerMessage}`;
+  if (sessionStorage.getItem(dismissedKey)) {
+    region.hidden = true;
+    document.body.style.paddingTop = "";
+    return;
+  }
+  region.hidden = false;
+  region.className = `banner-region banner-${settings.bannerLevel || "info"}`;
+  if (textEl) textEl.textContent = settings.bannerMessage;
+  if (iconEl) iconEl.textContent = BANNER_ICONS[settings.bannerLevel] || "ⓘ";
+  if (closeBtn) closeBtn.hidden = !settings.bannerDismissible;
+  // Add padding to body to prevent banner from covering content
+  const bannerHeight = region.offsetHeight || 40;
+  document.body.style.paddingTop = `${bannerHeight}px`;
+}
+
+function initBannerClose() {
+  const closeBtn = document.getElementById("banner-close");
+  if (!closeBtn) return;
+  closeBtn.addEventListener("click", () => {
+    const settings = window.kkrepoI18n?.settings?.();
+    if (settings?.bannerMessage) {
+      sessionStorage.setItem(`${BANNER_STORAGE_KEY}:${settings.bannerMessage}`, "1");
+    }
+    const region = document.getElementById("banner-region");
+    if (region) {
+      region.hidden = true;
+      document.body.style.paddingTop = "";
+    }
+  });
+}
+
 const securityTransfers = {
   userRoles: createTransferState(),
   rolePrivileges: createTransferState(),
@@ -2148,6 +2195,26 @@ function syncUiSettingsForm() {
   if (select && settings) {
     select.value = settings.defaultLanguage || "en";
   }
+  // Sync banner fields
+  const bannerEnabled = document.getElementById("ui-banner-enabled");
+  const bannerLevel = document.getElementById("ui-banner-level");
+  const bannerMessage = document.getElementById("ui-banner-message");
+  const bannerDismissible = document.getElementById("ui-banner-dismissible");
+  if (bannerEnabled && settings) bannerEnabled.checked = settings.bannerEnabled === true;
+  if (bannerLevel && settings) bannerLevel.value = settings.bannerLevel || "info";
+  if (bannerMessage && settings) bannerMessage.value = settings.bannerMessage || "";
+  if (bannerDismissible && settings) bannerDismissible.checked = settings.bannerDismissible !== false;
+  // Sync branding fields
+  const productName = document.getElementById("ui-product-name");
+  const productSubtitle = document.getElementById("ui-product-subtitle");
+  const logoText = document.getElementById("ui-logo-text");
+  const logoUrl = document.getElementById("ui-logo-url");
+  const faviconUrl = document.getElementById("ui-favicon-url");
+  if (productName && settings) productName.value = settings.productName || "";
+  if (productSubtitle && settings) productSubtitle.value = settings.productSubtitle || "";
+  if (logoText && settings) logoText.value = settings.logoText || "";
+  if (logoUrl && settings) logoUrl.value = settings.logoUrl || "";
+  if (faviconUrl && settings) faviconUrl.value = settings.faviconUrl || "";
   clearRequiredFieldErrors(uiSettingsRequiredFields);
   updateUiSettingsStatus();
 }
@@ -2173,9 +2240,29 @@ async function saveUiSettings() {
   if (!validateRequiredFields(uiSettingsRequiredFields)) return;
   button.disabled = true;
   try {
-    await window.kkrepoI18n.saveDefaultLanguage(select.value);
+    const bannerEnabled = document.getElementById("ui-banner-enabled")?.checked === true;
+    const bannerLevel = document.getElementById("ui-banner-level")?.value || "info";
+    const bannerMessage = document.getElementById("ui-banner-message")?.value || "";
+    const bannerDismissible = document.getElementById("ui-banner-dismissible")?.checked !== false;
+    const productName = document.getElementById("ui-product-name")?.value || "";
+    const productSubtitle = document.getElementById("ui-product-subtitle")?.value || "";
+    const logoText = document.getElementById("ui-logo-text")?.value || "";
+    const logoUrl = document.getElementById("ui-logo-url")?.value || "";
+    const faviconUrl = document.getElementById("ui-favicon-url")?.value || "";
+    await window.kkrepoI18n.saveUiSettings({
+      defaultLanguage: select.value,
+      bannerEnabled,
+      bannerLevel,
+      bannerMessage,
+      bannerDismissible,
+      productName,
+      productSubtitle,
+      logoText,
+      logoUrl,
+      faviconUrl
+    });
     syncUiSettingsForm();
-    showToast("UI language settings saved.", "ok");
+    showToast("UI settings saved.", "ok");
   } catch (error) {
     showToast(`Save failed: ${error.message}`, "error");
   } finally {
@@ -3928,7 +4015,11 @@ document.getElementById("ui-settings-form").addEventListener("submit", (event) =
   saveUiSettings();
 });
 bindRequiredFieldErrors(uiSettingsRequiredFields);
-window.addEventListener("kkrepo:i18n-change", syncUiSettingsForm);
+window.addEventListener("kkrepo:i18n-change", () => {
+  syncUiSettingsForm();
+  renderBanner();
+});
+initBannerClose();
 
 document.getElementById("create-security-api-key-button").addEventListener("click", showSecurityApiKeyForm);
 document.getElementById("cancel-security-api-key-button").addEventListener("click", hideSecurityApiKeyForm);

--- a/admin-ui/src/main/resources/META-INF/resources/admin/index.html
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/index.html
@@ -824,7 +824,7 @@
           <div class="page-heading">
             <span class="heading-icon">▨</span>
             <h1>UI Settings</h1>
-            <span class="heading-copy">Configure the default UI language shared by all replicas</span>
+            <span class="heading-copy">Configure the default UI language, banner messages, and branding shared by all replicas</span>
           </div>
           <form class="blobstore-form" id="ui-settings-form" novalidate>
             <div class="form-grid">
@@ -838,6 +838,56 @@
               </label>
               <p class="form-note full-width">This preference is stored in MySQL and applies to the administration, browse, and sign-in UI on every replica.</p>
             </div>
+
+            <div class="form-section-title">Banner Message</div>
+            <div class="form-grid">
+              <label class="checkbox-label full-width">
+                <input type="checkbox" id="ui-banner-enabled">
+                <span>Enable banner</span>
+              </label>
+              <label>
+                <span>Level</span>
+                <select id="ui-banner-level">
+                  <option value="info">Info</option>
+                  <option value="success">Success</option>
+                  <option value="warning">Warning</option>
+                  <option value="danger">Danger</option>
+                </select>
+              </label>
+              <label class="full-width">
+                <span>Message</span>
+                <textarea id="ui-banner-message" rows="3" placeholder="Enter banner message..."></textarea>
+              </label>
+              <label class="checkbox-label full-width">
+                <input type="checkbox" id="ui-banner-dismissible" checked>
+                <span>Dismissible</span>
+              </label>
+            </div>
+
+            <div class="form-section-title">Branding</div>
+            <div class="form-grid">
+              <label>
+                <span>Product name</span>
+                <input type="text" id="ui-product-name" placeholder="kkrepo">
+              </label>
+              <label>
+                <span>Product subtitle</span>
+                <input type="text" id="ui-product-subtitle" placeholder="Repository Manager">
+              </label>
+              <label>
+                <span>Logo text</span>
+                <input type="text" id="ui-logo-text" placeholder="KL">
+              </label>
+              <label>
+                <span>Logo URL</span>
+                <input type="url" id="ui-logo-url" placeholder="https://example.com/logo.png">
+              </label>
+              <label>
+                <span>Favicon URL</span>
+                <input type="url" id="ui-favicon-url" placeholder="https://example.com/favicon.ico">
+              </label>
+            </div>
+
             <div class="form-actions">
               <button class="create-button" id="save-ui-settings-button" type="button">Save UI settings</button>
             </div>
@@ -897,6 +947,14 @@
         </section>
 
       </main>
+    </div>
+
+    <div class="banner-region" id="banner-region" hidden>
+      <div class="banner-content" id="banner-content">
+        <span class="banner-icon" id="banner-icon">ⓘ</span>
+        <span class="banner-text" id="banner-text"></span>
+        <button class="banner-close" id="banner-close" type="button" hidden>✕</button>
+      </div>
     </div>
 
     <script src="/login/assets/ui-i18n.js?v=20260625-ui-i18n-5"></script>

--- a/admin-ui/src/main/resources/META-INF/resources/login/assets/ui-i18n.js
+++ b/admin-ui/src/main/resources/META-INF/resources/login/assets/ui-i18n.js
@@ -273,13 +273,29 @@
     "Refresh jobs": "刷新任务",
     "System": "系统",
     "UI Settings": "界面设置",
-    "Configure the default UI language shared by all replicas": "配置所有副本共享的默认界面语言",
+    "Configure the default UI language, banner messages, and branding shared by all replicas": "配置所有副本共享的默认界面语言、横幅消息和品牌标识",
     "Default language": "默认语言",
     "Follow browser": "跟随浏览器",
     "Chinese": "中文",
     "English": "英文",
     "Save UI settings": "保存界面设置",
     "This preference is stored in MySQL and applies to the administration, browse, and sign-in UI on every replica.": "此设置存储在 MySQL 中，对所有副本的管理、浏览和登录界面均生效。",
+    "Banner Message": "横幅消息",
+    "Enable banner": "启用横幅",
+    "Level": "级别",
+    "Info": "信息",
+    "Success": "成功",
+    "Warning": "警告",
+    "Danger": "危险",
+    "Message": "消息内容",
+    "Enter banner message...": "请输入横幅消息...",
+    "Dismissible": "可关闭",
+    "Branding": "品牌标识",
+    "Product name": "产品名称",
+    "Product subtitle": "产品副标题",
+    "Logo text": "Logo 文字",
+    "Logo URL": "Logo 地址",
+    "Favicon URL": "Favicon 地址",
     "Welcome": "欢迎",
     "Nexus-compatible repository access for internal packages": "面向内部包的 Nexus 兼容仓库访问",
     "Initial administrator setup": "初始管理员设置",
@@ -538,6 +554,18 @@
       supportedDefaultLanguages: Array.isArray(value?.supportedDefaultLanguages)
         ? value.supportedDefaultLanguages
         : ["browser", "zh-CN", "en"],
+      bannerEnabled: value?.bannerEnabled === true,
+      bannerLevel: value?.bannerLevel || "info",
+      bannerMessage: value?.bannerMessage || "",
+      bannerDismissible: value?.bannerDismissible !== false,
+      supportedBannerLevels: Array.isArray(value?.supportedBannerLevels)
+        ? value.supportedBannerLevels
+        : ["info", "success", "warning", "danger"],
+      productName: value?.productName || "",
+      productSubtitle: value?.productSubtitle || "",
+      logoText: value?.logoText || "",
+      logoUrl: value?.logoUrl || "",
+      faviconUrl: value?.faviconUrl || "",
       updatedAt: value?.updatedAt || null
     };
   }
@@ -592,6 +620,22 @@
         "Content-Type": "application/json"
       },
       body: JSON.stringify({ defaultLanguage: normalized }),
+      cache: "no-store"
+    });
+    if (!response.ok) {
+      throw new Error(await responseMessage(response, `HTTP ${response.status}`));
+    }
+    return updateSettings(await response.json(), { force: true });
+  }
+
+  async function saveUiSettings(payload) {
+    const response = await fetch("/internal/ui-settings", {
+      method: "PUT",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(payload),
       cache: "no-store"
     });
     if (!response.ok) {
@@ -840,6 +884,7 @@
     loadSettings,
     ready: () => readyPromise,
     saveDefaultLanguage,
+    saveUiSettings,
     setDefaultLanguage,
     settings: () => settings,
     text: translate

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
@@ -41,6 +41,69 @@ select {
   min-height: 100vh;
 }
 
+.banner-region {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  padding: 0;
+}
+
+.banner-content {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 20px;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.banner-icon {
+  flex-shrink: 0;
+  font-size: 16px;
+}
+
+.banner-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.banner-close {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 16px;
+  padding: 2px 6px;
+  opacity: 0.7;
+}
+
+.banner-close:hover {
+  opacity: 1;
+}
+
+.banner-info {
+  background: #1e3a5f;
+  color: #ffffff;
+}
+
+.banner-success {
+  background: #1e4d2b;
+  color: #ffffff;
+}
+
+.banner-warning {
+  background: #7a6200;
+  color: #ffffff;
+}
+
+.banner-danger {
+  background: #7a1f1f;
+  color: #ffffff;
+}
+
 .nx-topbar {
   grid-column: 1 / -1;
   display: flex;

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.js
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.js
@@ -57,6 +57,53 @@ const FORMAT_ROUTE_SEGMENT = {
   npm: "npm",
 };
 
+const BANNER_ICONS = { info: "ⓘ", success: "", warning: "ⓘ", danger: "" };
+const BANNER_STORAGE_KEY = "kkrepo-banner-dismissed";
+
+function renderBanner() {
+  const settings = window.kkrepoI18n?.settings?.();
+  const region = document.getElementById("banner-region");
+  const textEl = document.getElementById("banner-text");
+  const iconEl = document.getElementById("banner-icon");
+  const closeBtn = document.getElementById("banner-close");
+  if (!region || !settings) return;
+  if (!settings.bannerEnabled || !settings.bannerMessage) {
+    region.hidden = true;
+    document.body.style.paddingTop = "";
+    return;
+  }
+  const dismissedKey = `${BANNER_STORAGE_KEY}:${settings.bannerMessage}`;
+  if (sessionStorage.getItem(dismissedKey)) {
+    region.hidden = true;
+    document.body.style.paddingTop = "";
+    return;
+  }
+  region.hidden = false;
+  region.className = `banner-region banner-${settings.bannerLevel || "info"}`;
+  if (textEl) textEl.textContent = settings.bannerMessage;
+  if (iconEl) iconEl.textContent = BANNER_ICONS[settings.bannerLevel] || "ⓘ";
+  if (closeBtn) closeBtn.hidden = !settings.bannerDismissible;
+  // Add padding to body to prevent banner from covering content
+  const bannerHeight = region.offsetHeight || 40;
+  document.body.style.paddingTop = `${bannerHeight}px`;
+}
+
+function initBannerClose() {
+  const closeBtn = document.getElementById("banner-close");
+  if (!closeBtn) return;
+  closeBtn.addEventListener("click", () => {
+    const settings = window.kkrepoI18n?.settings?.();
+    if (settings?.bannerMessage) {
+      sessionStorage.setItem(`${BANNER_STORAGE_KEY}:${settings.bannerMessage}`, "1");
+    }
+    const region = document.getElementById("banner-region");
+    if (region) {
+      region.hidden = true;
+      document.body.style.paddingTop = "";
+    }
+  });
+}
+
 function installCsrfFetch() {
   if (window.__nexusPlusCsrfFetchInstalled) return;
   window.__nexusPlusCsrfFetchInstalled = true;
@@ -86,6 +133,34 @@ function csrfToken() {
     .map((part) => part.trim())
     .find((part) => part.startsWith("KKREPO_CSRF="))
     ?.substring("KKREPO_CSRF=".length) || "";
+}
+
+async function loadBranding() {
+  try {
+    const res = await fetch("/internal/ui-settings/branding", { cache: "no-store" });
+    if (!res.ok) return;
+    const branding = await res.json();
+    if (branding.productName) {
+      document.querySelectorAll(".product-name").forEach((el) => {
+        el.innerHTML = `${escapeHtml(branding.productName)}<br>${escapeHtml(branding.productSubtitle || "Repository Manager")}`;
+      });
+      document.title = `${branding.productName} browse`;
+    }
+    if (branding.faviconUrl) {
+      document.querySelectorAll("link[rel='icon']").forEach((link) => {
+        link.href = branding.faviconUrl;
+      });
+    }
+    document.querySelectorAll(".logo-mark").forEach((el) => {
+      if (branding.logoUrl) {
+        el.innerHTML = `<img src="${escapeHtml(branding.logoUrl)}" alt="" style="width:100%;height:100%;object-fit:contain;border-radius:4px;">`;
+        el.style.background = "none";
+        el.style.border = "none";
+      } else if (branding.logoText) {
+        el.textContent = branding.logoText;
+      }
+    });
+  } catch { /* ignore */ }
 }
 
 function browseListHash() {
@@ -2600,6 +2675,15 @@ function applyHashRoute() {
 }
 
 async function bootstrap() {
+  // Load branding and banner settings
+  await Promise.all([
+    loadBranding(),
+    window.kkrepoI18n?.ready().then(() => {
+      renderBanner();
+      initBannerClose();
+    }).catch(() => {})
+  ]);
+
   try {
     adminBootstrapStatus = await fetchAdminBootstrapStatus();
   } catch (e) {

--- a/browse-ui/src/main/resources/META-INF/resources/browse/index.html
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/index.html
@@ -260,6 +260,14 @@
       </main>
     </div>
 
+    <div class="banner-region" id="banner-region" hidden>
+      <div class="banner-content" id="banner-content">
+        <span class="banner-icon" id="banner-icon"></span>
+        <span class="banner-text" id="banner-text"></span>
+        <button class="banner-close" id="banner-close" type="button" hidden>✕</button>
+      </div>
+    </div>
+
     <script src="/login/assets/ui-i18n.js?v=20260624-ui-i18n-5"></script>
     <script src="/login/assets/login-modal.js?v=20260624-ui-i18n-1"></script>
     <script src="/browse/assets/browse.js?v=20260624-ui-i18n-1"></script>

--- a/persistence-mysql/src/main/java/com/github/klboke/kkrepo/persistence/mysql/dao/UiSettingsDao.java
+++ b/persistence-mysql/src/main/java/com/github/klboke/kkrepo/persistence/mysql/dao/UiSettingsDao.java
@@ -22,26 +22,100 @@ public class UiSettingsDao {
 
   public UiSettingsRecord read() {
     List<UiSettingsRecord> rows = jdbcTemplate.query("""
-        SELECT default_language, updated_at
+        SELECT default_language, banner_enabled, banner_level, banner_message, banner_dismissible,
+               product_name, product_subtitle, logo_text, logo_url, favicon_url, updated_at
         FROM ui_settings
         WHERE id = 1
         """, (rs, rowNum) -> new UiSettingsRecord(
             rs.getString("default_language"),
+            rs.getBoolean("banner_enabled"),
+            rs.getString("banner_level"),
+            rs.getString("banner_message"),
+            rs.getBoolean("banner_dismissible"),
+            rs.getString("product_name"),
+            rs.getString("product_subtitle"),
+            rs.getString("logo_text"),
+            rs.getString("logo_url"),
+            rs.getString("favicon_url"),
             JdbcRows.nullableInstant(rs, "updated_at")));
-    return rows.isEmpty() ? new UiSettingsRecord(DEFAULT_LANGUAGE, null) : rows.get(0);
+    return rows.isEmpty() ? defaultRecord() : rows.get(0);
+  }
+
+  private static UiSettingsRecord defaultRecord() {
+    return new UiSettingsRecord(DEFAULT_LANGUAGE, false, "info", null, true,
+        "kkrepo", "Repository Manager", "KL", null, null, null);
+  }
+
+  @Transactional
+  public UiSettingsRecord save(UiSettingsCommand command) {
+    UiSettingsRecord current = read();
+    String normalized = normalizeDefaultLanguage(
+        command.defaultLanguage() != null ? command.defaultLanguage() : current.defaultLanguage());
+    String normalizedLevel = normalizeBannerLevel(
+        command.bannerLevel() != null ? command.bannerLevel() : current.bannerLevel());
+    String productName = command.productName() != null ? command.productName() : current.productName();
+    String productSubtitle = command.productSubtitle() != null ? command.productSubtitle() : current.productSubtitle();
+    String logoText = command.logoText() != null ? command.logoText() : current.logoText();
+    String logoUrl = command.logoUrl() != null ? command.logoUrl() : current.logoUrl();
+    String faviconUrl = command.faviconUrl() != null ? command.faviconUrl() : current.faviconUrl();
+    boolean bannerEnabled = command.bannerEnabled() != null ? command.bannerEnabled() : current.bannerEnabled();
+    boolean bannerDismissible = command.bannerDismissible() != null ? command.bannerDismissible() : current.bannerDismissible();
+    String bannerMessage = command.bannerMessage() != null ? command.bannerMessage() : current.bannerMessage();
+    jdbcTemplate.update("""
+        INSERT INTO ui_settings (id, default_language, banner_enabled, banner_level, banner_message,
+          banner_dismissible, product_name, product_subtitle, logo_text, logo_url, favicon_url, updated_at)
+        VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(3))
+        ON DUPLICATE KEY UPDATE
+          default_language = VALUES(default_language),
+          banner_enabled = VALUES(banner_enabled),
+          banner_level = VALUES(banner_level),
+          banner_message = VALUES(banner_message),
+          banner_dismissible = VALUES(banner_dismissible),
+          product_name = VALUES(product_name),
+          product_subtitle = VALUES(product_subtitle),
+          logo_text = VALUES(logo_text),
+          logo_url = VALUES(logo_url),
+          favicon_url = VALUES(favicon_url),
+          updated_at = NOW(3)
+        """, normalized,
+        bannerEnabled,
+        normalizedLevel,
+        bannerMessage,
+        bannerDismissible,
+        productName,
+        productSubtitle,
+        logoText,
+        logoUrl,
+        faviconUrl);
+    return read();
   }
 
   @Transactional
   public UiSettingsRecord saveDefaultLanguage(String defaultLanguage) {
-    String normalized = normalizeDefaultLanguage(defaultLanguage);
-    jdbcTemplate.update("""
-        INSERT INTO ui_settings (id, default_language, updated_at)
-        VALUES (1, ?, NOW(3))
-        ON DUPLICATE KEY UPDATE
-          default_language = VALUES(default_language),
-          updated_at = NOW(3)
-        """, normalized);
-    return read();
+    return save(new UiSettingsCommand(defaultLanguage, false, "info", null, true,
+        null, null, null, null, null));
+  }
+
+  public static String normalizeBannerLevel(String level) {
+    if (level == null || level.isBlank()) return "info";
+    String normalized = level.trim().toLowerCase();
+    return switch (normalized) {
+      case "info", "success", "warning", "danger" -> normalized;
+      default -> "info";
+    };
+  }
+
+  public record UiSettingsCommand(
+      String defaultLanguage,
+      Boolean bannerEnabled,
+      String bannerLevel,
+      String bannerMessage,
+      Boolean bannerDismissible,
+      String productName,
+      String productSubtitle,
+      String logoText,
+      String logoUrl,
+      String faviconUrl) {
   }
 
   public static String normalizeDefaultLanguage(String defaultLanguage) {

--- a/persistence-mysql/src/main/java/com/github/klboke/kkrepo/persistence/mysql/model/UiSettingsRecord.java
+++ b/persistence-mysql/src/main/java/com/github/klboke/kkrepo/persistence/mysql/model/UiSettingsRecord.java
@@ -4,5 +4,14 @@ import java.time.Instant;
 
 public record UiSettingsRecord(
     String defaultLanguage,
+    boolean bannerEnabled,
+    String bannerLevel,
+    String bannerMessage,
+    boolean bannerDismissible,
+    String productName,
+    String productSubtitle,
+    String logoText,
+    String logoUrl,
+    String faviconUrl,
     Instant updatedAt) {
 }

--- a/server/src/main/java/com/github/klboke/kkrepo/server/settings/UiSettingsController.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/settings/UiSettingsController.java
@@ -5,7 +5,6 @@ import com.github.klboke.kkrepo.persistence.mysql.model.UiSettingsRecord;
 import java.time.Instant;
 import java.util.List;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,6 +19,8 @@ public class UiSettingsController {
       UiSettingsDao.LANGUAGE_BROWSER,
       UiSettingsDao.LANGUAGE_ZH_CN,
       UiSettingsDao.LANGUAGE_EN);
+  private static final List<String> SUPPORTED_BANNER_LEVELS = List.of(
+      "info", "success", "warning", "danger");
 
   private final UiSettingsDao uiSettingsDao;
 
@@ -32,10 +33,21 @@ public class UiSettingsController {
     return toView(uiSettingsDao.read());
   }
 
+  @GetMapping("/branding")
+  public BrandingView branding() {
+    UiSettingsRecord record = uiSettingsDao.read();
+    return new BrandingView(
+        record.productName(),
+        record.productSubtitle(),
+        record.logoText(),
+        record.logoUrl(),
+        record.faviconUrl());
+  }
+
   @PutMapping
-  public UiSettingsView update(@RequestBody UiSettingsCommand command) {
+  public UiSettingsView update(@RequestBody UiSettingsDao.UiSettingsCommand command) {
     try {
-      return toView(uiSettingsDao.saveDefaultLanguage(command == null ? null : command.defaultLanguage()));
+      return toView(uiSettingsDao.save(command));
     } catch (IllegalArgumentException e) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
     }
@@ -45,15 +57,40 @@ public class UiSettingsController {
     return new UiSettingsView(
         record.defaultLanguage(),
         SUPPORTED_DEFAULT_LANGUAGES,
+        record.bannerEnabled(),
+        record.bannerLevel(),
+        record.bannerMessage(),
+        record.bannerDismissible(),
+        SUPPORTED_BANNER_LEVELS,
+        record.productName(),
+        record.productSubtitle(),
+        record.logoText(),
+        record.logoUrl(),
+        record.faviconUrl(),
         record.updatedAt());
-  }
-
-  public record UiSettingsCommand(String defaultLanguage) {
   }
 
   public record UiSettingsView(
       String defaultLanguage,
       List<String> supportedDefaultLanguages,
+      boolean bannerEnabled,
+      String bannerLevel,
+      String bannerMessage,
+      boolean bannerDismissible,
+      List<String> supportedBannerLevels,
+      String productName,
+      String productSubtitle,
+      String logoText,
+      String logoUrl,
+      String faviconUrl,
       Instant updatedAt) {
+  }
+
+  public record BrandingView(
+      String productName,
+      String productSubtitle,
+      String logoText,
+      String logoUrl,
+      String faviconUrl) {
   }
 }

--- a/server/src/main/resources/db/migration/V28__ui_settings_banner_branding.sql
+++ b/server/src/main/resources/db/migration/V28__ui_settings_banner_branding.sql
@@ -1,0 +1,11 @@
+-- Add banner message and branding columns to ui_settings.
+ALTER TABLE ui_settings
+  ADD COLUMN banner_enabled TINYINT(1) NOT NULL DEFAULT 0,
+  ADD COLUMN banner_level VARCHAR(20) NOT NULL DEFAULT 'info',
+  ADD COLUMN banner_message TEXT NULL,
+  ADD COLUMN banner_dismissible TINYINT(1) NOT NULL DEFAULT 1,
+  ADD COLUMN product_name VARCHAR(200) NOT NULL DEFAULT 'kkrepo',
+  ADD COLUMN product_subtitle VARCHAR(200) NOT NULL DEFAULT 'Repository Manager',
+  ADD COLUMN logo_text VARCHAR(50) NOT NULL DEFAULT 'KL',
+  ADD COLUMN logo_url VARCHAR(512) NULL,
+  ADD COLUMN favicon_url VARCHAR(512) NULL;


### PR DESCRIPTION
- 横幅消息支持 info/success/warning/danger 四种级别，深色系配色
- 横幅固定在页面顶部全宽显示，支持可关闭功能
- 品牌标识(product-name/subtitle/logo/favicon)从配置文件迁移到数据库
- UI Settings 页面新增横幅消息和品牌标识配置表单
- 更新 UiSettingsRecord/Dao/Controller 支持新字段
- 添加 V28 数据库迁移脚本
- admin 和 browse 页面均支持横幅展示和品牌标识动态加载

## Summary

-

## Validation

- [ ] `mvn -pl server -am test`
- [ ] `mvn -pl compat-test -am -Dtest=MavenMetadataMergeCompatibilityTest,MavenWritePolicyCompatibilityTest,NpmProtocolCompatibilityTest -Dsurefire.failIfNoSpecifiedTests=false test`
- [ ] Live compatibility workflow with the `run-live-compat` label, or `scripts/ci/run-live-compat.sh smoke` for protocol/admin API changes, or not applicable.
- [ ] Real client E2E with the `run-client-e2e` label, or `scripts/ci/run-live-compat.sh client-e2e` for package-client publish/download/resolve changes, or not applicable.
- [ ] Other:

## Compatibility and design checklist

- [ ] Protocol behavior changes were compared with the official protocol and Nexus behavior, or this PR does not change protocol behavior.
- [ ] Protocol behavior changes include or update compatibility tests under `compat-test`, or the reason is explained.
- [ ] State, cache, locking, session, background task, upload/delete, metadata, and permission changes describe their multi-replica behavior, or this PR does not touch those areas.
- [ ] Migration changes are idempotent and consider dry-run, resume, checksum validation, and reporting, or this PR does not touch migration.

## Notes for reviewers

-
