### PR TITLE
Add GitHub links to product header

### DIFF
--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
@@ -323,6 +323,35 @@ select {
   min-width: 0;
 }
 
+.logo-mark,
+.product-link,
+.product-version {
+  text-decoration: none;
+}
+
+.product-link {
+  color: inherit;
+}
+
+.product-link:hover,
+.product-version:hover {
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.logo-mark:hover {
+  filter: brightness(1.08);
+}
+
+.logo-mark:focus-visible,
+.product-link:focus-visible,
+.product-version:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+}
+
 .workspace-tabs {
   display: flex;
   align-self: stretch;

--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
@@ -333,13 +333,6 @@ select {
   color: inherit;
 }
 
-.product-link:hover,
-.product-version:hover {
-  text-decoration: underline;
-  text-decoration-thickness: 1px;
-  text-underline-offset: 2px;
-}
-
 .logo-mark:hover {
   filter: brightness(1.08);
 }

--- a/admin-ui/src/main/resources/META-INF/resources/admin/index.html
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/index.html
@@ -6,15 +6,15 @@
     <title>kkrepo administration</title>
     <link rel="icon" type="image/svg+xml" href="/admin/assets/favicon.svg?v=20260609-kl-logo-1">
     <link rel="stylesheet" href="/browse/assets/format-icons.css?v=20260710-format-table-icons-1">
-    <link rel="stylesheet" href="./assets/admin.css?v=20260710-recipe-combobox-3">
+    <link rel="stylesheet" href="./assets/admin.css?v=20260710-project-links-1">
   </head>
   <body>
     <div class="nx-shell">
       <header class="nx-topbar">
         <div class="product">
-          <div class="logo-mark" aria-hidden="true">KL</div>
+          <a class="logo-mark product-home-link" href="https://github.com/klboke/kkRepo" target="_blank" rel="noopener noreferrer" aria-label="kkRepo GitHub repository">KL</a>
           <div class="product-copy">
-            <div class="product-name" data-i18n-skip>kkRepo <span class="product-version">v@project.version@</span><br>Repository Manager</div>
+            <div class="product-name" data-i18n-skip><a class="product-link" href="https://github.com/klboke/kkRepo" target="_blank" rel="noopener noreferrer">kkRepo</a> <a class="product-version" href="https://github.com/klboke/kkRepo/releases" target="_blank" rel="noopener noreferrer">v@project.version@</a><br><a class="product-link" href="https://github.com/klboke/kkRepo" target="_blank" rel="noopener noreferrer">Repository Manager</a></div>
           </div>
         </div>
         <nav class="workspace-tabs" aria-label="Workspace">

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminProductVersionContractTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminProductVersionContractTest.java
@@ -11,14 +11,24 @@ import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 
 class AdminProductVersionContractTest {
+  private static final String PROJECT_URL = "https://github.com/klboke/kkRepo";
+  private static final String RELEASES_URL = PROJECT_URL + "/releases";
+  private static final String EXTERNAL_LINK_ATTRIBUTES = "target=\"_blank\" rel=\"noopener noreferrer\"";
   private static final Pattern VERSION_BADGE = Pattern.compile(
-      "kkRepo <span class=\"product-version\">v[^<@]+</span><br>Repository Manager");
+      "<a class=\"product-version\" href=\"" + Pattern.quote(RELEASES_URL)
+          + "\" " + EXTERNAL_LINK_ATTRIBUTES + ">v[^<@]+</a>");
 
   @Test
-  void headerIncludesFilteredProjectVersion() throws IOException {
+  void headerLinksBrandAndFilteredVersion() throws IOException {
     String index = resource("/META-INF/resources/admin/index.html");
 
     assertTrue(VERSION_BADGE.matcher(index).find());
+    assertTrue(index.contains("class=\"logo-mark product-home-link\" href=\"" + PROJECT_URL
+        + "\" " + EXTERNAL_LINK_ATTRIBUTES));
+    assertTrue(index.contains("class=\"product-link\" href=\"" + PROJECT_URL + "\" "
+        + EXTERNAL_LINK_ATTRIBUTES + ">kkRepo</a>"));
+    assertTrue(index.contains("class=\"product-link\" href=\"" + PROJECT_URL + "\" "
+        + EXTERNAL_LINK_ATTRIBUTES + ">Repository Manager</a>"));
     assertFalse(index.contains("@project.version@"));
     assertTrue(index.contains("value=\"${dn}\""));
   }

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
@@ -101,13 +101,6 @@ select {
   color: inherit;
 }
 
-.product-link:hover,
-.product-version:hover {
-  text-decoration: underline;
-  text-decoration-thickness: 1px;
-  text-underline-offset: 2px;
-}
-
 .logo-mark:hover {
   filter: brightness(1.08);
 }

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
@@ -91,6 +91,35 @@ select {
   min-width: 0;
 }
 
+.logo-mark,
+.product-link,
+.product-version {
+  text-decoration: none;
+}
+
+.product-link {
+  color: inherit;
+}
+
+.product-link:hover,
+.product-version:hover {
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.logo-mark:hover {
+  filter: brightness(1.08);
+}
+
+.logo-mark:focus-visible,
+.product-link:focus-visible,
+.product-version:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+}
+
 .workspace-tabs {
   display: flex;
   align-self: stretch;

--- a/browse-ui/src/main/resources/META-INF/resources/browse/index.html
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/index.html
@@ -6,16 +6,16 @@
     <title>kkrepo browse</title>
     <link rel="icon" type="image/svg+xml" href="/browse/assets/favicon.svg?v=20260609-kl-logo-1">
     <link rel="stylesheet" href="/browse/assets/format-icons.css?v=20260710-format-table-icons-1">
-    <link rel="stylesheet" href="/browse/assets/browse.css?v=20260710-search-menu-format-icons-1">
+    <link rel="stylesheet" href="/browse/assets/browse.css?v=20260710-project-links-1">
     <link rel="stylesheet" href="/login/assets/login-modal.css?v=20260616-login-method-tabs-2">
   </head>
   <body>
     <div class="nx-shell">
       <header class="nx-topbar">
         <div class="product">
-          <div class="logo-mark" aria-hidden="true">KL</div>
+          <a class="logo-mark product-home-link" href="https://github.com/klboke/kkRepo" target="_blank" rel="noopener noreferrer" aria-label="kkRepo GitHub repository">KL</a>
           <div class="product-copy">
-            <div class="product-name" data-i18n-skip>kkRepo <span class="product-version">v@project.version@</span><br>Repository Manager</div>
+            <div class="product-name" data-i18n-skip><a class="product-link" href="https://github.com/klboke/kkRepo" target="_blank" rel="noopener noreferrer">kkRepo</a> <a class="product-version" href="https://github.com/klboke/kkRepo/releases" target="_blank" rel="noopener noreferrer">v@project.version@</a><br><a class="product-link" href="https://github.com/klboke/kkRepo" target="_blank" rel="noopener noreferrer">Repository Manager</a></div>
           </div>
         </div>
         <nav class="workspace-tabs" aria-label="Workspace">

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseProductVersionContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseProductVersionContractTest.java
@@ -11,14 +11,24 @@ import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 
 class BrowseProductVersionContractTest {
+  private static final String PROJECT_URL = "https://github.com/klboke/kkRepo";
+  private static final String RELEASES_URL = PROJECT_URL + "/releases";
+  private static final String EXTERNAL_LINK_ATTRIBUTES = "target=\"_blank\" rel=\"noopener noreferrer\"";
   private static final Pattern VERSION_BADGE = Pattern.compile(
-      "kkRepo <span class=\"product-version\">v[^<@]+</span><br>Repository Manager");
+      "<a class=\"product-version\" href=\"" + Pattern.quote(RELEASES_URL)
+          + "\" " + EXTERNAL_LINK_ATTRIBUTES + ">v[^<@]+</a>");
 
   @Test
-  void headerIncludesFilteredProjectVersion() throws IOException {
+  void headerLinksBrandAndFilteredVersion() throws IOException {
     String index = resource("/META-INF/resources/browse/index.html");
 
     assertTrue(VERSION_BADGE.matcher(index).find());
+    assertTrue(index.contains("class=\"logo-mark product-home-link\" href=\"" + PROJECT_URL
+        + "\" " + EXTERNAL_LINK_ATTRIBUTES));
+    assertTrue(index.contains("class=\"product-link\" href=\"" + PROJECT_URL + "\" "
+        + EXTERNAL_LINK_ATTRIBUTES + ">kkRepo</a>"));
+    assertTrue(index.contains("class=\"product-link\" href=\"" + PROJECT_URL + "\" "
+        + EXTERNAL_LINK_ATTRIBUTES + ">Repository Manager</a>"));
     assertFalse(index.contains("@project.version@"));
   }
 


### PR DESCRIPTION
## Summary

- link the logo, `kkRepo`, and `Repository Manager` labels to the GitHub project
- link the displayed product version to the GitHub Releases page in both Admin and Browse
- add external-link hover/focus styling and contract coverage

## Validation

- `mvn -pl admin-ui,browse-ui test -q`
- `env LC_ALL=C LANG=C ./scripts/recompile.sh`