### PR TITLE
Display build version in UI header

### DIFF
--- a/admin-ui/pom.xml
+++ b/admin-ui/pom.xml
@@ -22,4 +22,34 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>false</filtering>
+        <excludes>
+          <exclude>META-INF/resources/admin/index.html</exclude>
+        </excludes>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+        <includes>
+          <include>META-INF/resources/admin/index.html</include>
+        </includes>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.3.1</version>
+        <configuration>
+          <delimiters>
+            <delimiter>@</delimiter>
+          </delimiters>
+          <useDefaultDelimiters>false</useDefaultDelimiters>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
@@ -312,9 +312,11 @@ select {
 }
 
 .product-version {
-  margin-top: 2px;
+  margin-left: 4px;
   color: #e2e2e2;
-  font-size: 13px;
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
 }
 
 .product-copy {
@@ -1489,8 +1491,8 @@ textarea:focus-visible {
 .product {
   width: 272px;
   min-width: 272px;
-  gap: 12px;
-  padding: 0 18px;
+  gap: 10px;
+  padding: 0 14px;
 }
 
 .logo-mark {
@@ -1514,11 +1516,15 @@ textarea:focus-visible {
   font-size: 15px;
   font-weight: 750;
   line-height: 1.12;
+  white-space: nowrap;
 }
 
 .product-version {
+  margin-left: 4px;
   color: var(--topbar-muted);
-  font-size: 12px;
+  font-size: 11px;
+  font-weight: 650;
+  white-space: nowrap;
 }
 
 .product-copy {
@@ -2194,7 +2200,7 @@ code {
 
   .product {
     width: auto;
-    min-width: min(100%, 260px);
+    min-width: min(100%, 272px);
   }
 
   .side-nav {

--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
@@ -1491,8 +1491,8 @@ textarea:focus-visible {
 .product {
   width: 272px;
   min-width: 272px;
-  gap: 10px;
-  padding: 0 14px;
+  gap: 12px;
+  padding: 0 18px;
 }
 
 .logo-mark {
@@ -2200,7 +2200,7 @@ code {
 
   .product {
     width: auto;
-    min-width: min(100%, 272px);
+    min-width: min(100%, 260px);
   }
 
   .side-nav {

--- a/admin-ui/src/main/resources/META-INF/resources/admin/index.html
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/index.html
@@ -13,7 +13,7 @@
         <div class="product">
           <div class="logo-mark" aria-hidden="true">KL</div>
           <div class="product-copy">
-            <div class="product-name" data-i18n-skip>kkrepo<br>Repository Manager</div>
+            <div class="product-name" data-i18n-skip>kkrepo<br>Repository Manager <span class="product-version">v@project.version@</span></div>
           </div>
         </div>
         <nav class="workspace-tabs" aria-label="Workspace">

--- a/admin-ui/src/main/resources/META-INF/resources/admin/index.html
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/index.html
@@ -13,7 +13,7 @@
         <div class="product">
           <div class="logo-mark" aria-hidden="true">KL</div>
           <div class="product-copy">
-            <div class="product-name" data-i18n-skip>kkrepo<br>Repository Manager <span class="product-version">v@project.version@</span></div>
+            <div class="product-name" data-i18n-skip>kkRepo <span class="product-version">v@project.version@</span><br>Repository Manager</div>
           </div>
         </div>
         <nav class="workspace-tabs" aria-label="Workspace">

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminProductVersionContractTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminProductVersionContractTest.java
@@ -1,0 +1,31 @@
+package com.github.klboke.kkrepo.admin.ui;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+class AdminProductVersionContractTest {
+  private static final Pattern VERSION_BADGE = Pattern.compile(
+      "Repository Manager <span class=\"product-version\">v[^<@]+</span>");
+
+  @Test
+  void headerIncludesFilteredProjectVersion() throws IOException {
+    String index = resource("/META-INF/resources/admin/index.html");
+
+    assertTrue(VERSION_BADGE.matcher(index).find());
+    assertFalse(index.contains("@project.version@"));
+    assertTrue(index.contains("value=\"${dn}\""));
+  }
+
+  private String resource(String path) throws IOException {
+    try (InputStream stream = getClass().getResourceAsStream(path)) {
+      return new String(Objects.requireNonNull(stream).readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+}

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminProductVersionContractTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminProductVersionContractTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 
 class AdminProductVersionContractTest {
   private static final Pattern VERSION_BADGE = Pattern.compile(
-      "Repository Manager <span class=\"product-version\">v[^<@]+</span>");
+      "kkRepo <span class=\"product-version\">v[^<@]+</span><br>Repository Manager");
 
   @Test
   void headerIncludesFilteredProjectVersion() throws IOException {

--- a/browse-ui/pom.xml
+++ b/browse-ui/pom.xml
@@ -22,4 +22,34 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>false</filtering>
+        <excludes>
+          <exclude>META-INF/resources/browse/index.html</exclude>
+        </excludes>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+        <includes>
+          <include>META-INF/resources/browse/index.html</include>
+        </includes>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.3.1</version>
+        <configuration>
+          <delimiters>
+            <delimiter>@</delimiter>
+          </delimiters>
+          <useDefaultDelimiters>false</useDefaultDelimiters>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
@@ -80,9 +80,11 @@ select {
 }
 
 .product-version {
-  margin-top: 2px;
+  margin-left: 4px;
   color: #e2e2e2;
-  font-size: 13px;
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
 }
 
 .product-copy {
@@ -1633,8 +1635,8 @@ textarea:focus-visible {
 .product {
   width: 272px;
   min-width: 272px;
-  gap: 12px;
-  padding: 0 18px;
+  gap: 10px;
+  padding: 0 14px;
 }
 
 .logo-mark {
@@ -1658,11 +1660,15 @@ textarea:focus-visible {
   font-size: 15px;
   font-weight: 750;
   line-height: 1.12;
+  white-space: nowrap;
 }
 
 .product-version {
+  margin-left: 4px;
   color: var(--topbar-muted);
-  font-size: 12px;
+  font-size: 11px;
+  font-weight: 650;
+  white-space: nowrap;
 }
 
 .product-copy {
@@ -2189,7 +2195,7 @@ code,
 
   .product {
     width: auto;
-    min-width: min(100%, 260px);
+    min-width: min(100%, 272px);
   }
 
   .side-nav {

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
@@ -1635,8 +1635,8 @@ textarea:focus-visible {
 .product {
   width: 272px;
   min-width: 272px;
-  gap: 10px;
-  padding: 0 14px;
+  gap: 12px;
+  padding: 0 18px;
 }
 
 .logo-mark {
@@ -2195,7 +2195,7 @@ code,
 
   .product {
     width: auto;
-    min-width: min(100%, 272px);
+    min-width: min(100%, 260px);
   }
 
   .side-nav {

--- a/browse-ui/src/main/resources/META-INF/resources/browse/index.html
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/index.html
@@ -14,7 +14,7 @@
         <div class="product">
           <div class="logo-mark" aria-hidden="true">KL</div>
           <div class="product-copy">
-            <div class="product-name" data-i18n-skip>kkrepo<br>Repository Manager</div>
+            <div class="product-name" data-i18n-skip>kkrepo<br>Repository Manager <span class="product-version">v@project.version@</span></div>
           </div>
         </div>
         <nav class="workspace-tabs" aria-label="Workspace">

--- a/browse-ui/src/main/resources/META-INF/resources/browse/index.html
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/index.html
@@ -14,7 +14,7 @@
         <div class="product">
           <div class="logo-mark" aria-hidden="true">KL</div>
           <div class="product-copy">
-            <div class="product-name" data-i18n-skip>kkrepo<br>Repository Manager <span class="product-version">v@project.version@</span></div>
+            <div class="product-name" data-i18n-skip>kkRepo <span class="product-version">v@project.version@</span><br>Repository Manager</div>
           </div>
         </div>
         <nav class="workspace-tabs" aria-label="Workspace">

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseProductVersionContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseProductVersionContractTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 
 class BrowseProductVersionContractTest {
   private static final Pattern VERSION_BADGE = Pattern.compile(
-      "Repository Manager <span class=\"product-version\">v[^<@]+</span>");
+      "kkRepo <span class=\"product-version\">v[^<@]+</span><br>Repository Manager");
 
   @Test
   void headerIncludesFilteredProjectVersion() throws IOException {

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseProductVersionContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseProductVersionContractTest.java
@@ -1,0 +1,30 @@
+package com.github.klboke.kkrepo.browse.ui;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+class BrowseProductVersionContractTest {
+  private static final Pattern VERSION_BADGE = Pattern.compile(
+      "Repository Manager <span class=\"product-version\">v[^<@]+</span>");
+
+  @Test
+  void headerIncludesFilteredProjectVersion() throws IOException {
+    String index = resource("/META-INF/resources/browse/index.html");
+
+    assertTrue(VERSION_BADGE.matcher(index).find());
+    assertFalse(index.contains("@project.version@"));
+  }
+
+  private String resource(String path) throws IOException {
+    try (InputStream stream = getClass().getResourceAsStream(path)) {
+      return new String(Objects.requireNonNull(stream).readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- display the Maven project version beside `kkRepo` in the Browse and Admin headers
- render the brand as `kkRepo v<version>` above `Repository Manager`
- filter only each UI module's `index.html`, using `@project.version@` so existing runtime placeholders such as `${dn}` remain untouched
- add Admin and Browse resource contract tests to ensure the version is resolved during the build

## Validation

- `mvn -pl admin-ui,browse-ui test`
- `mvn -pl server -am test`
- desktop and mobile visual checks for both header layouts