### PR TITLE
Use modal dialogs for admin forms

### DIFF
--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
@@ -1884,6 +1884,87 @@ h1 {
   padding: 18px;
 }
 
+.has-form-modal {
+  overflow: hidden;
+}
+
+.form-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.form-modal[hidden] {
+  display: none !important;
+}
+
+.form-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(23, 36, 32, 0.48);
+}
+
+.form-modal-panel {
+  position: relative;
+  width: min(1120px, 100%);
+  max-height: calc(100vh - 48px);
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 28px 80px rgba(17, 24, 39, 0.28);
+}
+
+.form-modal-panel-narrow {
+  width: min(720px, 100%);
+}
+
+.form-modal-panel .blobstore-form.modal-form {
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  background: #ffffff;
+  box-shadow: none;
+}
+
+.modal-form .form-title {
+  padding-right: 42px;
+}
+
+.form-modal-close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 1;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #ffffff;
+  color: #344641;
+  cursor: pointer;
+  font-size: 22px;
+  line-height: 1;
+}
+
+.form-modal-close:hover,
+.form-modal-close:focus-visible {
+  border-color: var(--active);
+  color: var(--active);
+  outline: none;
+}
+
+.modal-form .role-transfer .member-list {
+  max-height: min(240px, 28vh);
+}
+
+.modal-form .role-transfer .member-pane[data-side="selected"] .member-list {
+  max-height: min(278px, 32vh);
+}
+
 .audit-filter-bar {
   padding: 12px;
 }
@@ -2165,6 +2246,15 @@ code {
   .pagination-size {
     margin-left: 0;
   }
+
+  .form-modal {
+    align-items: stretch;
+    padding: 12px;
+  }
+
+  .form-modal-panel {
+    max-height: calc(100vh - 24px);
+  }
 }
 
 @media (max-width: 760px) {
@@ -2185,5 +2275,17 @@ code {
 
   .workspace-tab {
     flex: 1;
+  }
+
+  .form-modal {
+    padding: 0;
+  }
+
+  .form-modal-panel {
+    width: 100%;
+    max-height: 100vh;
+    border-right: 0;
+    border-left: 0;
+    border-radius: 0;
   }
 }

--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js
@@ -32,6 +32,7 @@ let securityRoleMode = "create";
 let securityPrivilegeMode = "create";
 let repositorySort = { key: "name", direction: "asc" };
 const BUILT_IN_READ_ONLY_ROLE_IDS = new Set(["nx-admin", "nx-anonymous"]);
+const formModalDismissHandlers = new Map();
 
 function installCsrfFetch() {
   if (window.__nexusPlusCsrfFetchInstalled) return;
@@ -139,6 +140,116 @@ function applyOriginAwarePlaceholders() {
   if (oidcRedirectUri) {
     oidcRedirectUri.placeholder = `${window.location.origin}/internal/security/oidc/callback`;
   }
+}
+
+function formModalElement(formId) {
+  return document.getElementById(`${formId}-modal`);
+}
+
+function openFormModals() {
+  return Array.from(document.querySelectorAll(".form-modal:not([hidden])"));
+}
+
+function activeFormModal() {
+  const modals = openFormModals();
+  return modals.length > 0 ? modals[modals.length - 1] : null;
+}
+
+function updateFormModalBodyState() {
+  document.body.classList.toggle("has-form-modal", openFormModals().length > 0);
+}
+
+function isFocusableModalElement(element) {
+  return Boolean(element)
+    && !element.disabled
+    && !element.hidden
+    && !element.closest("[hidden]")
+    && element.type !== "hidden"
+    && element.getAttribute("aria-hidden") !== "true";
+}
+
+function modalFocusCandidates(modal) {
+  if (!modal) return [];
+  return Array.from(modal.querySelectorAll("button, input, select, textarea, [tabindex]:not([tabindex='-1'])"))
+    .filter(isFocusableModalElement);
+}
+
+function focusFormModal(formId, preferredFocusId = null) {
+  const modal = formModalElement(formId);
+  const preferred = preferredFocusId ? document.getElementById(preferredFocusId) : null;
+  const target = isFocusableModalElement(preferred)
+    ? preferred
+    : modalFocusCandidates(modal)[0];
+  if (target) setTimeout(() => target.focus(), 0);
+}
+
+function openFormModal(formId, preferredFocusId = null) {
+  const form = document.getElementById(formId);
+  if (!form) return;
+  const modal = formModalElement(formId);
+  form.hidden = false;
+  if (modal) {
+    modal.hidden = false;
+    modal.setAttribute("aria-hidden", "false");
+  }
+  updateFormModalBodyState();
+  focusFormModal(formId, preferredFocusId);
+}
+
+function closeFormModal(formId) {
+  const form = document.getElementById(formId);
+  if (form) form.hidden = true;
+  const modal = formModalElement(formId);
+  if (modal) {
+    modal.hidden = true;
+    modal.setAttribute("aria-hidden", "true");
+  }
+  updateFormModalBodyState();
+}
+
+function bindFormModalDismiss(formId, handler) {
+  formModalDismissHandlers.set(formId, handler);
+}
+
+function dismissFormModal(formId) {
+  const handler = formModalDismissHandlers.get(formId);
+  if (handler) {
+    handler();
+  } else {
+    closeFormModal(formId);
+  }
+}
+
+function trapFocusInFormModal(event) {
+  const modal = activeFormModal();
+  if (!modal) return false;
+  const candidates = modalFocusCandidates(modal);
+  if (candidates.length === 0) return false;
+  const first = candidates[0];
+  const last = candidates[candidates.length - 1];
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault();
+    last.focus();
+    return true;
+  }
+  if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault();
+    first.focus();
+    return true;
+  }
+  return false;
+}
+
+function handleFormModalKeydown(event) {
+  if (event.key === "Tab") {
+    return trapFocusInFormModal(event);
+  }
+  if (event.key !== "Escape") return false;
+  const modal = activeFormModal();
+  if (!modal) return false;
+  event.preventDefault();
+  dismissFormModal(modal.dataset.formId);
+  return true;
 }
 
 const blobStoreS3RequiredFields = [
@@ -1100,8 +1211,7 @@ function showCreateBlobStoreForm() {
   document.getElementById("blobstore-path-style").checked = true;
   refreshBlobStoreEngineControls();
   clearBlobStoreFormErrors();
-  document.getElementById("blobstore-form").hidden = false;
-  document.getElementById("blobstore-name").focus();
+  openFormModal("blobstore-form", "blobstore-name");
 }
 
 function showEditBlobStoreForm(id) {
@@ -1128,8 +1238,7 @@ function showEditBlobStoreForm(id) {
   document.getElementById("blobstore-path-style").checked = store.pathStyleAccess !== false;
   refreshBlobStoreEngineControls();
   clearBlobStoreFormErrors();
-  document.getElementById("blobstore-form").hidden = false;
-  document.getElementById(isFileBlobStore(store) ? "blobstore-path" : "blobstore-endpoint").focus();
+  openFormModal("blobstore-form", isFileBlobStore(store) ? "blobstore-path" : "blobstore-endpoint");
 }
 
 function normalizeBlobStoreEngine(engine) {
@@ -1146,7 +1255,7 @@ function hideBlobStoreForm() {
   setAccessFieldMode(true);
   setSecretFieldMode(true);
   document.getElementById("blobstore-path-style").disabled = false;
-  document.getElementById("blobstore-form").hidden = true;
+  closeFormModal("blobstore-form");
 }
 
 async function postBlobStoreAction(path, options, pendingMessage, successFallback = "Operation completed.") {
@@ -1701,8 +1810,7 @@ function showCreateRepositoryForm() {
   refreshRepositoryBlobStoreOptions();
   refreshRepositoryRecipeControls();
   clearRequiredFieldErrors(repositoryRequiredFields);
-  document.getElementById("repository-form").hidden = false;
-  document.getElementById("repository-name").focus();
+  openFormModal("repository-form", "repository-name");
 }
 
 function showEditRepositoryForm(name) {
@@ -1761,7 +1869,7 @@ function showEditRepositoryForm(name) {
   }
   refreshRepositoryRecipeControls();
   clearRequiredFieldErrors(repositoryRequiredFields);
-  document.getElementById("repository-form").hidden = false;
+  openFormModal("repository-form", "repository-online");
 }
 
 function hideRepositoryForm() {
@@ -1771,7 +1879,7 @@ function hideRepositoryForm() {
   document.getElementById("repository-blobstore").disabled = false;
   document.getElementById("repository-blobstore").title = "";
   clearRequiredFieldErrors(repositoryRequiredFields);
-  document.getElementById("repository-form").hidden = true;
+  closeFormModal("repository-form");
 }
 
 async function saveRepository() {
@@ -2231,11 +2339,11 @@ function showSecurityUserForm(user = null) {
   document.getElementById("security-user-password").value = "";
   setSecurityTransferSelection("userRoles", user?.roles || []);
   clearRequiredFieldErrors(securityUserRequiredFields);
-  document.getElementById("security-user-form").hidden = false;
+  openFormModal("security-user-form", user ? "security-user-first-name" : "security-user-id");
 }
 
 function hideSecurityUserForm() {
-  document.getElementById("security-user-form").hidden = true;
+  closeFormModal("security-user-form");
   document.getElementById("security-user-source").disabled = false;
   document.getElementById("security-user-id").disabled = false;
   clearRequiredFieldErrors(securityUserRequiredFields);
@@ -2336,11 +2444,11 @@ function showSecurityRoleForm(role = null, options = {}) {
   setSecurityTransferSelection("roleRoles", role?.roles || []);
   setSecurityRoleFormReadOnly(viewOnly);
   clearRequiredFieldErrors(securityRoleRequiredFields);
-  document.getElementById("security-role-form").hidden = false;
+  openFormModal("security-role-form", viewOnly ? "cancel-security-role-button" : role ? "security-role-name" : "security-role-id");
 }
 
 function hideSecurityRoleForm() {
-  document.getElementById("security-role-form").hidden = true;
+  closeFormModal("security-role-form");
   securityRoleMode = "create";
   setSecurityRoleFormReadOnly(false);
   document.getElementById("security-role-id").disabled = false;
@@ -2444,11 +2552,11 @@ function showSecurityPrivilegeForm(privilege = null) {
   document.getElementById("security-privilege-readonly").checked = Boolean(privilege?.readOnly);
   document.getElementById("security-privilege-properties").value = JSON.stringify(privilege?.properties || { pattern: "nexus:*" }, null, 2);
   clearRequiredFieldErrors(securityPrivilegeRequiredFields);
-  document.getElementById("security-privilege-form").hidden = false;
+  openFormModal("security-privilege-form", privilege ? "security-privilege-name" : "security-privilege-id");
 }
 
 function hideSecurityPrivilegeForm() {
-  document.getElementById("security-privilege-form").hidden = true;
+  closeFormModal("security-privilege-form");
   document.getElementById("security-privilege-id").disabled = false;
   clearRequiredFieldErrors(securityPrivilegeRequiredFields);
 }
@@ -2919,11 +3027,11 @@ function showSecurityApiKeyForm() {
   document.getElementById("security-api-key-display-name").value = "";
   document.getElementById("security-api-key-scopes").value = "";
   clearRequiredFieldErrors(securityApiKeyRequiredFields);
-  document.getElementById("security-api-key-form").hidden = false;
+  openFormModal("security-api-key-form", "security-api-key-owner-user-id");
 }
 
 function hideSecurityApiKeyForm() {
-  document.getElementById("security-api-key-form").hidden = true;
+  closeFormModal("security-api-key-form");
   clearRequiredFieldErrors(securityApiKeyRequiredFields);
 }
 
@@ -3748,6 +3856,14 @@ function applyHashRoute() {
 
 applyOriginAwarePlaceholders();
 initializeSideGroups();
+[
+  ["repository-form", hideRepositoryForm],
+  ["blobstore-form", hideBlobStoreForm],
+  ["security-user-form", hideSecurityUserForm],
+  ["security-role-form", hideSecurityRoleForm],
+  ["security-privilege-form", hideSecurityPrivilegeForm],
+  ["security-api-key-form", hideSecurityApiKeyForm]
+].forEach(([formId, handler]) => bindFormModalDismiss(formId, handler));
 
 document.querySelectorAll(".side-item[data-view]").forEach((item) => {
   item.addEventListener("click", () => switchView(item.dataset.view));
@@ -3775,9 +3891,16 @@ document.getElementById("signout-button").addEventListener("click", () => {
   window.location.href = `/internal/security/logout?returnTo=${encodeURIComponent("/browse/#browse/welcome")}`;
 });
 document.addEventListener("click", (event) => {
+  const dismissButton = event.target.closest("[data-modal-dismiss]");
+  if (!dismissButton) return;
+  event.preventDefault();
+  dismissFormModal(dismissButton.dataset.modalDismiss);
+});
+document.addEventListener("click", (event) => {
   if (!document.getElementById("user-menu").contains(event.target)) closeUserMenu();
 });
 document.addEventListener("keydown", (event) => {
+  if (handleFormModalKeydown(event)) return;
   if (event.key === "Escape") closeUserMenu();
 });
 document.getElementById("create-blobstore-button").addEventListener("click", showCreateBlobStoreForm);

--- a/admin-ui/src/main/resources/META-INF/resources/admin/index.html
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>kkrepo administration</title>
     <link rel="icon" type="image/svg+xml" href="/admin/assets/favicon.svg?v=20260609-kl-logo-1">
-    <link rel="stylesheet" href="./assets/admin.css?v=20260630-migration-plan-ui-1">
+    <link rel="stylesheet" href="./assets/admin.css?v=20260708-form-modal-1">
   </head>
   <body>
     <div class="nx-shell">
@@ -91,7 +91,11 @@
               <input id="repository-filter" type="search" placeholder="Filter">
             </label>
           </div>
-          <form class="blobstore-form" id="repository-form" hidden novalidate>
+          <div class="form-modal" id="repository-form-modal" data-form-id="repository-form" role="dialog" aria-modal="true" aria-labelledby="repository-form-title" hidden>
+            <div class="form-modal-backdrop" data-modal-dismiss="repository-form"></div>
+            <div class="form-modal-panel">
+              <button class="form-modal-close" data-modal-dismiss="repository-form" type="button" aria-label="Close dialog">&times;</button>
+          <form class="blobstore-form modal-form" id="repository-form" hidden novalidate>
             <div class="form-title" id="repository-form-title">Create repository</div>
             <div class="form-grid">
               <label>
@@ -241,6 +245,8 @@
               <button class="create-button secondary" id="cancel-repository-button" type="button">Cancel</button>
             </div>
           </form>
+            </div>
+          </div>
           <div class="nx-table-frame fixed-table-frame">
             <table class="nx-table">
               <thead>
@@ -294,7 +300,11 @@
               <input id="blobstore-filter" type="search" placeholder="Filter">
             </label>
           </div>
-          <form class="blobstore-form" id="blobstore-form" hidden novalidate>
+          <div class="form-modal" id="blobstore-form-modal" data-form-id="blobstore-form" role="dialog" aria-modal="true" aria-labelledby="blobstore-form-title" hidden>
+            <div class="form-modal-backdrop" data-modal-dismiss="blobstore-form"></div>
+            <div class="form-modal-panel">
+              <button class="form-modal-close" data-modal-dismiss="blobstore-form" type="button" aria-label="Close dialog">&times;</button>
+          <form class="blobstore-form modal-form" id="blobstore-form" hidden novalidate>
             <div class="form-title" id="blobstore-form-title">Create blob store</div>
             <div class="form-grid">
               <label>
@@ -347,6 +357,8 @@
               <button class="create-button secondary" id="cancel-blobstore-button" type="button">Cancel</button>
             </div>
           </form>
+            </div>
+          </div>
           <div class="nx-table-frame">
             <table class="nx-table blobstores-table">
               <thead>
@@ -416,7 +428,11 @@
               <input id="security-user-filter" type="search" placeholder="Filter">
             </label>
           </div>
-          <form class="blobstore-form" id="security-user-form" hidden novalidate>
+          <div class="form-modal" id="security-user-form-modal" data-form-id="security-user-form" role="dialog" aria-modal="true" aria-labelledby="security-user-form-title" hidden>
+            <div class="form-modal-backdrop" data-modal-dismiss="security-user-form"></div>
+            <div class="form-modal-panel">
+              <button class="form-modal-close" data-modal-dismiss="security-user-form" type="button" aria-label="Close dialog">&times;</button>
+          <form class="blobstore-form modal-form" id="security-user-form" hidden novalidate>
             <div class="form-title" id="security-user-form-title">Create user</div>
             <div class="form-grid">
               <label><span>Source</span><select id="security-user-source"><option value="Local">Local</option><option value="OIDC">OIDC</option><option value="LDAP">LDAP</option></select></label>
@@ -457,6 +473,8 @@
               <button class="create-button secondary" id="cancel-security-user-button" type="button">Cancel</button>
             </div>
           </form>
+            </div>
+          </div>
           <div class="nx-table-frame fixed-table-frame">
             <table class="nx-table">
               <thead><tr><th>Source</th><th>User ID</th><th>Status</th><th>Email</th><th>Roles</th><th class="actions-column">Actions</th></tr></thead>
@@ -475,7 +493,11 @@
             <button class="create-button" id="create-security-role-button" type="button">⊕ Create role</button>
             <label class="filter-box"><span class="filter-icon">▾</span><input id="security-role-filter" type="search" placeholder="Filter"></label>
           </div>
-          <form class="blobstore-form" id="security-role-form" hidden novalidate>
+          <div class="form-modal" id="security-role-form-modal" data-form-id="security-role-form" role="dialog" aria-modal="true" aria-labelledby="security-role-form-title" hidden>
+            <div class="form-modal-backdrop" data-modal-dismiss="security-role-form"></div>
+            <div class="form-modal-panel">
+              <button class="form-modal-close" data-modal-dismiss="security-role-form" type="button" aria-label="Close dialog">&times;</button>
+          <form class="blobstore-form modal-form" id="security-role-form" hidden novalidate>
             <div class="form-title" id="security-role-form-title">Create role</div>
             <div class="form-grid">
               <label><span>Role ID <span class="required-mark">*</span></span><input id="security-role-id" type="text" required></label>
@@ -538,6 +560,8 @@
               <button class="create-button secondary" id="cancel-security-role-button" type="button">Cancel</button>
             </div>
           </form>
+            </div>
+          </div>
           <div class="nx-table-frame">
             <table class="nx-table">
               <thead><tr><th>Role ID</th><th>Name</th><th>Description</th><th class="actions-column">Actions</th></tr></thead>
@@ -556,7 +580,11 @@
             <button class="create-button" id="create-security-privilege-button" type="button">⊕ Create privilege</button>
             <label class="filter-box"><span class="filter-icon">▾</span><input id="security-privilege-filter" type="search" placeholder="Filter"></label>
           </div>
-          <form class="blobstore-form" id="security-privilege-form" hidden novalidate>
+          <div class="form-modal" id="security-privilege-form-modal" data-form-id="security-privilege-form" role="dialog" aria-modal="true" aria-labelledby="security-privilege-form-title" hidden>
+            <div class="form-modal-backdrop" data-modal-dismiss="security-privilege-form"></div>
+            <div class="form-modal-panel">
+              <button class="form-modal-close" data-modal-dismiss="security-privilege-form" type="button" aria-label="Close dialog">&times;</button>
+          <form class="blobstore-form modal-form" id="security-privilege-form" hidden novalidate>
             <div class="form-title" id="security-privilege-form-title">Create privilege</div>
             <div class="form-grid">
               <label><span>Privilege ID <span class="required-mark">*</span></span><input id="security-privilege-id" type="text" required></label>
@@ -571,6 +599,8 @@
               <button class="create-button secondary" id="cancel-security-privilege-button" type="button">Cancel</button>
             </div>
           </form>
+            </div>
+          </div>
           <div class="nx-table-frame fixed-table-frame">
             <table class="nx-table">
               <thead><tr><th>Privilege ID</th><th>Type</th><th>Name</th><th>Permission</th><th class="actions-column">Actions</th></tr></thead>
@@ -697,8 +727,12 @@
           <div class="action-bar">
             <button class="create-button" id="create-security-api-key-button" type="button">⊕ Create API key</button>
           </div>
-          <form class="blobstore-form" id="security-api-key-form" hidden novalidate>
-            <div class="form-title">Create API key</div>
+          <div class="form-modal" id="security-api-key-form-modal" data-form-id="security-api-key-form" role="dialog" aria-modal="true" aria-labelledby="security-api-key-form-title" hidden>
+            <div class="form-modal-backdrop" data-modal-dismiss="security-api-key-form"></div>
+            <div class="form-modal-panel form-modal-panel-narrow">
+              <button class="form-modal-close" data-modal-dismiss="security-api-key-form" type="button" aria-label="Close dialog">&times;</button>
+          <form class="blobstore-form modal-form" id="security-api-key-form" hidden novalidate>
+            <div class="form-title" id="security-api-key-form-title">Create API key</div>
             <div class="form-grid">
               <label>
                 <span>Domain</span>
@@ -720,6 +754,8 @@
               <button class="create-button secondary" id="cancel-security-api-key-button" type="button">Cancel</button>
             </div>
           </form>
+            </div>
+          </div>
           <div class="nx-table-frame">
             <table class="nx-table">
               <thead><tr><th>Domain</th><th>Owner</th><th>Status</th><th>Prefix</th><th>Scopes</th><th class="actions-column">Actions</th></tr></thead>
@@ -901,6 +937,6 @@
 
     <script src="/login/assets/ui-i18n.js?v=20260625-ui-i18n-5"></script>
     <script src="./assets/admin-filter.js?v=20260706-wildcard-filter-1"></script>
-    <script src="./assets/admin.js?v=20260706-wildcard-filter-1"></script>
+    <script src="./assets/admin.js?v=20260708-form-modal-1"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Move admin create/edit forms for repositories, blob stores, users, roles, privileges, and API keys into modal dialogs
- Keep role privilege and inherited-role pickers inside the role dialog with shared close and focus handling
- Add responsive modal styling and refresh admin asset cache keys

## Validation
- node --check admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js
- git diff --check
- mvn -pl admin-ui -am test
- Headless Chrome modal open/close checks plus desktop and 390px role dialog screenshots

Closes #69