### PR TITLE
Update Telegram support group link

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -165,7 +165,7 @@ AI agent 和贡献者的开发说明见 [AGENTS.md](AGENTS.md)。
 
 ## 支持
 
-加入 [kkRepo Telegram 群](https://t.me/+M6prtFUGnF9kYTU1) 获取社区支持和使用交流。Issue 分类、支持范围和安全问题报告边界见 [SUPPORT.md](SUPPORT.md)。
+加入 [kkRepo Telegram 群](https://t.me/+UbIsTKXTzxBhYjFl) 获取社区支持和使用交流。Issue 分类、支持范围和安全问题报告边界见 [SUPPORT.md](SUPPORT.md)。
 
 ## 安全
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Local development and testing are documented in the [Development Guide](docs/en/
 
 ## Support
 
-Join the [kkRepo Telegram group](https://t.me/+M6prtFUGnF9kYTU1) for community support and usage discussion. See [SUPPORT.md](SUPPORT.md) for issue routing, support scope, and security-reporting boundaries.
+Join the [kkRepo Telegram group](https://t.me/+UbIsTKXTzxBhYjFl) for community support and usage discussion. See [SUPPORT.md](SUPPORT.md) for issue routing, support scope, and security-reporting boundaries.
 
 ## Security
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -5,7 +5,7 @@ Thanks for trying kkrepo. This page explains where to ask questions, report bugs
 ## Community Support
 
 - Use GitHub issues for reproducible bugs, compatibility differences, feature requests, and documentation problems.
-- Use the [kkrepo Telegram group](https://t.me/+M6prtFUGnF9kYTU1) for community discussion and usage questions.
+- Use the [kkrepo Telegram group](https://t.me/+UbIsTKXTzxBhYjFl) for community discussion and usage questions.
 - Before opening an issue, check the README, build/deployment guide, compatibility testing guide, and troubleshooting guide.
 
 ## Issue Types

--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -181,7 +181,7 @@ kkrepo is licensed under the [Apache License 2.0](../../LICENSE).
 Use:
 
 - GitHub issues for bugs, compatibility differences, feature requests, and documentation problems.
-- The [kkrepo Telegram group](https://t.me/+M6prtFUGnF9kYTU1) for community discussion.
+- The [kkrepo Telegram group](https://t.me/+UbIsTKXTzxBhYjFl) for community discussion.
 - GitHub Security Advisories for exploitable security issues.
 
 See [SUPPORT.md](../../SUPPORT.md).

--- a/docs/zh/faq.md
+++ b/docs/zh/faq.md
@@ -181,7 +181,7 @@ kkrepo 使用 [Apache License 2.0](../../LICENSE)。
 可使用：
 
 - GitHub issues：报告 bug、兼容差异、功能建议和文档问题。
-- [kkrepo Telegram 群](https://t.me/+M6prtFUGnF9kYTU1)：社区讨论。
+- [kkrepo Telegram 群](https://t.me/+UbIsTKXTzxBhYjFl)：社区讨论。
 - GitHub Security Advisories：报告可利用安全问题。
 
 详见 [SUPPORT.md](../../SUPPORT.md)。


### PR DESCRIPTION
## Summary
- Replace the old Telegram channel invite with the new discussion group invite across support entry points.
- Keep SUPPORT.md, README, README.cn, and FAQ links consistent.

Closes #88

## Tests
- git diff --check
- rg -n "M6prtFUGnF9kYTU1" . (no matches)