### PR TITLE
Improve persistence, storage, and protocol test coverage

### DIFF
--- a/persistence-mysql/pom.xml
+++ b/persistence-mysql/pom.xml
@@ -33,5 +33,38 @@
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-mysql</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers-mysql</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+  <build>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+      </testResource>
+      <testResource>
+        <directory>../server/src/main/resources</directory>
+        <includes>
+          <include>db/migration/**</include>
+        </includes>
+      </testResource>
+    </testResources>
+  </build>
 </project>

--- a/persistence-mysql/src/main/java/com/github/klboke/kkrepo/persistence/mysql/dao/DockerRegistryDao.java
+++ b/persistence-mysql/src/main/java/com/github/klboke/kkrepo/persistence/mysql/dao/DockerRegistryDao.java
@@ -1,6 +1,7 @@
 package com.github.klboke.kkrepo.persistence.mysql.dao;
 
 import static com.github.klboke.kkrepo.persistence.mysql.support.JdbcRows.nullableInstant;
+import static com.github.klboke.kkrepo.persistence.mysql.support.JdbcRows.nullableLong;
 import static com.github.klboke.kkrepo.persistence.mysql.support.JdbcRows.nullableTimestamp;
 
 import com.github.klboke.kkrepo.persistence.mysql.model.docker.DockerManifestRecord;
@@ -365,10 +366,11 @@ public class DockerRegistryDao {
       return DeletedManifest.notFound();
     }
     long id = manifest.get().id();
-    Long assetBlobId = jdbcTemplate.queryForList(
+    List<Long> assetBlobIds = jdbcTemplate.query(
         "SELECT asset_blob_id FROM asset WHERE id = ?",
-        Long.class,
-        manifest.get().assetId()).stream().findFirst().orElse(null);
+        (rs, rowNum) -> nullableLong(rs, "asset_blob_id"),
+        manifest.get().assetId());
+    Long assetBlobId = assetBlobIds.isEmpty() ? null : assetBlobIds.get(0);
     jdbcTemplate.update("DELETE FROM docker_tag WHERE manifest_id = ?", id);
     int deleted = jdbcTemplate.update("""
         UPDATE docker_manifest

--- a/persistence-mysql/src/main/java/com/github/klboke/kkrepo/persistence/mysql/dao/DockerRegistryDao.java
+++ b/persistence-mysql/src/main/java/com/github/klboke/kkrepo/persistence/mysql/dao/DockerRegistryDao.java
@@ -366,11 +366,10 @@ public class DockerRegistryDao {
       return DeletedManifest.notFound();
     }
     long id = manifest.get().id();
-    List<Long> assetBlobIds = jdbcTemplate.query(
+    Long assetBlobId = jdbcTemplate.queryForObject(
         "SELECT asset_blob_id FROM asset WHERE id = ?",
         (rs, rowNum) -> nullableLong(rs, "asset_blob_id"),
         manifest.get().assetId());
-    Long assetBlobId = assetBlobIds.isEmpty() ? null : assetBlobIds.get(0);
     jdbcTemplate.update("DELETE FROM docker_tag WHERE manifest_id = ?", id);
     int deleted = jdbcTemplate.update("""
         UPDATE docker_manifest

--- a/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/AssetDaoMySqlIntegrationTest.java
+++ b/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/AssetDaoMySqlIntegrationTest.java
@@ -1,0 +1,151 @@
+package com.github.klboke.kkrepo.persistence.mysql.dao;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetBlobRecord;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetRecord;
+import com.github.klboke.kkrepo.persistence.mysql.support.HashColumns;
+import com.github.klboke.kkrepo.persistence.mysql.support.MySqlIntegrationTestSupport;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AssetDaoMySqlIntegrationTest extends MySqlIntegrationTestSupport {
+  @Test
+  void blobLifecycleDeduplicatesSoftDeletesAndRecovers() {
+    long blobStoreId = insertBlobStore("asset-store");
+    AssetDao dao = new AssetDao(jdbc(), jsonColumns());
+    AssetBlobRecord candidate = blob(blobStoreId, "content/a.jar", "a".repeat(64), 12);
+
+    AssetBlobRecord inserted = dao.insertBlobOrFindExisting(candidate);
+    AssetBlobRecord duplicate = dao.insertBlobOrFindExisting(candidate);
+
+    assertEquals(inserted.id(), duplicate.id());
+    assertEquals(Map.of("origin", "test"), duplicate.attributes());
+    assertTrue(dao.findReusableBlobBySha256(blobStoreId, candidate.sha256(), candidate.size()).isPresent());
+
+    assertEquals(1, dao.markBlobDeletedIfUnreferenced(inserted.id(), "test cleanup"));
+    assertFalse(dao.findReusableBlobBySha256(blobStoreId, candidate.sha256(), candidate.size()).isPresent());
+    assertEquals(1, dao.countDeletedBlobsAwaitingGc());
+
+    AssetBlobRecord recovered = dao.recoverDeletedBlobBySha256(
+        blobStoreId, candidate.sha256(), candidate.size()).orElseThrow();
+    assertEquals(inserted.id(), recovered.id());
+    assertEquals(0, dao.countDeletedBlobsAwaitingGc());
+    assertTrue(dao.hasLiveBlobForObjectKeyHash(blobStoreId, candidate.objectKeyHash()));
+  }
+
+  @Test
+  void assetUniquenessLookupsAndPrefixQueriesUseRealIndexes() {
+    long repositoryId = insertRepository("maven-one", "maven2");
+    long secondRepositoryId = insertRepository("maven-two", "maven2");
+    AssetDao dao = new AssetDao(jdbc(), jsonColumns());
+
+    long firstId = dao.insertAsset(asset(repositoryId, "com/acme/a/1.0/a-1.0.jar"));
+    long duplicateId = dao.insertAsset(asset(repositoryId, "com/acme/a/1.0/a-1.0.jar"));
+    long secondId = dao.insertAsset(asset(repositoryId, "com/acme/b/1.0/b-1.0.jar"));
+    long otherRepositoryId = dao.insertAsset(asset(secondRepositoryId, "com/acme/a/1.0/a-1.0.jar"));
+
+    assertEquals(firstId, duplicateId);
+    assertNotEquals(firstId, secondId);
+    assertNotEquals(firstId, otherRepositoryId);
+    assertEquals(firstId, dao.findAssetByPath(
+        repositoryId, "com/acme/a/1.0/a-1.0.jar").orElseThrow().id());
+    assertEquals(
+        Map.of(repositoryId, firstId, secondRepositoryId, otherRepositoryId),
+        dao.findAssetsByPathHash(
+                List.of(repositoryId, secondRepositoryId),
+                HashColumns.pathHash("com/acme/a/1.0/a-1.0.jar"))
+            .entrySet().stream()
+            .collect(java.util.stream.Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().id())));
+    assertEquals(
+        List.of("com/acme/a/1.0/a-1.0.jar", "com/acme/b/1.0/b-1.0.jar"),
+        dao.listAssetsByPrefix(repositoryId, "com/acme/").stream().map(AssetRecord::path).toList());
+    assertTrue(dao.findAssetsByPathHash(List.of(), HashColumns.pathHash("unused")).isEmpty());
+  }
+
+  @Test
+  void reconciliationAndGcClaimOnlyUnreferencedDeletedBlobs() {
+    long repositoryId = insertRepository("raw-hosted", "raw");
+    long blobStoreId = jdbc().queryForObject(
+        "SELECT blob_store_id FROM repository WHERE id = ?", Long.class, repositoryId);
+    AssetDao dao = new AssetDao(jdbc(), jsonColumns());
+    long referencedBlobId = dao.insertBlob(blob(blobStoreId, "referenced.bin", "b".repeat(64), 5));
+    long orphanBlobId = dao.insertBlob(blob(blobStoreId, "orphan.bin", "c".repeat(64), 7));
+    AssetRecord referencedAsset = asset(repositoryId, "files/referenced.bin");
+    dao.insertAsset(new AssetRecord(
+        referencedAsset.id(),
+        referencedAsset.repositoryId(),
+        referencedAsset.componentId(),
+        referencedBlobId,
+        referencedAsset.format(),
+        referencedAsset.path(),
+        referencedAsset.pathHash(),
+        referencedAsset.name(),
+        referencedAsset.kind(),
+        referencedAsset.contentType(),
+        referencedAsset.size(),
+        referencedAsset.lastDownloadedAt(),
+        referencedAsset.lastUpdatedAt(),
+        referencedAsset.attributes()));
+
+    AssetDao.BlobReconcileWindow window = inTransaction(
+        () -> dao.markUnreferencedBlobsDeletedAfter(0, 10, 10, "reconcile"));
+
+    assertEquals(1, window.marked());
+    assertEquals(2, window.scanned());
+    assertTrue(dao.lockLiveBlobById(referencedBlobId).isPresent());
+    assertTrue(dao.lockDeletedBlobById(orphanBlobId).isPresent());
+
+    List<AssetBlobRecord> claimed = inTransaction(() -> dao.claimDeletedBlobsForGc(
+        10, Instant.now().plusSeconds(1), Instant.now().minusSeconds(60)));
+    assertEquals(List.of(orphanBlobId), claimed.stream().map(AssetBlobRecord::id).toList());
+    assertEquals(1, dao.releaseBlobGcClaim(orphanBlobId));
+    assertEquals(1, dao.hardDeleteBlobByIdIfDeleted(orphanBlobId));
+    assertTrue(dao.findBlobById(orphanBlobId).isEmpty());
+  }
+
+  private static AssetBlobRecord blob(long blobStoreId, String objectKey, String sha256, long size) {
+    String blobRef = "default@" + objectKey;
+    return new AssetBlobRecord(
+        null,
+        blobStoreId,
+        blobRef,
+        HashColumns.blobRefHash(blobRef),
+        objectKey,
+        HashColumns.objectKeyHash(objectKey),
+        "1".repeat(40),
+        sha256,
+        "2".repeat(32),
+        size,
+        "application/octet-stream",
+        "tester",
+        "127.0.0.1",
+        Instant.parse("2026-01-01T00:00:00Z"),
+        Instant.parse("2026-01-01T00:00:00Z"),
+        Map.of("origin", "test"));
+  }
+
+  private static AssetRecord asset(long repositoryId, String path) {
+    return new AssetRecord(
+        null,
+        repositoryId,
+        null,
+        null,
+        RepositoryFormat.MAVEN2,
+        path,
+        HashColumns.pathHash(path),
+        path.substring(path.lastIndexOf('/') + 1),
+        "ARTIFACT",
+        "application/octet-stream",
+        10L,
+        null,
+        Instant.parse("2026-01-01T00:00:00Z"),
+        Map.of("tested", true));
+  }
+}

--- a/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/DockerRegistryDaoMySqlIntegrationTest.java
+++ b/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/DockerRegistryDaoMySqlIntegrationTest.java
@@ -1,0 +1,171 @@
+package com.github.klboke.kkrepo.persistence.mysql.dao;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetRecord;
+import com.github.klboke.kkrepo.persistence.mysql.model.docker.DockerManifestRecord;
+import com.github.klboke.kkrepo.persistence.mysql.model.docker.DockerManifestReferenceRecord;
+import com.github.klboke.kkrepo.persistence.mysql.model.docker.DockerTagRecord;
+import com.github.klboke.kkrepo.persistence.mysql.support.HashColumns;
+import com.github.klboke.kkrepo.persistence.mysql.support.MySqlIntegrationTestSupport;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class DockerRegistryDaoMySqlIntegrationTest extends MySqlIntegrationTestSupport {
+  @Test
+  void manifestTagAndReferenceLifecycleUsesDockerUniqueKeys() {
+    long repositoryId = insertRepository("docker-hosted", "docker");
+    AssetDao assetDao = new AssetDao(jdbc(), jsonColumns());
+    long assetId = assetDao.insertAsset(asset(repositoryId, "docker/manifests/acme/app/v1"));
+    DockerRegistryDao dao = new DockerRegistryDao(jdbc(), jsonColumns());
+    DockerManifestRecord first = manifest(repositoryId, assetId, "sha256:" + "a".repeat(64), 10);
+
+    DockerManifestRecord inserted = inTransaction(() -> dao.upsertManifest(first));
+    DockerManifestRecord updated = inTransaction(() -> dao.upsertManifest(
+        manifest(repositoryId, assetId, first.digest(), 20)));
+
+    assertEquals(inserted.id(), updated.id());
+    assertEquals(20, updated.size());
+    assertEquals(updated.id(), dao.findManifestByReference(
+        repositoryId, "acme/app", first.digest()).orElseThrow().id());
+
+    inTransaction(() -> {
+      dao.upsertTag(tag(repositoryId, updated, "latest"));
+      dao.upsertTag(tag(repositoryId, updated, "1.0"));
+      dao.replaceManifestReferences(updated.id(), List.of(reference(repositoryId, updated)));
+    });
+
+    assertEquals(List.of("1.0", "latest"), dao.listTags(repositoryId, "acme/app", null, 10));
+    assertEquals(List.of("latest"), dao.listTags(repositoryId, "acme/app", "1.0", 10));
+    assertEquals(2, dao.countTags(repositoryId, "acme/app"));
+    assertTrue(dao.tagExists(repositoryId, "acme/app", "latest"));
+    assertEquals(updated.id(), dao.findManifestByTag(
+        repositoryId, "acme/app", "latest").orElseThrow().id());
+    assertEquals(1, dao.listReferences(updated.id()).size());
+    assertTrue(dao.imageReferencesDigest(repositoryId, "acme/app", referenceDigest()));
+    assertEquals(List.of("acme/app"), dao.listCatalog(repositoryId, null, 10));
+
+    DockerRegistryDao.DeletedManifest deleted = inTransaction(
+        () -> dao.deleteManifest(repositoryId, "acme/app", first.digest()));
+    assertEquals(1, deleted.deleted());
+    assertEquals(assetId, deleted.assetId());
+    assertFalse(dao.imageExists(repositoryId, "acme/app"));
+    assertTrue(dao.listTagsForManifest(updated.id()).isEmpty());
+    assertEquals(0, inTransaction(
+        () -> dao.deleteManifest(repositoryId, "acme/app", first.digest())).deleted());
+  }
+
+  @Test
+  void paginationAndBrowsePathsReturnOnlyLiveImages() {
+    long repositoryId = insertRepository("docker-browse", "docker");
+    AssetDao assetDao = new AssetDao(jdbc(), jsonColumns());
+    DockerRegistryDao dao = new DockerRegistryDao(jdbc(), jsonColumns());
+    long alphaAssetId = assetDao.insertAsset(asset(repositoryId, "docker/manifests/acme/alpha/v1"));
+    long betaAssetId = assetDao.insertAsset(asset(repositoryId, "docker/manifests/acme/beta/v1"));
+    DockerManifestRecord alpha = inTransaction(() -> dao.upsertManifest(
+        manifest(repositoryId, alphaAssetId, "sha256:" + "b".repeat(64), 11, "acme/alpha")));
+    DockerManifestRecord beta = inTransaction(() -> dao.upsertManifest(
+        manifest(repositoryId, betaAssetId, "sha256:" + "c".repeat(64), 12, "acme/beta")));
+    inTransaction(() -> {
+      dao.upsertTag(tag(repositoryId, alpha, "stable"));
+      dao.upsertTag(tag(repositoryId, beta, "latest"));
+    });
+
+    assertEquals(List.of("acme/alpha"), dao.listCatalog(repositoryId, null, 1));
+    assertEquals(List.of("acme/beta"), dao.listCatalog(repositoryId, "acme/alpha", 10));
+    assertEquals(2, dao.listBrowseImages(repositoryId, "acme").size());
+    assertEquals(2, dao.listBrowseReferences(repositoryId, "acme/alpha").size());
+    assertTrue(dao.findBrowseManifestByReferencePath(
+        repositoryId, "acme/alpha/manifests/stable").isPresent());
+    assertTrue(dao.findBrowseManifestByReferencePath(repositoryId, "invalid").isEmpty());
+  }
+
+  private static AssetRecord asset(long repositoryId, String path) {
+    return new AssetRecord(
+        null,
+        repositoryId,
+        null,
+        null,
+        RepositoryFormat.DOCKER,
+        path,
+        HashColumns.pathHash(path),
+        "manifest.json",
+        "MANIFEST",
+        "application/vnd.oci.image.manifest.v1+json",
+        10L,
+        null,
+        Instant.parse("2026-01-01T00:00:00Z"),
+        Map.of());
+  }
+
+  private static DockerManifestRecord manifest(
+      long repositoryId, long assetId, String digest, long size) {
+    return manifest(repositoryId, assetId, digest, size, "acme/app");
+  }
+
+  private static DockerManifestRecord manifest(
+      long repositoryId, long assetId, String digest, long size, String imageName) {
+    return new DockerManifestRecord(
+        null,
+        repositoryId,
+        imageName,
+        DockerRegistryDao.hash(imageName),
+        "sha256",
+        digest,
+        DockerRegistryDao.hash(digest),
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.example.sbom",
+        null,
+        null,
+        assetId,
+        size,
+        "tester",
+        "127.0.0.1",
+        null,
+        Map.of("source", "integration-test"),
+        null,
+        null);
+  }
+
+  private static DockerTagRecord tag(
+      long repositoryId, DockerManifestRecord manifest, String tag) {
+    return new DockerTagRecord(
+        null,
+        repositoryId,
+        manifest.imageName(),
+        DockerRegistryDao.hash(manifest.imageName()),
+        tag,
+        DockerRegistryDao.hash(tag),
+        manifest.id(),
+        manifest.digest(),
+        "tester",
+        "127.0.0.1",
+        null,
+        null);
+  }
+
+  private static DockerManifestReferenceRecord reference(
+      long repositoryId, DockerManifestRecord manifest) {
+    return new DockerManifestReferenceRecord(
+        null,
+        manifest.id(),
+        repositoryId,
+        manifest.imageName(),
+        referenceDigest(),
+        DockerRegistryDao.hash(referenceDigest()),
+        "MANIFEST",
+        "application/vnd.oci.image.manifest.v1+json",
+        123L,
+        Map.of("os", "linux", "architecture", "amd64"),
+        Map.of("org.opencontainers.image.title", "base"));
+  }
+
+  private static String referenceDigest() {
+    return "sha256:" + "d".repeat(64);
+  }
+}

--- a/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/RepositoryDataMigrationDaoMySqlIntegrationTest.java
+++ b/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/RepositoryDataMigrationDaoMySqlIntegrationTest.java
@@ -1,0 +1,136 @@
+package com.github.klboke.kkrepo.persistence.mysql.dao;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.persistence.mysql.model.RepositoryDataMigrationAssetRecord;
+import com.github.klboke.kkrepo.persistence.mysql.support.HashColumns;
+import com.github.klboke.kkrepo.persistence.mysql.support.MySqlIntegrationTestSupport;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class RepositoryDataMigrationDaoMySqlIntegrationTest extends MySqlIntegrationTestSupport {
+  @Test
+  void failedAssetCanBeRetriedAndClaimedAgainWithRealJsonAndLockingSql() {
+    long repositoryId = insertRepository("migration-target", "maven2");
+    long migrationJobId = insertMigrationJob(true);
+    RepositoryDataMigrationDao dao = new RepositoryDataMigrationDao(jdbc(), jsonColumns());
+    long repositoryJobId = dao.createRepositoryJob(
+        migrationJobId,
+        "maven-releases",
+        "migration-target",
+        repositoryId,
+        RepositoryFormat.MAVEN2,
+        100,
+        Map.of("sourceType", "hosted"));
+    dao.upsertDiscoveredAssets(repositoryJobId, List.of(asset()), Map.of());
+    dao.finishDiscoveryPage(repositoryJobId, null, true);
+
+    List<RepositoryDataMigrationDao.AssetClaim> firstClaims = inTransaction(
+        () -> dao.claimAssetsForMigration(migrationJobId, 10, 3, Instant.now().minusSeconds(60)));
+    assertEquals(1, firstClaims.size());
+    assertEquals(0, firstClaims.get(0).asset().attempts());
+    assertEquals(1, jdbc().queryForObject("""
+        SELECT attempts
+        FROM repository_data_migration_asset
+        WHERE id = ?
+        """, Integer.class, firstClaims.get(0).asset().id()));
+    assertEquals("migrating", dao.findRepositoryJob(repositoryJobId).orElseThrow().status());
+
+    long assetId = firstClaims.get(0).asset().id();
+    dao.markAssetFailed(assetId, repositoryJobId, 1, "upstream failed");
+    dao.refreshRepositoryProgress(repositoryJobId);
+
+    assertEquals(
+        RepositoryDataMigrationDao.REPOSITORY_FINISHED_WITH_FAILURES,
+        dao.findRepositoryJob(repositoryJobId).orElseThrow().status());
+    assertEquals(1, dao.retryFailedAssets(migrationJobId));
+    assertEquals("migrating", dao.findRepositoryJob(repositoryJobId).orElseThrow().status());
+
+    List<RepositoryDataMigrationDao.AssetClaim> retried = inTransaction(
+        () -> dao.claimAssetsForMigration(migrationJobId, 10, 3, Instant.now().plusSeconds(1)));
+    assertEquals(1, retried.size());
+    assertEquals(0, retried.get(0).asset().attempts());
+
+    dao.markAssetMigrated(assetId, repositoryJobId, null, null, null);
+    dao.refreshRepositoryProgress(repositoryJobId);
+    RepositoryDataMigrationDao.MigrationJobProgress progress = dao.jobProgress(migrationJobId);
+    assertEquals(1, progress.migratedAssets());
+    assertEquals(0, progress.failedAssets());
+    assertEquals(0, progress.pendingAssets());
+    assertFalse(progress.active());
+  }
+
+  @Test
+  void discoveryClaimHonorsJobFilterAndRetryCutoff() {
+    long firstRepositoryId = insertRepository("target-one", "maven2");
+    long secondRepositoryId = insertRepository("target-two", "maven2");
+    long firstJobId = insertMigrationJob(true);
+    long secondJobId = insertMigrationJob(true);
+    RepositoryDataMigrationDao dao = new RepositoryDataMigrationDao(jdbc(), jsonColumns());
+    long firstRepositoryJobId = dao.createRepositoryJob(
+        firstJobId, "source-one", "target-one", firstRepositoryId,
+        RepositoryFormat.MAVEN2, 50, Map.of());
+    long secondRepositoryJobId = dao.createRepositoryJob(
+        secondJobId, "source-two", "target-two", secondRepositoryId,
+        RepositoryFormat.MAVEN2, 50, Map.of());
+
+    assertEquals(secondRepositoryJobId, inTransaction(() -> dao.claimRepositoryForDiscovery(
+        secondJobId, Instant.now())).orElseThrow().id());
+    assertTrue(inTransaction(() -> dao.claimRepositoryForDiscovery(
+        secondJobId, Instant.EPOCH)).isEmpty());
+    assertEquals(firstRepositoryJobId, inTransaction(() -> dao.claimRepositoryForDiscovery(
+        firstJobId, Instant.now())).orElseThrow().id());
+  }
+
+  private long insertMigrationJob(boolean packageMigrationEnabled) {
+    jdbc().update("""
+        INSERT INTO migration_job
+          (source_nexus_version, source_data_path, status, options_json, summary_json)
+        VALUES ('3.70.0', '/nexus-data', 'running', ?, JSON_OBJECT())
+        """, jsonColumns().write(Map.of(
+            "scope", "repository-data",
+            "packageMigrationEnabled", packageMigrationEnabled)));
+    return jdbc().queryForObject("SELECT MAX(id) FROM migration_job", Long.class);
+  }
+
+  private static RepositoryDataMigrationAssetRecord asset() {
+    String path = "com/acme/app/1.0/app-1.0.jar";
+    Instant updated = Instant.parse("2026-01-01T00:00:00Z");
+    return new RepositoryDataMigrationAssetRecord(
+        null,
+        0,
+        "#12:0",
+        "#11:0",
+        path,
+        HashColumns.pathHash(path),
+        RepositoryFormat.MAVEN2,
+        "com.acme",
+        "app",
+        "1.0",
+        "ARTIFACT",
+        "application/java-archive",
+        1024L,
+        "default@abc",
+        updated,
+        null,
+        updated,
+        updated,
+        "admin",
+        "127.0.0.1",
+        RepositoryDataMigrationDao.ASSET_PENDING,
+        0,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        Map.of("sourceRepositoryType", "hosted"),
+        null);
+  }
+}

--- a/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/SecurityDaoMySqlIntegrationTest.java
+++ b/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/SecurityDaoMySqlIntegrationTest.java
@@ -1,0 +1,148 @@
+package com.github.klboke.kkrepo.persistence.mysql.dao;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.klboke.kkrepo.core.security.SecretCipher;
+import com.github.klboke.kkrepo.persistence.mysql.model.ApiKeyRecord;
+import com.github.klboke.kkrepo.persistence.mysql.model.SecurityPrivilegeRecord;
+import com.github.klboke.kkrepo.persistence.mysql.model.SecurityRealmRecord;
+import com.github.klboke.kkrepo.persistence.mysql.model.SecurityRoleRecord;
+import com.github.klboke.kkrepo.persistence.mysql.model.SecurityUserRecord;
+import com.github.klboke.kkrepo.persistence.mysql.support.MySqlIntegrationTestSupport;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DuplicateKeyException;
+
+class SecurityDaoMySqlIntegrationTest extends MySqlIntegrationTestSupport {
+  @Test
+  void userRoleAndPrivilegeRelationshipsRespectUniqueKeysAndForeignKeys() {
+    SecurityDao dao = new SecurityDao(jdbc(), jsonColumns());
+    long userId = dao.insertUser(user("alice"));
+    assertThrows(DuplicateKeyException.class, () -> dao.insertUser(user("alice")));
+
+    dao.upsertRole(role("developers", "Developers"));
+    dao.upsertRole(role("readers", "Readers"));
+    dao.upsertPrivilege(privilege("nx-repository-view-*-*-read"));
+    dao.assignRole(userId, "developers");
+    dao.assignRole(userId, "developers");
+    dao.grantPrivilege("developers", "nx-repository-view-*-*-read");
+    dao.grantPrivilege("developers", "nx-repository-view-*-*-read");
+    dao.inheritRole("developers", "readers");
+
+    assertEquals(List.of("developers"), dao.listUserRoleIds("Local", "alice"));
+    assertEquals(List.of("nx-repository-view-*-*-read"), dao.listRolePrivilegeIds("developers"));
+    assertEquals(List.of("readers"), dao.listRoleChildIds("developers"));
+    assertEquals(1, dao.listPrivilegesForRoles(List.of("developers")).size());
+
+    dao.replaceUserRoles(userId, List.of("readers"));
+    dao.replaceRolePrivileges("developers", List.of());
+    dao.replaceRoleInheritance("developers", null);
+
+    assertEquals(List.of("readers"), dao.listUserRoleIds(userId));
+    assertTrue(dao.listRolePrivilegeIds("developers").isEmpty());
+    assertTrue(dao.listRoleChildIds("developers").isEmpty());
+    dao.assignRole(userId, "missing-role");
+    assertEquals(List.of("readers"), dao.listUserRoleIds(userId));
+  }
+
+  @Test
+  void realmSecretsAreEncryptedAtRestAndDecryptedOnRead() {
+    SecurityDao dao = new SecurityDao(jdbc(), jsonColumns());
+    dao.upsertRealm(new SecurityRealmRecord(
+        null,
+        "oidc-test",
+        "OIDC",
+        "Test OIDC",
+        true,
+        10,
+        Map.of("issuer", "https://issuer.example", "clientSecret", "plain-secret")));
+
+    String stored = jdbc().queryForObject("""
+        SELECT JSON_UNQUOTE(JSON_EXTRACT(attributes_json, '$.clientSecret'))
+        FROM security_realm
+        WHERE realm_id = 'oidc-test'
+        """, String.class);
+    SecurityRealmRecord loaded = dao.findRealm("oidc-test").orElseThrow();
+
+    assertNotEquals("plain-secret", stored);
+    assertTrue(SecretCipher.isEncrypted(stored));
+    assertEquals("plain-secret", loaded.attributes().get("clientSecret"));
+    assertEquals("https://issuer.example", loaded.attributes().get("issuer"));
+  }
+
+  @Test
+  void apiKeyUpsertAndOwnerQueriesRoundTripJsonAndTimestamps() {
+    SecurityDao dao = new SecurityDao(jdbc(), jsonColumns());
+    LocalDateTime expiry = LocalDateTime.of(2027, 1, 1, 0, 0);
+    dao.upsertApiKey(apiKey("hash-one", "ACTIVE", expiry));
+    ApiKeyRecord created = dao.findApiKey("npm", "Local", "alice").orElseThrow();
+
+    assertEquals(Map.of("repositories", List.of("npm-hosted")), created.scopes());
+    assertTrue(dao.findApiKeyByDomainAndHash("npm", "hash-one").isPresent());
+    assertFalse(dao.findApiKeyForOwner(created.id(), "Local", "bob").isPresent());
+
+    dao.upsertApiKey(apiKey("hash-two", "REVOKED", expiry.plusDays(1)));
+    ApiKeyRecord updated = dao.findApiKey(created.id()).orElseThrow();
+
+    assertEquals("hash-two", updated.apiKeyHash());
+    assertEquals("REVOKED", updated.status());
+    assertEquals(1, dao.listApiKeysForOwner("Local", "alice").size());
+    LocalDateTime usedAt = LocalDateTime.of(2026, 7, 13, 12, 30);
+    dao.markApiKeyUsed(created.id(), usedAt);
+    assertEquals(usedAt, dao.findApiKey(created.id()).orElseThrow().lastUsedAt());
+    assertEquals(1, dao.deleteApiKeysForOwner("Local", "alice"));
+    assertTrue(dao.listApiKeys().isEmpty());
+  }
+
+  private static SecurityUserRecord user(String userId) {
+    return new SecurityUserRecord(
+        null,
+        "Local",
+        userId,
+        "Alice",
+        "Example",
+        userId + "@example.com",
+        "hash",
+        "active",
+        null,
+        Map.of("department", "infra"));
+  }
+
+  private static SecurityRoleRecord role(String roleId, String name) {
+    return new SecurityRoleRecord(roleId, "Local", name, name, false, Map.of());
+  }
+
+  private static SecurityPrivilegeRecord privilege(String privilegeId) {
+    return new SecurityPrivilegeRecord(
+        privilegeId,
+        privilegeId,
+        "read repositories",
+        "repository-view",
+        false,
+        Map.of("actions", List.of("read")));
+  }
+
+  private static ApiKeyRecord apiKey(String hash, String status, LocalDateTime expiry) {
+    return new ApiKeyRecord(
+        null,
+        "npm",
+        "Local",
+        "alice",
+        "npm token",
+        status,
+        hash,
+        "npm_",
+        Map.of("repositories", List.of("npm-hosted")),
+        "encrypted-payload",
+        null,
+        null,
+        expiry,
+        null);
+  }
+}

--- a/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/support/MySqlIntegrationTestSupport.java
+++ b/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/support/MySqlIntegrationTestSupport.java
@@ -1,0 +1,108 @@
+package com.github.klboke.kkrepo.persistence.mysql.support;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Statement;
+import java.util.List;
+import java.util.function.Supplier;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.jdbc.core.ConnectionCallback;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.mysql.MySQLContainer;
+
+public abstract class MySqlIntegrationTestSupport {
+  private static final MySQLContainer MYSQL = new MySQLContainer("mysql:8.0")
+      .withDatabaseName("kkrepo")
+      .withUsername("kkrepo")
+      .withPassword("kkrepo");
+
+  private static JdbcTemplate jdbcTemplate;
+  private static JsonColumns jsonColumns;
+  private static TransactionTemplate transactionTemplate;
+
+  @BeforeAll
+  static void startMySql() {
+    if (!MYSQL.isRunning()) {
+      MYSQL.start();
+      DriverManagerDataSource dataSource = new DriverManagerDataSource(
+          MYSQL.getJdbcUrl() + "?useUnicode=true&characterEncoding=utf8&useSSL=false"
+              + "&allowPublicKeyRetrieval=true&connectionTimeZone=LOCAL",
+          MYSQL.getUsername(),
+          MYSQL.getPassword());
+      jdbcTemplate = new JdbcTemplate(dataSource);
+      jsonColumns = new JsonColumns(new ObjectMapper());
+      transactionTemplate = new TransactionTemplate(new DataSourceTransactionManager(dataSource));
+      Flyway.configure()
+          .dataSource(dataSource)
+          .locations("classpath:db/migration")
+          .failOnMissingLocations(true)
+          .load()
+          .migrate();
+    }
+  }
+
+  @BeforeEach
+  void truncateDatabase() {
+    List<String> tables = jdbcTemplate.queryForList("""
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_schema = ?
+          AND table_type = 'BASE TABLE'
+          AND table_name <> 'flyway_schema_history'
+        """, String.class, MYSQL.getDatabaseName());
+    jdbcTemplate.execute((ConnectionCallback<Void>) connection -> {
+      try (Statement statement = connection.createStatement()) {
+        statement.execute("SET FOREIGN_KEY_CHECKS = 0");
+        try {
+          for (String table : tables) {
+            statement.execute("TRUNCATE TABLE `" + table.replace("`", "``") + "`");
+          }
+        } finally {
+          statement.execute("SET FOREIGN_KEY_CHECKS = 1");
+        }
+      }
+      return null;
+    });
+  }
+
+  protected JdbcTemplate jdbc() {
+    return jdbcTemplate;
+  }
+
+  protected JsonColumns jsonColumns() {
+    return jsonColumns;
+  }
+
+  protected <T> T inTransaction(Supplier<T> action) {
+    return transactionTemplate.execute(status -> action.get());
+  }
+
+  protected void inTransaction(Runnable action) {
+    transactionTemplate.executeWithoutResult(status -> action.run());
+  }
+
+  protected long insertBlobStore(String name) {
+    jdbcTemplate.update("""
+        INSERT INTO blob_store (name, type, attributes_json)
+        VALUES (?, 'S3', JSON_OBJECT())
+        """, name);
+    return jdbcTemplate.queryForObject(
+        "SELECT id FROM blob_store WHERE name = ?", Long.class, name);
+  }
+
+  protected long insertRepository(String name, String format) {
+    long blobStoreId = insertBlobStore(name + "-store");
+    jdbcTemplate.update("""
+        INSERT INTO repository
+          (name, format, type, recipe_name, blob_store_id, attributes_json)
+        VALUES (?, ?, 'hosted', ?, ?, JSON_OBJECT())
+        """, name, format, format + "-hosted", blobStoreId);
+    return jdbcTemplate.queryForObject(
+        "SELECT id FROM repository WHERE name = ?", Long.class, name);
+  }
+
+}

--- a/protocol-go/pom.xml
+++ b/protocol-go/pom.xml
@@ -16,5 +16,10 @@
       <groupId>com.github.klboke</groupId>
       <artifactId>kkrepo-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/protocol-go/src/test/java/com/github/klboke/kkrepo/protocol/goartifact/GoRepositoryProtocolTest.java
+++ b/protocol-go/src/test/java/com/github/klboke/kkrepo/protocol/goartifact/GoRepositoryProtocolTest.java
@@ -1,0 +1,19 @@
+package com.github.klboke.kkrepo.protocol.goartifact;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.klboke.kkrepo.core.ProtocolCapability;
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import org.junit.jupiter.api.Test;
+
+class GoRepositoryProtocolTest {
+  @Test
+  void describesSupportedRepositoryModes() {
+    GoRepositoryProtocol protocol = new GoRepositoryProtocol();
+
+    assertEquals(RepositoryFormat.GO, protocol.format());
+    assertEquals(
+        new ProtocolCapability(false, false, true, true, true),
+        protocol.capability());
+  }
+}

--- a/protocol-helm/src/test/java/com/github/klboke/kkrepo/protocol/helm/HelmIndexTest.java
+++ b/protocol-helm/src/test/java/com/github/klboke/kkrepo/protocol/helm/HelmIndexTest.java
@@ -1,0 +1,146 @@
+package com.github.klboke.kkrepo.protocol.helm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class HelmIndexTest {
+  @Test
+  void buildsSortedHostedIndexAndFiltersInvalidCoordinates() {
+    byte[] body = HelmIndex.buildHosted(List.of(
+        chart("zeta", "1.0.0"),
+        chart("demo", "1.0.0"),
+        chart("demo", "2.0.0"),
+        chart("", "3.0.0"),
+        chart("ignored", null)),
+        Instant.parse("2026-07-13T00:00:00Z"));
+
+    assertEquals(List.of(
+        new HelmIndex.Entry("demo", "2.0.0", List.of("demo-2.0.0.tgz")),
+        new HelmIndex.Entry("demo", "1.0.0", List.of("demo-1.0.0.tgz")),
+        new HelmIndex.Entry("zeta", "1.0.0", List.of("zeta-1.0.0.tgz"))),
+        HelmIndex.entries(body));
+    assertTrue(text(body).contains("generated: \"2026-07-13T00:00:00Z\""));
+  }
+
+  @Test
+  void writesOptionalFieldsDefaultsAndEscapedStrings() {
+    HelmIndex.ChartRecord chart = new HelmIndex.ChartRecord(
+        "demo",
+        "1.0.0",
+        " ",
+        "quoted \"value\"\nnext",
+        "1.2",
+        "https://example.test/icon.png",
+        Instant.parse("2026-07-13T01:02:03Z"),
+        "sha256-demo",
+        Arrays.asList("demo-1.0.0.tgz", null, " "),
+        List.of("https://example.test/source"),
+        Arrays.asList(null, Map.of(),
+            Map.of("name", "ops", "email", "ops@example.test", "blank", " ")));
+
+    String yaml = text(HelmIndex.buildHosted(List.of(chart), null));
+
+    assertTrue(yaml.contains("apiVersion: \"v1\""));
+    assertTrue(yaml.contains("description: \"quoted \\\"value\\\"\\nnext\""));
+    assertTrue(yaml.contains("created: \"2026-07-13T01:02:03Z\""));
+    assertTrue(yaml.contains("digest: \"sha256-demo\""));
+    assertTrue(yaml.contains("name: \"ops\""));
+    assertTrue(yaml.contains("email: \"ops@example.test\""));
+    assertFalse(yaml.contains("blank:"));
+    assertEquals(1, HelmIndex.entries(yaml.getBytes(StandardCharsets.UTF_8)).size());
+  }
+
+  @Test
+  void rewritesRelativeAbsoluteProvenanceAndFallbackUrls() {
+    byte[] upstream = """
+        apiVersion: v1
+        entries:
+          demo:
+            - name: demo
+              version: 1.2.3
+              urls:
+                - charts/demo-original.tgz
+                - https://cdn.example.test/demo-original.tgz.prov
+            - urls:
+                - fallback.tgz
+            - name: empty
+              version: 1.0.0
+              urls: []
+          ignored: not-a-list
+        """.getBytes(StandardCharsets.UTF_8);
+
+    HelmIndex.RewriteResult result = HelmIndex.rewriteProxyIndex(
+        upstream, "https://repo.example.test/helm");
+
+    assertEquals(
+        "https://repo.example.test/helm/charts/demo-original.tgz",
+        result.remoteUrlsByLocalPath().get("demo-1.2.3.tgz"));
+    assertEquals(
+        "https://cdn.example.test/demo-original.tgz.prov",
+        result.remoteUrlsByLocalPath().get("demo-1.2.3.tgz.prov"));
+    assertEquals(
+        "https://repo.example.test/helm/fallback.tgz",
+        result.remoteUrlsByLocalPath().get("fallback.tgz"));
+    assertEquals(3, result.remoteUrlsByLocalPath().size());
+  }
+
+  @Test
+  void toleratesMalformedAndNonMappingIndexes() {
+    byte[] malformedUrl = """
+        entries:
+          demo:
+            - urls:
+                - "http://["
+        """.getBytes(StandardCharsets.UTF_8);
+
+    HelmIndex.RewriteResult rewritten = HelmIndex.rewriteProxyIndex(malformedUrl, null);
+    assertEquals("http://[", rewritten.remoteUrlsByLocalPath().get("["));
+    assertEquals(List.of(), HelmIndex.entries("[]".getBytes(StandardCharsets.UTF_8)));
+    assertEquals(List.of(), HelmIndex.entries("entries: []".getBytes(StandardCharsets.UTF_8)));
+  }
+
+  @Test
+  void readsFallbackNamesAndSkipsNonMappingVersions() {
+    byte[] body = """
+        entries:
+          demo:
+            - version: 1.0.0
+              urls:
+                - demo.tgz
+                - ""
+                - null
+            - not-a-map
+        """.getBytes(StandardCharsets.UTF_8);
+
+    assertEquals(
+        List.of(new HelmIndex.Entry("demo", "1.0.0", List.of("demo.tgz"))),
+        HelmIndex.entries(body));
+  }
+
+  private static HelmIndex.ChartRecord chart(String name, String version) {
+    return new HelmIndex.ChartRecord(
+        name,
+        version,
+        "v2",
+        null,
+        null,
+        null,
+        null,
+        null,
+        name == null || version == null ? List.of() : List.of(name + "-" + version + ".tgz"),
+        null,
+        null);
+  }
+
+  private static String text(byte[] body) {
+    return new String(body, StandardCharsets.UTF_8);
+  }
+}

--- a/protocol-helm/src/test/java/com/github/klboke/kkrepo/protocol/helm/HelmModelTest.java
+++ b/protocol-helm/src/test/java/com/github/klboke/kkrepo/protocol/helm/HelmModelTest.java
@@ -1,0 +1,92 @@
+package com.github.klboke.kkrepo.protocol.helm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.klboke.kkrepo.core.ProtocolCapability;
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class HelmModelTest {
+  @Test
+  void describesSupportedRepositoryModes() {
+    HelmRepositoryProtocol protocol = new HelmRepositoryProtocol();
+
+    assertEquals(RepositoryFormat.HELM, protocol.format());
+    assertEquals(
+        new ProtocolCapability(true, true, true, false, true),
+        protocol.capability());
+  }
+
+  @Test
+  void classifiesSupportedAssetPaths() {
+    assertEquals(HelmAssetKind.INDEX, HelmAssetKind.fromPath("INDEX.YAML"));
+    assertEquals(HelmAssetKind.PACKAGE, HelmAssetKind.fromPath("charts/demo-1.0.0.TGZ"));
+    assertEquals(HelmAssetKind.PROVENANCE, HelmAssetKind.fromPath("demo-1.0.0.tgz.prov"));
+
+    assertEquals("index.yaml", HelmAssetKind.INDEX.fixedPath());
+    assertEquals(".yaml", HelmAssetKind.INDEX.extension());
+    assertEquals("text/x-yaml", HelmAssetKind.INDEX.contentType());
+    assertTrue(HelmAssetKind.INDEX.metadata());
+    assertFalse(HelmAssetKind.PACKAGE.metadata());
+    assertEquals("application/gzip", HelmAssetKind.PACKAGE.contentType());
+    assertEquals("application/octet-stream", HelmAssetKind.PROVENANCE.contentType());
+  }
+
+  @Test
+  void rejectsUnsupportedAssetPaths() {
+    assertThrows(IllegalArgumentException.class, () -> HelmAssetKind.fromPath(null));
+    assertThrows(IllegalArgumentException.class, () -> HelmAssetKind.fromPath("README.md"));
+  }
+
+  @Test
+  void convertsChartYamlValuesAndDropsInvalidCollections() {
+    HelmChartMetadata metadata = HelmChartMetadata.fromYamlMap(Map.of(
+        "apiVersion", "v2",
+        "name", "demo",
+        "version", 123,
+        "description", "",
+        "sources", List.of("https://example.test/source", "", 42),
+        "maintainers", List.of(
+            Map.of("name", "ops", "email", "ops@example.test"),
+            "not-a-map",
+            Map.of())));
+
+    assertEquals("v2", metadata.apiVersion());
+    assertEquals("demo", metadata.name());
+    assertEquals("123", metadata.version());
+    assertEquals(List.of("https://example.test/source", "42"), metadata.sources());
+    assertEquals(
+        List.of(Map.of("name", "ops", "email", "ops@example.test")),
+        metadata.maintainers());
+    assertEquals(Map.of(
+        "apiVersion", "v2",
+        "name", "demo",
+        "version", "123",
+        "sources", List.of("https://example.test/source", "42"),
+        "maintainers", List.of(Map.of("name", "ops", "email", "ops@example.test"))),
+        metadata.attributes());
+  }
+
+  @Test
+  void handlesNullMetadataAndRequiresCoordinates() {
+    HelmChartMetadata empty = HelmChartMetadata.fromYamlMap(null);
+    assertEquals(Map.of(), empty.raw());
+    assertEquals(List.of(), empty.sources());
+    assertEquals(List.of(), empty.maintainers());
+    assertThrows(IllegalArgumentException.class, empty::requireNameAndVersion);
+
+    HelmChartMetadata missingVersion = HelmChartMetadata.fromYamlMap(Map.of("name", "demo"));
+    IllegalArgumentException error = assertThrows(
+        IllegalArgumentException.class, missingVersion::requireNameAndVersion);
+    assertEquals("Helm chart metadata is missing version", error.getMessage());
+
+    HelmChartMetadata valid = HelmChartMetadata.fromYamlMap(
+        Map.of("name", "demo", "version", "1.2.3"));
+    valid.requireNameAndVersion();
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/blob/BlobGarbageCollectionWorkerTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/blob/BlobGarbageCollectionWorkerTest.java
@@ -1,0 +1,196 @@
+package com.github.klboke.kkrepo.server.blob;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.core.BlobStorage;
+import com.github.klboke.kkrepo.persistence.mysql.dao.AssetDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.AssetDao.BlobReconcileWindow;
+import com.github.klboke.kkrepo.persistence.mysql.dao.MaintenanceCursorDao;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetBlobRecord;
+import com.github.klboke.kkrepo.server.maven.BlobStorageRegistry;
+import com.github.klboke.kkrepo.server.metrics.KkRepoMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+class BlobGarbageCollectionWorkerTest {
+
+  @Test
+  void disabledWorkerDoesNotTouchSharedState() {
+    AssetDao assetDao = mock(AssetDao.class);
+    MaintenanceCursorDao cursorDao = mock(MaintenanceCursorDao.class);
+    BlobStorageRegistry storageRegistry = mock(BlobStorageRegistry.class);
+
+    worker(assetDao, cursorDao, storageRegistry, false, new SimpleMeterRegistry()).drain();
+
+    verifyNoInteractions(assetDao, cursorDao, storageRegistry);
+  }
+
+  @Test
+  void lockedReconcileCursorSkipsScanAndRecordsLockOutcome() {
+    AssetDao assetDao = mock(AssetDao.class);
+    MaintenanceCursorDao cursorDao = mock(MaintenanceCursorDao.class);
+    BlobStorageRegistry storageRegistry = mock(BlobStorageRegistry.class);
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    when(cursorDao.tryLockLastSeenId(MaintenanceCursorDao.BLOB_UNREFERENCED_RECONCILE))
+        .thenReturn(OptionalLong.empty());
+    when(assetDao.claimDeletedBlobsForGc(anyInt(), any(), any())).thenReturn(List.of());
+
+    worker(assetDao, cursorDao, storageRegistry, true, registry).drain();
+
+    verify(assetDao, never()).markUnreferencedBlobsDeletedAfter(anyLong(), anyInt(), anyInt(), any());
+    assertNotNull(registry.find("kkrepo_worker_items_total")
+        .tags("worker", "blob_gc", "kind", "reconcile", "outcome", "locked")
+        .counter());
+  }
+
+  @Test
+  void reconcileAdvancesCursorAndCollectsUnreferencedBlob() {
+    AssetDao assetDao = mock(AssetDao.class);
+    MaintenanceCursorDao cursorDao = mock(MaintenanceCursorDao.class);
+    BlobStorageRegistry storageRegistry = mock(BlobStorageRegistry.class);
+    BlobStorage storage = mock(BlobStorage.class);
+    AssetBlobRecord blob = blob(11L);
+    when(cursorDao.tryLockLastSeenId(MaintenanceCursorDao.BLOB_UNREFERENCED_RECONCILE))
+        .thenReturn(OptionalLong.of(7L));
+    when(assetDao.markUnreferencedBlobsDeletedAfter(7L, 32, 16, "unreferenced blob reconcile"))
+        .thenReturn(new BlobReconcileWindow(1, 4, 12L, false));
+    when(assetDao.claimDeletedBlobsForGc(eq(8), any(), any())).thenReturn(List.of(blob));
+    when(assetDao.lockDeletedBlobById(11L)).thenReturn(Optional.of(blob));
+    when(assetDao.hasLiveBlobForObjectKeyHash(3L, blob.objectKeyHash())).thenReturn(false);
+    when(storageRegistry.forBlobStoreId(3L)).thenReturn(storage);
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+    worker(assetDao, cursorDao, storageRegistry, true, registry).drain();
+
+    verify(cursorDao).updateLastSeenId(MaintenanceCursorDao.BLOB_UNREFERENCED_RECONCILE, 12L);
+    verify(storage).delete(argThat(reference ->
+        "bucket".equals(reference.bucket())
+            && blob.objectKey().equals(reference.objectKey())
+            && blob.sha256().equals(reference.sha256())
+            && blob.size() == reference.size()));
+    verify(assetDao).hardDeleteBlobByIdIfDeleted(11L);
+    assertEquals(42.0, registry.get("kkrepo_blob_gc_deleted_bytes_total").counter().count());
+  }
+
+  @Test
+  void liveReferenceKeepsPhysicalObjectButRemovesDeletedBlobRow() {
+    AssetDao assetDao = mock(AssetDao.class);
+    MaintenanceCursorDao cursorDao = mock(MaintenanceCursorDao.class);
+    BlobStorageRegistry storageRegistry = mock(BlobStorageRegistry.class);
+    BlobStorage storage = mock(BlobStorage.class);
+    AssetBlobRecord blob = blob(12L);
+    stubLockedReconcile(cursorDao);
+    when(assetDao.claimDeletedBlobsForGc(anyInt(), any(), any())).thenReturn(List.of(blob));
+    when(assetDao.lockDeletedBlobById(12L)).thenReturn(Optional.of(blob));
+    when(assetDao.hasLiveBlobForObjectKeyHash(3L, blob.objectKeyHash())).thenReturn(true);
+    when(storageRegistry.forBlobStoreId(3L)).thenReturn(storage);
+
+    worker(assetDao, cursorDao, storageRegistry, true, new SimpleMeterRegistry()).drain();
+
+    verify(storage, never()).delete(any());
+    verify(assetDao).hardDeleteBlobByIdIfDeleted(12L);
+  }
+
+  @Test
+  void storageFailureReleasesClaimForRetry() {
+    AssetDao assetDao = mock(AssetDao.class);
+    MaintenanceCursorDao cursorDao = mock(MaintenanceCursorDao.class);
+    BlobStorageRegistry storageRegistry = mock(BlobStorageRegistry.class);
+    BlobStorage storage = mock(BlobStorage.class);
+    AssetBlobRecord blob = blob(13L);
+    stubLockedReconcile(cursorDao);
+    when(assetDao.claimDeletedBlobsForGc(anyInt(), any(), any())).thenReturn(List.of(blob));
+    when(assetDao.lockDeletedBlobById(13L)).thenReturn(Optional.of(blob));
+    when(assetDao.hasLiveBlobForObjectKeyHash(3L, blob.objectKeyHash())).thenReturn(false);
+    when(storageRegistry.forBlobStoreId(3L)).thenReturn(storage);
+    doThrow(new IllegalStateException("storage unavailable")).when(storage).delete(any());
+
+    worker(assetDao, cursorDao, storageRegistry, true, new SimpleMeterRegistry()).drain();
+
+    verify(assetDao).releaseBlobGcClaim(13L);
+    verify(assetDao, never()).hardDeleteBlobByIdIfDeleted(13L);
+  }
+
+  private static void stubLockedReconcile(MaintenanceCursorDao cursorDao) {
+    when(cursorDao.tryLockLastSeenId(MaintenanceCursorDao.BLOB_UNREFERENCED_RECONCILE))
+        .thenReturn(OptionalLong.empty());
+  }
+
+  private static BlobGarbageCollectionWorker worker(
+      AssetDao assetDao,
+      MaintenanceCursorDao cursorDao,
+      BlobStorageRegistry storageRegistry,
+      boolean enabled,
+      SimpleMeterRegistry registry) {
+    return new BlobGarbageCollectionWorker(
+        assetDao,
+        cursorDao,
+        storageRegistry,
+        new RecordingTransactionManager(),
+        enabled,
+        8,
+        32,
+        16,
+        0,
+        60,
+        new KkRepoMetrics(registry));
+  }
+
+  private static AssetBlobRecord blob(long id) {
+    Instant now = Instant.now();
+    return new AssetBlobRecord(
+        id,
+        3L,
+        "blob://bucket/raw/demo.bin",
+        new byte[] {1},
+        "raw/demo.bin",
+        new byte[] {2},
+        "sha1",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "md5",
+        42L,
+        "application/octet-stream",
+        "alice",
+        "127.0.0.1",
+        now.minusSeconds(120),
+        now.minusSeconds(60),
+        Map.of());
+  }
+
+  private static final class RecordingTransactionManager implements PlatformTransactionManager {
+    @Override
+    public TransactionStatus getTransaction(TransactionDefinition definition) throws TransactionException {
+      return new SimpleTransactionStatus();
+    }
+
+    @Override
+    public void commit(TransactionStatus status) throws TransactionException {
+    }
+
+    @Override
+    public void rollback(TransactionStatus status) throws TransactionException {
+    }
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/browse/BrowseContentDeleteControllerTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/browse/BrowseContentDeleteControllerTest.java
@@ -1,0 +1,212 @@
+package com.github.klboke.kkrepo.server.browse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.auth.AccessDecision;
+import com.github.klboke.kkrepo.auth.PermissionSubject;
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.mysql.dao.AssetDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.BrowseNodeDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.ComponentDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.MetadataRebuildDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.RepositoryDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.RepositoryIndexRebuildDao;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetRecord;
+import com.github.klboke.kkrepo.persistence.mysql.model.RepositoryRecord;
+import com.github.klboke.kkrepo.server.cache.AssetMetadataCache;
+import com.github.klboke.kkrepo.server.cache.GroupMemberAssetCache;
+import com.github.klboke.kkrepo.server.npm.NpmGroupPackumentCache;
+import com.github.klboke.kkrepo.server.pypi.PypiGroupSimpleIndexCache;
+import com.github.klboke.kkrepo.server.security.AuthenticatedSubject;
+import com.github.klboke.kkrepo.server.security.SecurityAuthenticationService;
+import com.github.klboke.kkrepo.server.security.SecurityManagementService;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.server.ResponseStatusException;
+
+class BrowseContentDeleteControllerTest {
+  @Test
+  void requiresAuthenticationPermissionAndPath() {
+    Fixture unauthenticated = fixture(false, AccessDecision.allow());
+    assertStatus(HttpStatus.UNAUTHORIZED, () -> unauthenticated.controller.delete(
+        "raw", "file.txt", null, new MockHttpServletRequest()));
+
+    Fixture forbidden = fixture(true, AccessDecision.deny("denied"));
+    assertStatus(HttpStatus.FORBIDDEN, () -> forbidden.controller.delete(
+        "raw", "file.txt", null, new MockHttpServletRequest()));
+
+    Fixture blank = fixture(true, AccessDecision.allow());
+    when(blank.repositoryDao.findByName("raw"))
+        .thenReturn(Optional.of(repository(1L, "raw", RepositoryFormat.RAW, RepositoryType.HOSTED)));
+    assertStatus(HttpStatus.BAD_REQUEST, () -> blank.controller.delete(
+        "raw", " / ", null, new MockHttpServletRequest()));
+  }
+
+  @Test
+  void deletesMavenAssetChecksumSiblingAndEnqueuesMetadataRebuilds() {
+    Fixture fixture = fixture(true, AccessDecision.allow());
+    RepositoryRecord repository =
+        repository(1L, "maven", RepositoryFormat.MAVEN2, RepositoryType.HOSTED);
+    String path = "com/acme/app/1.0-SNAPSHOT/app-1.0-SNAPSHOT.jar";
+    AssetRecord jar = asset(11L, 21L, 31L, RepositoryFormat.MAVEN2, path, "artifact", Map.of());
+    AssetRecord sha1 = asset(
+        12L, null, 32L, RepositoryFormat.MAVEN2, path + ".sha1", "checksum", Map.of());
+    when(fixture.repositoryDao.findByName("maven")).thenReturn(Optional.of(repository));
+    when(fixture.assetDao.findAssetByPath(1L, path)).thenReturn(Optional.of(jar));
+    when(fixture.assetDao.findAssetByPath(1L, path + ".sha1")).thenReturn(Optional.of(sha1));
+    when(fixture.assetDao.listAssetsByPrefix(1L, path + "/")).thenReturn(List.of());
+
+    BrowseContentDeleteController.BrowseDeleteResult result = fixture.controller.delete(
+        "maven", "/" + path, null, new MockHttpServletRequest());
+
+    assertEquals(2, result.deletedAssets());
+    verify(fixture.assetDao).deleteAssetById(11L);
+    verify(fixture.assetDao).deleteAssetById(12L);
+    verify(fixture.assetDao).markBlobDeletedIfUnreferenced(31L, "asset unlinked");
+    verify(fixture.componentDao).deleteIfNoAssets(21L);
+    verify(fixture.metadataRebuildDao).enqueue(1L, "ga:com.acme/app");
+    verify(fixture.metadataRebuildDao).enqueue(1L, "gav:com.acme/app/1.0-SNAPSHOT");
+  }
+
+  @Test
+  void validatesExplicitGroupSourceMembership() {
+    Fixture fixture = fixture(true, AccessDecision.allow());
+    RepositoryRecord group =
+        repository(1L, "group", RepositoryFormat.RAW, RepositoryType.GROUP);
+    RepositoryRecord outsider =
+        repository(2L, "outside", RepositoryFormat.RAW, RepositoryType.HOSTED);
+    when(fixture.repositoryDao.findByName("group")).thenReturn(Optional.of(group));
+    when(fixture.repositoryDao.findByName("outside")).thenReturn(Optional.of(outsider));
+    when(fixture.repositoryDao.listMembers(1L)).thenReturn(List.of());
+
+    assertStatus(HttpStatus.BAD_REQUEST, () -> fixture.controller.delete(
+        "group", "file.txt", "outside", new MockHttpServletRequest()));
+    verify(fixture.assetDao, never()).deleteAssetById(anyLong());
+  }
+
+  @Test
+  void invalidatesNpmPackageAndMemberCaches() {
+    Fixture fixture = fixture(true, AccessDecision.allow());
+    RepositoryRecord repository =
+        repository(1L, "npm", RepositoryFormat.NPM, RepositoryType.HOSTED);
+    AssetRecord tarball = asset(
+        11L, 21L, 31L, RepositoryFormat.NPM, "demo/-/demo-1.0.0.tgz", "tarball",
+        Map.of("packageId", "demo"));
+    when(fixture.repositoryDao.findByName("npm")).thenReturn(Optional.of(repository));
+    when(fixture.assetDao.findAssetByPath(1L, "demo/-/demo-1.0.0.tgz"))
+        .thenReturn(Optional.of(tarball));
+    when(fixture.assetDao.listAssetsByPrefix(1L, "demo/-/demo-1.0.0.tgz/"))
+        .thenReturn(List.of());
+
+    fixture.controller.delete(
+        "npm", "demo/-/demo-1.0.0.tgz", null, new MockHttpServletRequest());
+
+    verify(fixture.npmCache).invalidateMemberPackageAfterCommit(1L, "demo");
+    verify(fixture.groupMemberAssetCache).invalidateMemberAfterCommit(1L);
+  }
+
+  @Test
+  void mapsPypiPublicPathAndRebuildsProjectAndRootIndexes() {
+    Fixture fixture = fixture(true, AccessDecision.allow());
+    RepositoryRecord repository =
+        repository(1L, "pypi", RepositoryFormat.PYPI, RepositoryType.HOSTED);
+    String storagePath = "packages/demo-pkg/1.0.0/demo_pkg-1.0.0.whl";
+    AssetRecord wheel = asset(
+        11L, 21L, 31L, RepositoryFormat.PYPI, storagePath, "package",
+        Map.of("normalizedName", "demo-pkg"));
+    when(fixture.repositoryDao.findByName("pypi")).thenReturn(Optional.of(repository));
+    when(fixture.assetDao.findAssetByPath(1L, storagePath)).thenReturn(Optional.of(wheel));
+    when(fixture.assetDao.listAssetsByPrefix(1L, storagePath + "/")).thenReturn(List.of());
+
+    BrowseContentDeleteController.BrowseDeleteResult result = fixture.controller.delete(
+        "pypi", "demo-pkg/1.0.0/demo_pkg-1.0.0.whl", null, new MockHttpServletRequest());
+
+    assertEquals("demo-pkg/1.0.0/demo_pkg-1.0.0.whl", result.path());
+    verify(fixture.indexRebuildDao).enqueue(1L, RepositoryIndexRebuildDao.PYPI_ROOT);
+    verify(fixture.indexRebuildDao).enqueue(
+        1L, RepositoryIndexRebuildDao.PYPI_PROJECT, "demo-pkg");
+    verify(fixture.pypiCache).invalidateMemberProjectAfterCommit(1L, "demo-pkg");
+    verify(fixture.groupMemberAssetCache).invalidateMemberAfterCommit(1L);
+  }
+
+  private static void assertStatus(HttpStatus status, Runnable invocation) {
+    ResponseStatusException error = assertThrows(ResponseStatusException.class, invocation::run);
+    assertEquals(status, error.getStatusCode());
+  }
+
+  private static Fixture fixture(boolean authenticated, AccessDecision decision) {
+    RepositoryDao repositoryDao = mock(RepositoryDao.class);
+    AssetDao assetDao = mock(AssetDao.class);
+    BrowseNodeDao browseNodeDao = mock(BrowseNodeDao.class);
+    ComponentDao componentDao = mock(ComponentDao.class);
+    MetadataRebuildDao metadataRebuildDao = mock(MetadataRebuildDao.class);
+    RepositoryIndexRebuildDao indexRebuildDao = mock(RepositoryIndexRebuildDao.class);
+    SecurityAuthenticationService authentication = mock(SecurityAuthenticationService.class);
+    SecurityManagementService security = mock(SecurityManagementService.class);
+    AssetMetadataCache assetCache = mock(AssetMetadataCache.class);
+    NpmGroupPackumentCache npmCache = mock(NpmGroupPackumentCache.class);
+    PypiGroupSimpleIndexCache pypiCache = mock(PypiGroupSimpleIndexCache.class);
+    GroupMemberAssetCache groupMemberAssetCache = mock(GroupMemberAssetCache.class);
+    PermissionSubject permissionSubject = mock(PermissionSubject.class);
+    AuthenticatedSubject subject =
+        new AuthenticatedSubject("test", "admin", "local", null, permissionSubject);
+    when(authentication.authenticate(any())).thenReturn(
+        authenticated ? Optional.of(subject) : Optional.empty());
+    when(security.decide(permissionSubject, "nexus:*")).thenReturn(decision);
+    BrowseContentDeleteController controller = new BrowseContentDeleteController(
+        repositoryDao, assetDao, browseNodeDao, componentDao, metadataRebuildDao,
+        indexRebuildDao, authentication, security, assetCache, npmCache, pypiCache,
+        groupMemberAssetCache);
+    return new Fixture(
+        repositoryDao, assetDao, browseNodeDao, componentDao, metadataRebuildDao,
+        indexRebuildDao, npmCache, pypiCache, groupMemberAssetCache, controller);
+  }
+
+  private static RepositoryRecord repository(
+      long id, String name, RepositoryFormat format, RepositoryType type) {
+    return new RepositoryRecord(
+        id, name, format, type, name, true, 7L, null, null,
+        null, null, "ALLOW", true, Map.of());
+  }
+
+  private static AssetRecord asset(
+      long id,
+      Long componentId,
+      Long blobId,
+      RepositoryFormat format,
+      String path,
+      String kind,
+      Map<String, Object> attributes) {
+    return new AssetRecord(
+        id, 1L, componentId, blobId, format, path, null,
+        path.substring(path.lastIndexOf('/') + 1), kind, "application/octet-stream",
+        4L, null, Instant.EPOCH, attributes);
+  }
+
+  private record Fixture(
+      RepositoryDao repositoryDao,
+      AssetDao assetDao,
+      BrowseNodeDao browseNodeDao,
+      ComponentDao componentDao,
+      MetadataRebuildDao metadataRebuildDao,
+      RepositoryIndexRebuildDao indexRebuildDao,
+      NpmGroupPackumentCache npmCache,
+      PypiGroupSimpleIndexCache pypiCache,
+      GroupMemberAssetCache groupMemberAssetCache,
+      BrowseContentDeleteController controller) {
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/goartifact/GoAssetWriterTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/goartifact/GoAssetWriterTest.java
@@ -1,0 +1,208 @@
+package com.github.klboke.kkrepo.server.goartifact;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.core.BlobReference;
+import com.github.klboke.kkrepo.core.BlobStorage;
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.mysql.dao.AssetDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.BrowseNodeDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.ComponentDao;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetBlobRecord;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetRecord;
+import com.github.klboke.kkrepo.server.cache.AssetMetadataCache;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import org.junit.jupiter.api.Test;
+
+class GoAssetWriterTest {
+  private static final String PATH = "example.com/acme/demo/@v/v1.2.3.zip";
+
+  @Test
+  void writesNewComponentAssetAndKeepsResponseBody() throws Exception {
+    Fixture fixture = fixture();
+    stubUploadedBlob(fixture);
+    when(fixture.assetDao.findAssetByPath(10L, PATH)).thenReturn(Optional.empty());
+    when(fixture.componentDao.upsertReturningId(any())).thenReturn(3L);
+    when(fixture.assetDao.tryInsertAsset(any())).thenReturn(OptionalLong.of(11L));
+
+    GoAssetWriter.Stored stored = fixture.writer.write(
+        runtime(), fixture.storage, 7L, GoPath.parse(PATH),
+        new ByteArrayInputStream("archive".getBytes(StandardCharsets.UTF_8)), Map.of(), true);
+
+    assertEquals(11L, stored.asset().id());
+    assertEquals("example.com/acme/demo", stored.asset().attributes().get("module"));
+    assertEquals("v1.2.3", stored.asset().attributes().get("version"));
+    assertEquals("archive",
+        new String(stored.openBody().readAllBytes(), StandardCharsets.UTF_8));
+    verify(fixture.componentDao).upsertReturningId(any());
+    verify(fixture.browseNodeDao).upsertPathAncestors(10L, PATH, 11L, 3L);
+    verify(fixture.cache).evictAfterCommit(10L, PATH);
+  }
+
+  @Test
+  void updatesExistingAssetAndMarksPreviousBlobDeleted() {
+    Fixture fixture = fixture();
+    stubUploadedBlob(fixture);
+    AssetRecord existing = asset(11L, 99L);
+    when(fixture.assetDao.findAssetByPath(10L, PATH)).thenReturn(Optional.of(existing));
+    when(fixture.componentDao.upsertReturningId(any())).thenReturn(3L);
+
+    GoAssetWriter.Stored stored = fixture.writer.write(
+        runtime(), fixture.storage, 7L, GoPath.parse(PATH),
+        new ByteArrayInputStream("archive".getBytes(StandardCharsets.UTF_8)), Map.of());
+
+    assertEquals(2L, stored.asset().assetBlobId());
+    verify(fixture.assetDao).updateAssetBlobBindingAndMetadata(
+        eq(11L), eq(3L), eq(2L), eq("PACKAGE"), eq("application/zip"),
+        eq(7L), any(Instant.class), any());
+    verify(fixture.assetDao).markBlobDeletedIfUnreferenced(99L, "asset replaced");
+  }
+
+  @Test
+  void recoversFromConcurrentAssetInsert() {
+    Fixture fixture = fixture();
+    stubUploadedBlob(fixture);
+    AssetRecord winner = asset(12L, 88L);
+    when(fixture.assetDao.findAssetByPath(10L, PATH))
+        .thenReturn(Optional.empty(), Optional.of(winner));
+    when(fixture.componentDao.upsertReturningId(any())).thenReturn(3L);
+    when(fixture.assetDao.tryInsertAsset(any())).thenReturn(OptionalLong.empty());
+
+    GoAssetWriter.Stored stored = fixture.writer.write(
+        runtime(), fixture.storage, 7L, GoPath.parse(PATH),
+        new ByteArrayInputStream("archive".getBytes(StandardCharsets.UTF_8)), Map.of());
+
+    assertEquals(12L, stored.asset().id());
+    verify(fixture.assetDao).updateAssetBlobBindingAndMetadata(
+        eq(12L), eq(3L), eq(2L), anyString(), anyString(), eq(7L), any(), any());
+    verify(fixture.assetDao).markBlobDeletedIfUnreferenced(88L, "asset replaced");
+  }
+
+  @Test
+  void reusesExistingBlobWithoutUploadingAndRecoversDeletedBlobForRemoteAttributes() {
+    Fixture reusable = fixture();
+    AssetBlobRecord blob = blob(5L, "object");
+    when(reusable.assetDao.findReusableBlobBySha256(eq(7L), anyString(), eq(7L)))
+        .thenReturn(Optional.of(blob));
+    when(reusable.assetDao.findAssetByPath(10L, PATH)).thenReturn(Optional.empty());
+    when(reusable.componentDao.upsertReturningId(any())).thenReturn(3L);
+    when(reusable.assetDao.tryInsertAsset(any())).thenReturn(OptionalLong.of(11L));
+
+    GoAssetWriter.Stored reused = reusable.writer.write(
+        runtime(), reusable.storage, 7L, GoPath.parse(PATH),
+        new ByteArrayInputStream("archive".getBytes(StandardCharsets.UTF_8)), Map.of());
+    assertEquals(5L, reused.blob().id());
+    verify(reusable.storage, never()).putFile(anyString(), anyString(), any(), anyString());
+
+    Fixture recovered = fixture();
+    BlobReference uploaded = new BlobReference("bucket", "uploaded", "sha256", 7L);
+    when(recovered.storage.putFile(eq("go"), eq(PATH), any(Path.class), anyString()))
+        .thenReturn(uploaded);
+    when(recovered.assetDao.recoverDeletedBlobBySha256(eq(7L), anyString(), eq(7L)))
+        .thenReturn(Optional.of(blob));
+    when(recovered.assetDao.findAssetByPath(10L, PATH)).thenReturn(Optional.empty());
+    when(recovered.componentDao.upsertReturningId(any())).thenReturn(3L);
+    when(recovered.assetDao.tryInsertAsset(any())).thenReturn(OptionalLong.of(11L));
+    when(recovered.assetDao.hasLiveBlobForObjectKeyHash(eq(7L), any())).thenReturn(false);
+
+    GoAssetWriter.Stored restored = recovered.writer.write(
+        runtime(), recovered.storage, 7L, GoPath.parse(PATH),
+        new ByteArrayInputStream("archive".getBytes(StandardCharsets.UTF_8)),
+        Map.of("remoteEtag", "etag"));
+
+    assertEquals("etag", restored.blob().attributes().get("remoteEtag"));
+    verify(recovered.assetDao).updateBlobAttributes(5L, Map.of("remoteEtag", "etag"));
+    verify(recovered.storage).delete(uploaded);
+  }
+
+  @Test
+  void cleansUploadedBlobWhenMetadataPersistenceFails() {
+    Fixture fixture = fixture();
+    BlobReference uploaded = new BlobReference("bucket", "uploaded", "sha256", 7L);
+    when(fixture.assetDao.findReusableBlobBySha256(eq(7L), anyString(), eq(7L)))
+        .thenReturn(Optional.empty());
+    when(fixture.storage.putFile(eq("go"), eq(PATH), any(Path.class), anyString()))
+        .thenReturn(uploaded);
+    when(fixture.assetDao.findAssetByPath(10L, PATH)).thenReturn(Optional.empty());
+    when(fixture.assetDao.insertBlobOrFindExisting(any()))
+        .thenThrow(new IllegalStateException("database unavailable"));
+    when(fixture.assetDao.hasLiveBlobForObjectKeyHash(eq(7L), any())).thenReturn(false);
+
+    assertThrows(IllegalStateException.class, () -> fixture.writer.write(
+        runtime(), fixture.storage, 7L, GoPath.parse(PATH),
+        new ByteArrayInputStream("archive".getBytes(StandardCharsets.UTF_8)), Map.of()));
+
+    verify(fixture.storage).delete(uploaded);
+  }
+
+  private static void stubUploadedBlob(Fixture fixture) {
+    when(fixture.assetDao.findReusableBlobBySha256(eq(7L), anyString(), anyLong()))
+        .thenReturn(Optional.empty());
+    when(fixture.storage.putFile(eq("go"), anyString(), any(Path.class), anyString()))
+        .thenAnswer(invocation -> new BlobReference(
+            "bucket", invocation.getArgument(1), invocation.getArgument(3), 7L));
+    when(fixture.assetDao.insertBlobOrFindExisting(any()))
+        .thenAnswer(invocation -> ((AssetBlobRecord) invocation.getArgument(0)).withId(2L));
+  }
+
+  private static Fixture fixture() {
+    AssetDao assetDao = mock(AssetDao.class);
+    ComponentDao componentDao = mock(ComponentDao.class);
+    BrowseNodeDao browseNodeDao = mock(BrowseNodeDao.class);
+    AssetMetadataCache cache = mock(AssetMetadataCache.class);
+    BlobStorage storage = mock(BlobStorage.class);
+    return new Fixture(
+        assetDao, componentDao, browseNodeDao, cache, storage,
+        new GoAssetWriter(assetDao, componentDao, browseNodeDao, cache, null));
+  }
+
+  private static RepositoryRuntime runtime() {
+    return new RepositoryRuntime(
+        10L, "go", RepositoryFormat.GO, RepositoryType.PROXY, "go", true, 7L,
+        null, null, null, true, "https://proxy.golang.org/",
+        60, 60, true, null, List.of());
+  }
+
+  private static AssetRecord asset(long id, long blobId) {
+    return new AssetRecord(
+        id, 10L, 3L, blobId, RepositoryFormat.GO, PATH, null,
+        "v1.2.3.zip", "PACKAGE", "application/zip", 7L,
+        null, Instant.EPOCH, Map.of());
+  }
+
+  private static AssetBlobRecord blob(long id, String objectKey) {
+    return new AssetBlobRecord(
+        id, 7L, "blob://bucket/" + objectKey, null, objectKey, null,
+        "sha1", "sha256", "md5", 7L, "application/zip", "proxy", "upstream",
+        Instant.EPOCH, Instant.EPOCH, Map.of());
+  }
+
+  private record Fixture(
+      AssetDao assetDao,
+      ComponentDao componentDao,
+      BrowseNodeDao browseNodeDao,
+      AssetMetadataCache cache,
+      BlobStorage storage,
+      GoAssetWriter writer) {
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/goartifact/GoGroupServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/goartifact/GoGroupServiceTest.java
@@ -1,0 +1,72 @@
+package com.github.klboke.kkrepo.server.goartifact;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.server.maven.MavenExceptions;
+import com.github.klboke.kkrepo.server.maven.MavenResponse;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class GoGroupServiceTest {
+  @Test
+  void returnsFirstSuccessfulProxyMemberAfterMissesAndFailures() {
+    GoProxyService proxy = mock(GoProxyService.class);
+    RepositoryRuntime miss = runtime(2L, "miss", RepositoryType.PROXY, List.of());
+    RepositoryRuntime failed = runtime(3L, "failed", RepositoryType.PROXY, List.of());
+    RepositoryRuntime success = runtime(4L, "success", RepositoryType.PROXY, List.of());
+    MavenResponse expected = MavenResponse.noBody(200);
+    when(proxy.get(miss, "example.com/demo/@latest", true))
+        .thenThrow(new MavenExceptions.MavenNotFoundException("missing"));
+    when(proxy.get(failed, "example.com/demo/@latest", true))
+        .thenThrow(new MavenExceptions.BadUpstreamException("offline"));
+    when(proxy.get(success, "example.com/demo/@latest", true)).thenReturn(expected);
+
+    MavenResponse response = new GoGroupService(proxy).get(
+        runtime(1L, "group", RepositoryType.GROUP, List.of(miss, failed, success)),
+        "example.com/demo/@latest", true);
+
+    assertSame(expected, response);
+  }
+
+  @Test
+  void supportsNestedGroupsAndSkipsHostedMembers() {
+    GoProxyService proxy = mock(GoProxyService.class);
+    RepositoryRuntime hosted = runtime(2L, "hosted", RepositoryType.HOSTED, List.of());
+    RepositoryRuntime success = runtime(3L, "success", RepositoryType.PROXY, List.of());
+    RepositoryRuntime nested = runtime(4L, "nested", RepositoryType.GROUP, List.of(hosted, success));
+    MavenResponse expected = MavenResponse.noBody(200);
+    when(proxy.get(success, "example.com/demo/@v/list", false)).thenReturn(expected);
+
+    assertSame(expected, new GoGroupService(proxy).get(
+        runtime(1L, "group", RepositoryType.GROUP, List.of(nested)),
+        "example.com/demo/@v/list", false));
+  }
+
+  @Test
+  void rejectsNonGroupsAndEmptyOrExhaustedGroups() {
+    GoGroupService service = new GoGroupService(mock(GoProxyService.class));
+    assertThrows(IllegalStateException.class,
+        () -> service.get(runtime(1L, "proxy", RepositoryType.PROXY, List.of()), "x", false));
+    assertThrows(MavenExceptions.MavenNotFoundException.class,
+        () -> service.get(runtime(1L, "empty", RepositoryType.GROUP, List.of()), "x", false));
+    assertThrows(MavenExceptions.MavenNotFoundException.class,
+        () -> service.get(
+            runtime(1L, "hosted-only", RepositoryType.GROUP,
+                List.of(runtime(2L, "hosted", RepositoryType.HOSTED, List.of()))),
+            "x", false));
+  }
+
+  private static RepositoryRuntime runtime(
+      long id, String name, RepositoryType type, List<RepositoryRuntime> members) {
+    return new RepositoryRuntime(
+        id, name, RepositoryFormat.GO, type, name, true, 7L,
+        null, null, null, true, "https://proxy.golang.org/",
+        60, 60, true, null, members);
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/goartifact/GoPathTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/goartifact/GoPathTest.java
@@ -1,0 +1,52 @@
+package com.github.klboke.kkrepo.server.goartifact;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class GoPathTest {
+  @Test
+  void parsesLatestListAndVersionedPaths() {
+    GoPath latest = GoPath.parse("/example.com/acme/demo/@latest");
+    GoPath list = GoPath.parse("example.com/acme/demo/@v/list");
+    GoPath info = GoPath.parse("example.com/acme/demo/@v/v1.2.3.info");
+    GoPath module = GoPath.parse("example.com/acme/demo/@v/v1.2.3.mod");
+    GoPath archive = GoPath.parse("example.com/acme/demo/@v/v1.2.3.zip");
+
+    assertEquals(GoAssetKind.LATEST, latest.kind());
+    assertEquals(GoAssetKind.LIST, list.kind());
+    assertEquals("v1.2.3", info.version());
+    assertEquals(GoAssetKind.MODULE, module.kind());
+    assertEquals("v1.2.3.zip", archive.fileName());
+    assertTrue(archive.hasComponent());
+    assertFalse(list.hasComponent());
+  }
+
+  @Test
+  void exposesProtocolContentTypesAndMetadataKinds() {
+    assertEquals("application/zip",
+        GoPath.parse("example.com/demo/@v/v1.0.0.zip").contentType());
+    assertEquals("application/json",
+        GoPath.parse("example.com/demo/@v/list").contentType());
+    assertEquals("text/plain",
+        GoPath.parse("example.com/demo/@v/v1.0.0.mod").contentType());
+    assertFalse(GoPath.parse("example.com/demo/@v/v1.0.0.zip").metadata());
+    assertTrue(GoPath.parse("example.com/demo/@latest").metadata());
+  }
+
+  @Test
+  void rejectsMalformedAndUnsupportedPaths() {
+    assertThrows(IllegalArgumentException.class, () -> GoPath.parse(null));
+    assertThrows(IllegalArgumentException.class, () -> GoPath.parse("example.com/demo/"));
+    assertThrows(IllegalArgumentException.class, () -> GoPath.parse("example.com/demo"));
+    assertThrows(IllegalArgumentException.class,
+        () -> GoPath.parse("example.com/demo/@v/version"));
+    assertThrows(IllegalArgumentException.class,
+        () -> GoPath.parse("example.com/demo/@v/v1.0.0.txt"));
+    assertThrows(IllegalArgumentException.class,
+        () -> GoPath.parse("example.com/@v/demo/@v/v1.0.0.mod"));
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/goartifact/GoProxyServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/goartifact/GoProxyServiceTest.java
@@ -1,0 +1,235 @@
+package com.github.klboke.kkrepo.server.goartifact;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.core.BlobStorage;
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.mysql.dao.AssetDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.ProxyStateDao;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetBlobRecord;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetRecord;
+import com.github.klboke.kkrepo.server.cache.AssetMetadataCache;
+import com.github.klboke.kkrepo.server.cache.CachedAssetMetadata;
+import com.github.klboke.kkrepo.server.maven.BlobStorageRegistry;
+import com.github.klboke.kkrepo.server.maven.HttpRemoteFetcher;
+import com.github.klboke.kkrepo.server.maven.MavenExceptions;
+import com.github.klboke.kkrepo.server.maven.MavenResponse;
+import com.github.klboke.kkrepo.server.maven.ProxyNegativeCache;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class GoProxyServiceTest {
+  private static final String PATH = "example.com/acme/demo/@v/v1.2.3.mod";
+
+  @Test
+  void servesFreshCachedBodyAndMissingPhysicalBlob() throws Exception {
+    Fixture fixture = fixture();
+    CachedAssetMetadata cached = snapshot(PATH, Instant.now(), Map.of("remoteEtag", "etag"));
+    when(fixture.cache.find(eq(10L), eq(PATH), any())).thenReturn(Optional.of(cached));
+    when(fixture.registry.forBlobStoreId(7L)).thenReturn(fixture.storage);
+    when(fixture.storage.get(any())).thenReturn(Optional.of(
+        new ByteArrayInputStream("module demo".getBytes(StandardCharsets.UTF_8))));
+
+    MavenResponse response = fixture.service.get(runtime(60, 7L), PATH, false);
+    assertEquals("module demo",
+        new String(response.body().readAllBytes(), StandardCharsets.UTF_8));
+    verify(fixture.fetcher, never()).fetchWithBodyRetry(any(), anyString(), any());
+
+    when(fixture.storage.get(any())).thenReturn(Optional.empty());
+    assertThrows(MavenExceptions.MavenNotFoundException.class,
+        () -> fixture.service.get(runtime(60, 7L), PATH, false).body());
+  }
+
+  @Test
+  void honorsNegativeCacheAndBlockedUpstreamFallback() {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(1, 7L);
+    when(fixture.cache.find(eq(10L), eq(PATH), any())).thenReturn(Optional.empty());
+    when(fixture.negativeCache.isNotFoundCached(runtime, PATH)).thenReturn(true);
+    assertThrows(MavenExceptions.MavenNotFoundException.class,
+        () -> fixture.service.get(runtime, PATH, false));
+
+    CachedAssetMetadata stale = snapshot(PATH, Instant.EPOCH, Map.of());
+    when(fixture.cache.find(eq(10L), eq(PATH), any())).thenReturn(Optional.of(stale));
+    when(fixture.negativeCache.isNotFoundCached(runtime, PATH)).thenReturn(false);
+    when(fixture.proxyStateDao.isBlocked(eq(10L), any())).thenReturn(true);
+    when(fixture.registry.forBlobStoreId(7L)).thenReturn(fixture.storage);
+    MavenResponse response = fixture.service.get(runtime, PATH, true);
+    assertEquals(200, response.status());
+
+    when(fixture.cache.find(eq(10L), eq(PATH), any())).thenReturn(Optional.empty());
+    assertThrows(MavenExceptions.BadUpstreamException.class,
+        () -> fixture.service.get(runtime, PATH, false));
+  }
+
+  @Test
+  void cachesSuccessfulHeadResponseAndPassesRemoteAttributes() throws Exception {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(1, 7L);
+    when(fixture.cache.find(eq(10L), eq(PATH), any())).thenReturn(Optional.empty());
+    when(fixture.registry.forBlobStoreId(7L)).thenReturn(fixture.storage);
+    AtomicReference<HttpRemoteFetcher.Request> request = new AtomicReference<>();
+    doAnswer(invocation -> {
+      request.set(invocation.getArgument(0));
+      @SuppressWarnings("unchecked")
+      HttpRemoteFetcher.ResultHandler<MavenResponse> handler = invocation.getArgument(2);
+      return handler.handle(new HttpRemoteFetcher.Result(
+          200,
+          Map.of(
+              "Content-Type", "text/plain",
+              "ETag", "\"remote\"",
+              "Last-Modified", "Wed, 01 Jan 2025 00:00:00 GMT"),
+          new ByteArrayInputStream("module demo".getBytes(StandardCharsets.UTF_8))));
+    }).when(fixture.fetcher).fetchWithBodyRetry(any(), eq(PATH), any());
+    GoAssetWriter.Stored stored = stored(PATH, Map.of(
+        "remoteEtag", "\"remote\"",
+        "remoteLastModified", "2025-01-01T00:00:00Z"));
+    when(fixture.writer.write(
+        eq(runtime), eq(fixture.storage), eq(7L), any(GoPath.class), any(), any(), eq(false)))
+        .thenReturn(stored);
+
+    MavenResponse response = fixture.service.get(runtime, PATH, true);
+
+    assertEquals(200, response.status());
+    assertEquals("https://proxy.golang.org/" + PATH, request.get().url());
+    assertEquals("\"remote\"", response.etag());
+    verify(fixture.proxyStateDao).recordSuccess(eq(10L), any());
+    verify(fixture.negativeCache).invalidate(runtime, PATH);
+  }
+
+  @Test
+  void handlesNotModifiedAndRemoteMisses() throws Exception {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(1, 7L);
+    CachedAssetMetadata stale = snapshot(PATH, Instant.EPOCH, Map.of());
+    when(fixture.cache.find(eq(10L), eq(PATH), any())).thenReturn(Optional.of(stale));
+    when(fixture.registry.forBlobStoreId(7L)).thenReturn(fixture.storage);
+    respond(fixture.fetcher, new HttpRemoteFetcher.Result(
+        304, Map.of(), new ByteArrayInputStream(new byte[0])));
+
+    assertEquals(200, fixture.service.get(runtime, PATH, true).status());
+    verify(fixture.assetDao).touchAssetLastUpdated(eq(1L), any());
+    verify(fixture.cache).touchVerified(eq(10L), eq(PATH), any());
+
+    Fixture missing = fixture();
+    when(missing.cache.find(eq(10L), eq(PATH), any())).thenReturn(Optional.empty());
+    respond(missing.fetcher, new HttpRemoteFetcher.Result(
+        404, Map.of(), new ByteArrayInputStream(new byte[0])));
+    assertThrows(MavenExceptions.MavenNotFoundException.class,
+        () -> missing.service.get(runtime, PATH, false));
+    verify(missing.negativeCache).rememberNotFound(runtime, PATH);
+  }
+
+  @Test
+  void fallsBackToStaleOnFailuresAndValidatesRuntime() throws Exception {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(1, 7L);
+    CachedAssetMetadata stale = snapshot(PATH, Instant.EPOCH, Map.of());
+    when(fixture.cache.find(eq(10L), eq(PATH), any())).thenReturn(Optional.of(stale));
+    when(fixture.registry.forBlobStoreId(7L)).thenReturn(fixture.storage);
+    respond(fixture.fetcher, new HttpRemoteFetcher.Result(
+        503, Map.of(), new ByteArrayInputStream(new byte[0])));
+    assertEquals(200, fixture.service.get(runtime, PATH, true).status());
+    verify(fixture.proxyStateDao).recordFailure(eq(10L), eq(30L), anyString(), any());
+
+    assertThrows(MavenExceptions.MethodNotAllowed.class,
+        () -> fixture.service.get(
+            new RepositoryRuntime(
+                10L, "go", RepositoryFormat.GO, RepositoryType.HOSTED, "go", true, 7L,
+                null, null, null, true, null, 1, 1, true, null, List.of()),
+            PATH, false));
+    assertThrows(MavenExceptions.MavenNotFoundException.class,
+        () -> fixture.service.get(runtime, "invalid", false));
+
+    Fixture noStore = fixture();
+    when(noStore.cache.find(eq(10L), eq(PATH), any())).thenReturn(Optional.empty());
+    respond(noStore.fetcher, new HttpRemoteFetcher.Result(
+        200, Map.of(), new ByteArrayInputStream("module demo".getBytes(StandardCharsets.UTF_8))));
+    assertThrows(IllegalStateException.class,
+        () -> noStore.service.get(runtime(1, null), PATH, false));
+  }
+
+  private static void respond(HttpRemoteFetcher fetcher, HttpRemoteFetcher.Result result)
+      throws IOException {
+    doAnswer(invocation -> {
+      @SuppressWarnings("unchecked")
+      HttpRemoteFetcher.ResultHandler<MavenResponse> handler = invocation.getArgument(2);
+      return handler.handle(result);
+    }).when(fetcher).fetchWithBodyRetry(any(), anyString(), any());
+  }
+
+  private static Fixture fixture() {
+    AssetDao assetDao = mock(AssetDao.class);
+    BlobStorageRegistry registry = mock(BlobStorageRegistry.class);
+    GoAssetWriter writer = mock(GoAssetWriter.class);
+    ProxyStateDao proxyStateDao = mock(ProxyStateDao.class);
+    HttpRemoteFetcher fetcher = mock(HttpRemoteFetcher.class);
+    ProxyNegativeCache negativeCache = mock(ProxyNegativeCache.class);
+    AssetMetadataCache cache = mock(AssetMetadataCache.class);
+    BlobStorage storage = mock(BlobStorage.class);
+    return new Fixture(
+        assetDao, registry, writer, proxyStateDao, fetcher, negativeCache, cache, storage,
+        new GoProxyService(
+            assetDao, registry, writer, proxyStateDao, fetcher, negativeCache, cache));
+  }
+
+  private static RepositoryRuntime runtime(int maxAgeMinutes, Long blobStoreId) {
+    return new RepositoryRuntime(
+        10L, "go", RepositoryFormat.GO, RepositoryType.PROXY, "go", true, blobStoreId,
+        null, null, null, true, "https://proxy.golang.org/",
+        maxAgeMinutes, maxAgeMinutes, true, null, List.of());
+  }
+
+  private static CachedAssetMetadata snapshot(
+      String path, Instant updatedAt, Map<String, Object> blobAttributes) {
+    AssetRecord asset = new AssetRecord(
+        1L, 10L, 3L, 2L, RepositoryFormat.GO, path, null,
+        "v1.2.3.mod", "MODULE", "text/plain", 11L, null, updatedAt, Map.of());
+    return CachedAssetMetadata.of(asset, blob(blobAttributes));
+  }
+
+  private static GoAssetWriter.Stored stored(String path, Map<String, Object> attributes) {
+    AssetRecord asset = new AssetRecord(
+        1L, 10L, 3L, 2L, RepositoryFormat.GO, path, null,
+        "v1.2.3.mod", "MODULE", "text/plain", 11L, null, Instant.now(), Map.of());
+    return new GoAssetWriter.Stored(asset, blob(attributes), null);
+  }
+
+  private static AssetBlobRecord blob(Map<String, Object> attributes) {
+    return new AssetBlobRecord(
+        2L, 7L, "blob://bucket/object", null, "object", null,
+        "sha1", "sha256", "md5", 11L, "text/plain", "proxy", "upstream",
+        Instant.EPOCH, Instant.EPOCH, attributes);
+  }
+
+  private record Fixture(
+      AssetDao assetDao,
+      BlobStorageRegistry registry,
+      GoAssetWriter writer,
+      ProxyStateDao proxyStateDao,
+      HttpRemoteFetcher fetcher,
+      ProxyNegativeCache negativeCache,
+      AssetMetadataCache cache,
+      BlobStorage storage,
+      GoProxyService service) {
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/helm/HelmAssetReaderTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/helm/HelmAssetReaderTest.java
@@ -1,0 +1,104 @@
+package com.github.klboke.kkrepo.server.helm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.core.BlobReference;
+import com.github.klboke.kkrepo.core.BlobStorage;
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.persistence.mysql.dao.AssetDao;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetBlobRecord;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetRecord;
+import com.github.klboke.kkrepo.server.cache.AssetMetadataCache;
+import com.github.klboke.kkrepo.server.cache.CachedAssetMetadata;
+import com.github.klboke.kkrepo.server.maven.BlobStorageRegistry;
+import com.github.klboke.kkrepo.server.maven.MavenExceptions;
+import com.github.klboke.kkrepo.server.maven.MavenResponse;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class HelmAssetReaderTest {
+  @Test
+  void servesHeadWithoutOpeningStorage() {
+    AssetDao assetDao = mock(AssetDao.class);
+    BlobStorageRegistry registry = mock(BlobStorageRegistry.class);
+    when(assetDao.findBlobById(2L)).thenReturn(Optional.of(blob()));
+
+    MavenResponse response = new HelmAssetReader(
+        assetDao, registry, mock(AssetMetadataCache.class))
+        .serve(asset(), true, "demo-1.0.0.tgz");
+
+    assertEquals(200, response.status());
+    assertFalse(response.hasBody());
+    assertEquals(4, response.contentLength());
+    assertEquals("application/gzip", response.contentType());
+    assertEquals("sha1", response.etag());
+    verify(registry, never()).forBlobStoreId(7L);
+  }
+
+  @Test
+  void lazilyStreamsSnapshotBody() throws Exception {
+    BlobStorageRegistry registry = mock(BlobStorageRegistry.class);
+    BlobStorage storage = mock(BlobStorage.class);
+    when(registry.forBlobStoreId(7L)).thenReturn(storage);
+    when(storage.get(any(BlobReference.class)))
+        .thenReturn(Optional.of(new ByteArrayInputStream("body".getBytes(StandardCharsets.UTF_8))));
+    HelmAssetReader reader = new HelmAssetReader(
+        mock(AssetDao.class), registry, mock(AssetMetadataCache.class));
+
+    MavenResponse response = reader.serveSnapshot(
+        CachedAssetMetadata.of(asset(), blob()), false, "demo-1.0.0.tgz");
+
+    assertTrue(response.hasBody());
+    assertEquals("body", new String(response.body().readAllBytes(), StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void reportsMissingMetadataAndPhysicalBlob() {
+    AssetDao assetDao = mock(AssetDao.class);
+    BlobStorageRegistry registry = mock(BlobStorageRegistry.class);
+    HelmAssetReader reader = new HelmAssetReader(
+        assetDao, registry, mock(AssetMetadataCache.class));
+    AssetRecord missingBinding = new AssetRecord(
+        1L, 10L, null, null, RepositoryFormat.HELM, "missing.tgz", null,
+        "missing.tgz", "PACKAGE", "application/gzip", 4L, null, Instant.EPOCH, Map.of());
+
+    assertThrows(MavenExceptions.MavenNotFoundException.class,
+        () -> reader.serve(missingBinding, false, "missing.tgz"));
+    assertThrows(MavenExceptions.MavenNotFoundException.class,
+        () -> reader.serveSnapshot(
+            CachedAssetMetadata.of(missingBinding, null), false, "missing.tgz"));
+
+    when(assetDao.findBlobById(2L)).thenReturn(Optional.of(blob()));
+    BlobStorage storage = mock(BlobStorage.class);
+    when(registry.forBlobStoreId(7L)).thenReturn(storage);
+    when(storage.get(any(BlobReference.class))).thenReturn(Optional.empty());
+    MavenResponse response = reader.serve(asset(), false, "demo-1.0.0.tgz");
+    assertThrows(MavenExceptions.MavenNotFoundException.class, response::body);
+  }
+
+  private static AssetRecord asset() {
+    return new AssetRecord(
+        1L, 10L, 3L, 2L, RepositoryFormat.HELM, "demo-1.0.0.tgz", null,
+        "demo-1.0.0.tgz", "PACKAGE", "application/gzip", 4L, null,
+        Instant.parse("2026-07-13T00:00:00Z"), Map.of("name", "demo", "version", "1.0.0"));
+  }
+
+  private static AssetBlobRecord blob() {
+    return new AssetBlobRecord(
+        2L, 7L, "blob://bucket/demo.tgz", null, "demo.tgz", null,
+        "sha1", "sha256", "md5", 4, "application/gzip", "user", "127.0.0.1",
+        Instant.EPOCH, Instant.EPOCH, Map.of());
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/helm/HelmAssetWriterTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/helm/HelmAssetWriterTest.java
@@ -1,0 +1,215 @@
+package com.github.klboke.kkrepo.server.helm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.core.BlobReference;
+import com.github.klboke.kkrepo.core.BlobStorage;
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.mysql.dao.AssetDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.BrowseNodeDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.ComponentDao;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetBlobRecord;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetRecord;
+import com.github.klboke.kkrepo.protocol.helm.HelmAssetKind;
+import com.github.klboke.kkrepo.server.cache.AssetMetadataCache;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.zip.GZIPOutputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class HelmAssetWriterTest {
+  @Test
+  void writesChartPackageWithParsedMetadataAndDigests() throws Exception {
+    Fixture fixture = fixture();
+    byte[] chart = chartPackage("demo", "1.2.3");
+    stubNewAsset(fixture, "demo-1.2.3.tgz");
+
+    HelmAssetWriter.Stored stored = fixture.writer.write(
+        runtime(), fixture.storage, 7L, "demo-1.2.3.tgz",
+        new ByteArrayInputStream(chart), null, HelmAssetKind.PACKAGE, null,
+        Map.of("remoteUrl", "https://example.test/demo.tgz"), Map.of(),
+        "user", "127.0.0.1");
+
+    assertTrue(stored.created());
+    assertEquals("demo", stored.asset().attributes().get("name"));
+    assertEquals("1.2.3", stored.asset().attributes().get("version"));
+    assertEquals("PACKAGE", stored.asset().attributes().get("asset_kind"));
+    assertEquals("https://example.test/demo.tgz", stored.asset().attributes().get("remoteUrl"));
+    assertEquals(chart.length, stored.digests().size());
+    assertNotNull(stored.digests().sha256());
+    verify(fixture.componentDao).upsertReturningId(any());
+    verify(fixture.browseNodeDao).upsertPathAncestors(10L, "demo-1.2.3.tgz", 11L, 3L);
+    verify(fixture.cache).evictAfterCommit(10L, "demo-1.2.3.tgz");
+  }
+
+  @Test
+  void parsesProvenanceCoordinatesAndUpdatesExistingAsset() {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime();
+    AssetRecord existing = new AssetRecord(
+        11L, runtime.id(), 3L, 99L, RepositoryFormat.HELM, "demo-1.2.3.tgz.prov", null,
+        "demo-1.2.3.tgz.prov", "PROVENANCE", "application/octet-stream", 1L,
+        null, Instant.EPOCH, Map.of());
+    when(fixture.assetDao.findAssetByPath(runtime.id(), "demo-1.2.3.tgz.prov"))
+        .thenReturn(Optional.of(existing));
+    stubBlobPersistence(fixture);
+    byte[] provenance = """
+        apiVersion: v2
+        name: demo
+        version: 1.2.3
+        -----BEGIN PGP SIGNATURE-----
+        ignored: true
+        """.getBytes(StandardCharsets.UTF_8);
+
+    HelmAssetWriter.Stored stored = fixture.writer.write(
+        runtime, fixture.storage, 7L, "demo-1.2.3.tgz.prov",
+        new ByteArrayInputStream(provenance), null, HelmAssetKind.PROVENANCE, null,
+        Map.of(), Map.of("remoteEtag", "etag"), "proxy", "upstream");
+
+    assertFalse(stored.created());
+    assertEquals("demo", stored.asset().attributes().get("name"));
+    assertEquals("1.2.3", stored.asset().attributes().get("version"));
+    verify(fixture.assetDao).updateAssetBlobBindingAndMetadata(
+        eq(11L), eq(3L), eq(2L), eq("PROVENANCE"), eq("application/octet-stream"),
+        eq((long) provenance.length), any(Instant.class), any());
+    verify(fixture.assetDao).markBlobDeletedIfUnreferenced(99L, "asset replaced");
+  }
+
+  @Test
+  void cleansUploadedBlobWhenMetadataPersistenceFails() throws Exception {
+    Fixture fixture = fixture();
+    byte[] chart = chartPackage("demo", "1.0.0");
+    when(fixture.assetDao.findReusableBlobBySha256(eq(7L), anyString(), eq((long) chart.length)))
+        .thenReturn(Optional.empty());
+    when(fixture.storage.putFile(eq("helm"), eq("demo-1.0.0.tgz"), any(Path.class), anyString()))
+        .thenReturn(new BlobReference("bucket", "uploaded.tgz", "sha256", chart.length));
+    when(fixture.assetDao.insertBlobOrFindExisting(any()))
+        .thenThrow(new IllegalStateException("database unavailable"));
+    when(fixture.assetDao.hasLiveBlobForObjectKeyHash(eq(7L), any())).thenReturn(false);
+
+    assertThrows(IllegalStateException.class, () -> fixture.writer.write(
+        runtime(), fixture.storage, 7L, "demo-1.0.0.tgz",
+        new ByteArrayInputStream(chart), null, HelmAssetKind.PACKAGE, null,
+        Map.of(), Map.of(), "user", "127.0.0.1"));
+
+    verify(fixture.storage).delete(
+        new BlobReference("bucket", "uploaded.tgz", "sha256", chart.length));
+  }
+
+  @Test
+  void deletesMetadataAndUnreferencedBlob() {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime();
+    AssetRecord existing = new AssetRecord(
+        11L, runtime.id(), 3L, 2L, RepositoryFormat.HELM, "demo-1.0.0.tgz", null,
+        "demo-1.0.0.tgz", "PACKAGE", "application/gzip", 4L,
+        null, Instant.EPOCH, Map.of());
+    when(fixture.assetDao.findAssetByPath(runtime.id(), "demo-1.0.0.tgz"))
+        .thenReturn(Optional.of(existing));
+
+    assertEquals(1, fixture.writer.deleteAsset(runtime, fixture.storage, "demo-1.0.0.tgz"));
+    assertEquals(0, fixture.writer.deleteAsset(runtime, fixture.storage, "missing.tgz"));
+
+    verify(fixture.browseNodeDao).deleteByAssetId(11L);
+    verify(fixture.assetDao).deleteAssetById(11L);
+    verify(fixture.assetDao).markBlobDeletedIfUnreferenced(2L, "asset unlinked");
+    verify(fixture.componentDao).deleteIfNoAssets(3L);
+    verify(fixture.cache).evictAfterCommit(runtime.id(), "demo-1.0.0.tgz");
+    verify(fixture.storage, never()).delete(any());
+  }
+
+  private static void stubNewAsset(Fixture fixture, String path) {
+    when(fixture.assetDao.findAssetByPath(10L, path)).thenReturn(Optional.empty());
+    stubBlobPersistence(fixture);
+    when(fixture.componentDao.upsertReturningId(any())).thenReturn(3L);
+    when(fixture.assetDao.tryInsertAsset(any())).thenReturn(OptionalLong.of(11L));
+  }
+
+  private static void stubBlobPersistence(Fixture fixture) {
+    when(fixture.assetDao.findReusableBlobBySha256(eq(7L), anyString(), anyLong()))
+        .thenReturn(Optional.empty());
+    when(fixture.assetDao.recoverDeletedBlobBySha256(eq(7L), anyString(), anyLong()))
+        .thenReturn(Optional.empty());
+    when(fixture.storage.putFile(eq("helm"), anyString(), any(Path.class), anyString()))
+        .thenAnswer(invocation -> new BlobReference(
+            "bucket", invocation.getArgument(1), invocation.getArgument(3), 0));
+    when(fixture.assetDao.insertBlobOrFindExisting(any()))
+        .thenAnswer(invocation -> ((AssetBlobRecord) invocation.getArgument(0)).withId(2L));
+    when(fixture.componentDao.upsertReturningId(any())).thenReturn(3L);
+  }
+
+  private static Fixture fixture() {
+    AssetDao assetDao = mock(AssetDao.class);
+    ComponentDao componentDao = mock(ComponentDao.class);
+    BrowseNodeDao browseNodeDao = mock(BrowseNodeDao.class);
+    AssetMetadataCache cache = mock(AssetMetadataCache.class);
+    BlobStorage storage = mock(BlobStorage.class);
+    return new Fixture(
+        assetDao,
+        componentDao,
+        browseNodeDao,
+        cache,
+        storage,
+        new HelmAssetWriter(assetDao, componentDao, browseNodeDao, cache, null));
+  }
+
+  private static RepositoryRuntime runtime() {
+    return new RepositoryRuntime(
+        10L, "helm", RepositoryFormat.HELM, RepositoryType.HOSTED, "helm", true, 7L,
+        "ALLOW", null, null, true, null, 60, 60, true, null, List.of());
+  }
+
+  private static byte[] chartPackage(String name, String version) throws Exception {
+    ByteArrayOutputStream tarBytes = new ByteArrayOutputStream();
+    try (TarArchiveOutputStream tar = new TarArchiveOutputStream(tarBytes)) {
+      byte[] body = """
+          apiVersion: v2
+          name: %s
+          version: %s
+          """.formatted(name, version).getBytes(StandardCharsets.UTF_8);
+      TarArchiveEntry entry = new TarArchiveEntry(name + "/Chart.yaml");
+      entry.setSize(body.length);
+      tar.putArchiveEntry(entry);
+      tar.write(body);
+      tar.closeArchiveEntry();
+    }
+    ByteArrayOutputStream gzipBytes = new ByteArrayOutputStream();
+    try (GZIPOutputStream gzip = new GZIPOutputStream(gzipBytes)) {
+      gzip.write(tarBytes.toByteArray());
+    }
+    return gzipBytes.toByteArray();
+  }
+
+  private record Fixture(
+      AssetDao assetDao,
+      ComponentDao componentDao,
+      BrowseNodeDao browseNodeDao,
+      AssetMetadataCache cache,
+      BlobStorage storage,
+      HelmAssetWriter writer) {
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/helm/HelmHostedServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/helm/HelmHostedServiceTest.java
@@ -1,0 +1,204 @@
+package com.github.klboke.kkrepo.server.helm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.core.BlobStorage;
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.mysql.dao.AssetDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.RepositoryIndexRebuildDao;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetRecord;
+import com.github.klboke.kkrepo.protocol.helm.HelmAssetKind;
+import com.github.klboke.kkrepo.server.cache.AssetMetadataCache;
+import com.github.klboke.kkrepo.server.cache.CachedAssetMetadata;
+import com.github.klboke.kkrepo.server.maven.BlobStorageRegistry;
+import com.github.klboke.kkrepo.server.maven.MavenExceptions;
+import com.github.klboke.kkrepo.server.maven.MavenResponse;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.zip.GZIPOutputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+class HelmHostedServiceTest {
+  @Test
+  void generatesMissingIndexBeforeServingIt() {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(RepositoryType.HOSTED, 7L, "ALLOW");
+    CachedAssetMetadata snapshot = snapshot("index.yaml");
+    MavenResponse expected = MavenResponse.noBody(200);
+    when(fixture.assetDao.findAssetByPath(runtime.id(), "index.yaml")).thenReturn(Optional.empty());
+    when(fixture.registry.forBlobStoreId(7L)).thenReturn(fixture.storage);
+    when(fixture.cache.find(eq(runtime.id()), eq("index.yaml"), any()))
+        .thenReturn(Optional.of(snapshot));
+    when(fixture.reader.serveSnapshot(snapshot, true, "index.yaml")).thenReturn(expected);
+
+    assertSame(expected, fixture.service.get(runtime, "/index.yaml", true));
+
+    verify(fixture.writer).write(
+        eq(runtime), eq(fixture.storage), eq(7L), eq("index.yaml"), any(),
+        eq("text/x-yaml"), eq(HelmAssetKind.INDEX), eq(null),
+        eq(Map.of()), eq(Map.of()), eq("system"), eq(null));
+    verify(fixture.indexDao).enqueue(runtime.id(), RepositoryIndexRebuildDao.HELM_INDEX);
+  }
+
+  @Test
+  void putsPackagesAndProvenanceButRejectsIndexAndUnknownPaths() {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(RepositoryType.HOSTED, 7L, "ALLOW");
+    when(fixture.registry.forBlobStoreId(7L)).thenReturn(fixture.storage);
+
+    assertEquals(200, fixture.service.put(
+        runtime, "demo-1.0.0.tgz", new ByteArrayInputStream(new byte[] {1}),
+        "application/gzip", "user", "ip").status());
+    assertEquals(200, fixture.service.put(
+        runtime, "demo-1.0.0.tgz.prov", new ByteArrayInputStream(new byte[] {2}),
+        "application/octet-stream", "user", "ip").status());
+    assertEquals(404, fixture.service.put(
+        runtime, "index.yaml", new ByteArrayInputStream(new byte[] {3}),
+        "text/x-yaml", "user", "ip").status());
+    assertEquals(404, fixture.service.put(
+        runtime, "README.md", new ByteArrayInputStream(new byte[] {4}),
+        "text/plain", "user", "ip").status());
+
+    verify(fixture.indexDao).enqueue(runtime.id(), RepositoryIndexRebuildDao.HELM_INDEX);
+  }
+
+  @Test
+  void validatesPushCoordinatesAndPreventsDuplicateCharts() throws Exception {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(RepositoryType.HOSTED, 7L, "ALLOW");
+    when(fixture.registry.forBlobStoreId(7L)).thenReturn(fixture.storage);
+    MockMultipartFile chart = new MockMultipartFile(
+        "chart", "demo.tgz", "application/gzip", chartPackage("demo", "1.2.3"));
+
+    assertEquals(201, fixture.service.push(runtime, chart, "user", "ip").status());
+    verify(fixture.indexDao).enqueue(runtime.id(), RepositoryIndexRebuildDao.HELM_INDEX);
+
+    when(fixture.assetDao.findAssetByPath(runtime.id(), "demo-1.2.3.tgz"))
+        .thenReturn(Optional.of(snapshot("demo-1.2.3.tgz").toAssetRecord()));
+    assertThrows(MavenExceptions.WritePolicyDenied.class,
+        () -> fixture.service.push(runtime, chart, "user", "ip"));
+
+    MockMultipartFile invalid = new MockMultipartFile(
+        "chart", "bad.tgz", "application/gzip", chartPackage("../bad", "1.0.0"));
+    assertThrows(MavenExceptions.LayoutPolicyViolation.class,
+        () -> fixture.service.push(runtime, invalid, "user", "ip"));
+  }
+
+  @Test
+  void enforcesTypePolicyAndBlobAssignment() {
+    Fixture fixture = fixture();
+    assertThrows(MavenExceptions.MethodNotAllowed.class,
+        () -> fixture.service.get(
+            runtime(RepositoryType.PROXY, 7L, "ALLOW"), "index.yaml", false));
+    assertThrows(MavenExceptions.WritePolicyDenied.class,
+        () -> fixture.service.put(
+            runtime(RepositoryType.HOSTED, 7L, "DENY"), "demo.tgz",
+            new ByteArrayInputStream(new byte[] {1}), null, "user", "ip"));
+    RepositoryRuntime once = runtime(RepositoryType.HOSTED, 7L, "ALLOW_ONCE");
+    when(fixture.assetDao.findAssetByPath(once.id(), "demo.tgz"))
+        .thenReturn(Optional.of(snapshot("demo.tgz").toAssetRecord()));
+    assertThrows(MavenExceptions.WritePolicyDenied.class,
+        () -> fixture.service.put(
+            once, "demo.tgz", new ByteArrayInputStream(new byte[] {1}), null, "user", "ip"));
+    assertThrows(IllegalStateException.class,
+        () -> fixture.service.put(
+            runtime(RepositoryType.HOSTED, null, "ALLOW"), "demo.tgz",
+            new ByteArrayInputStream(new byte[] {1}), null, "user", "ip"));
+    assertThrows(MavenExceptions.MavenNotFoundException.class,
+        () -> HelmHostedService.normalizePath("///"));
+  }
+
+  @Test
+  void deletesOnlyPackagesAndRebuildsIndexAfterSuccess() {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(RepositoryType.HOSTED, 7L, "ALLOW");
+    when(fixture.registry.forBlobStoreId(7L)).thenReturn(fixture.storage);
+    when(fixture.writer.deleteAsset(runtime, fixture.storage, "demo.tgz")).thenReturn(0, 1);
+
+    assertEquals(404, fixture.service.delete(runtime, "index.yaml").status());
+    assertEquals(404, fixture.service.delete(runtime, "demo.tgz.prov").status());
+    assertEquals(404, fixture.service.delete(runtime, "demo.tgz").status());
+    assertEquals(200, fixture.service.delete(runtime, "demo.tgz").status());
+    verify(fixture.indexDao).enqueue(runtime.id(), RepositoryIndexRebuildDao.HELM_INDEX);
+    verify(fixture.writer, never()).deleteAsset(runtime, fixture.storage, "index.yaml");
+  }
+
+  private static Fixture fixture() {
+    AssetDao assetDao = mock(AssetDao.class);
+    RepositoryIndexRebuildDao indexDao = mock(RepositoryIndexRebuildDao.class);
+    BlobStorageRegistry registry = mock(BlobStorageRegistry.class);
+    HelmAssetWriter writer = mock(HelmAssetWriter.class);
+    HelmAssetReader reader = mock(HelmAssetReader.class);
+    AssetMetadataCache cache = mock(AssetMetadataCache.class);
+    BlobStorage storage = mock(BlobStorage.class);
+    return new Fixture(
+        assetDao, indexDao, registry, writer, reader, cache, storage,
+        new HelmHostedService(assetDao, indexDao, registry, writer, reader, cache));
+  }
+
+  private static RepositoryRuntime runtime(
+      RepositoryType type, Long blobStoreId, String writePolicy) {
+    return new RepositoryRuntime(
+        10L, "helm", RepositoryFormat.HELM, type, "helm", true, blobStoreId,
+        writePolicy, null, null, true, "https://charts.example.test/",
+        60, 60, true, null, List.of());
+  }
+
+  private static CachedAssetMetadata snapshot(String path) {
+    AssetRecord asset = new AssetRecord(
+        1L, 10L, null, null, RepositoryFormat.HELM, path, null,
+        path, "INDEX", "text/x-yaml", 1L, null, Instant.EPOCH, Map.of());
+    return CachedAssetMetadata.of(asset, null);
+  }
+
+  private static byte[] chartPackage(String name, String version) throws Exception {
+    ByteArrayOutputStream tarBytes = new ByteArrayOutputStream();
+    try (TarArchiveOutputStream tar = new TarArchiveOutputStream(tarBytes)) {
+      byte[] body = """
+          apiVersion: v2
+          name: %s
+          version: %s
+          """.formatted(name, version).getBytes(StandardCharsets.UTF_8);
+      TarArchiveEntry entry = new TarArchiveEntry("chart/Chart.yaml");
+      entry.setSize(body.length);
+      tar.putArchiveEntry(entry);
+      tar.write(body);
+      tar.closeArchiveEntry();
+    }
+    ByteArrayOutputStream gzipBytes = new ByteArrayOutputStream();
+    try (GZIPOutputStream gzip = new GZIPOutputStream(gzipBytes)) {
+      gzip.write(tarBytes.toByteArray());
+    }
+    return gzipBytes.toByteArray();
+  }
+
+  private record Fixture(
+      AssetDao assetDao,
+      RepositoryIndexRebuildDao indexDao,
+      BlobStorageRegistry registry,
+      HelmAssetWriter writer,
+      HelmAssetReader reader,
+      AssetMetadataCache cache,
+      BlobStorage storage,
+      HelmHostedService service) {
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/helm/HelmProxyServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/helm/HelmProxyServiceTest.java
@@ -1,0 +1,270 @@
+package com.github.klboke.kkrepo.server.helm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.core.BlobStorage;
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.mysql.dao.AssetDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.ProxyStateDao;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetBlobRecord;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetRecord;
+import com.github.klboke.kkrepo.protocol.helm.HelmAssetKind;
+import com.github.klboke.kkrepo.server.cache.AssetMetadataCache;
+import com.github.klboke.kkrepo.server.cache.CachedAssetMetadata;
+import com.github.klboke.kkrepo.server.maven.BlobStorageRegistry;
+import com.github.klboke.kkrepo.server.maven.HttpRemoteFetcher;
+import com.github.klboke.kkrepo.server.maven.MavenExceptions;
+import com.github.klboke.kkrepo.server.maven.MavenResponse;
+import com.github.klboke.kkrepo.server.maven.ProxyNegativeCache;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class HelmProxyServiceTest {
+  @Test
+  void servesFreshIndexAndPackageFromCache() {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(RepositoryType.PROXY, 60);
+    CachedAssetMetadata index = snapshot("index.yaml", Instant.now().plusSeconds(60), Map.of());
+    CachedAssetMetadata chart = snapshot("demo-1.0.0.tgz", Instant.now().plusSeconds(60), Map.of());
+    MavenResponse indexResponse = MavenResponse.noBody(200);
+    MavenResponse chartResponse = MavenResponse.noBody(200);
+    when(fixture.cache.find(eq(runtime.id()), anyString(), any()))
+        .thenAnswer(invocation -> Optional.of(
+            invocation.getArgument(1).equals("index.yaml") ? index : chart));
+    when(fixture.reader.serveSnapshot(index, true, "index.yaml")).thenReturn(indexResponse);
+    when(fixture.reader.serveSnapshot(chart, false, "demo-1.0.0.tgz")).thenReturn(chartResponse);
+
+    assertSame(indexResponse, fixture.service.get(runtime, "index.yaml", true));
+    assertSame(chartResponse, fixture.service.get(runtime, "demo-1.0.0.tgz", false));
+    verify(fixture.negativeCache, never()).isNotFoundCached(eq(runtime), anyString());
+  }
+
+  @Test
+  void honorsNegativeCacheAndBlockedUpstreamFallback() {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(RepositoryType.PROXY, 1);
+    when(fixture.cache.find(eq(runtime.id()), eq("missing.tgz"), any()))
+        .thenReturn(Optional.empty());
+    when(fixture.negativeCache.isNotFoundCached(runtime, "missing.tgz")).thenReturn(true);
+    assertThrows(MavenExceptions.MavenNotFoundException.class,
+        () -> fixture.service.get(runtime, "missing.tgz", false));
+
+    CachedAssetMetadata stale = snapshot("demo.tgz", Instant.EPOCH, Map.of());
+    MavenResponse expected = MavenResponse.noBody(200);
+    when(fixture.cache.find(eq(runtime.id()), eq("demo.tgz"), any()))
+        .thenReturn(Optional.of(stale));
+    when(fixture.proxyStateDao.isBlocked(eq(runtime.id()), any())).thenReturn(true);
+    when(fixture.reader.serveSnapshot(stale, true, "demo.tgz")).thenReturn(expected);
+    assertSame(expected, fixture.service.get(runtime, "demo.tgz", true));
+
+    when(fixture.cache.find(eq(runtime.id()), eq("other.tgz"), any()))
+        .thenReturn(Optional.empty());
+    assertThrows(MavenExceptions.BadUpstreamException.class,
+        () -> fixture.service.get(runtime, "other.tgz", false));
+  }
+
+  @Test
+  void cachesAndRewritesRemoteIndexForHead() throws Exception {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(RepositoryType.PROXY, 1);
+    when(fixture.cache.find(eq(runtime.id()), eq("index.yaml"), any()))
+        .thenReturn(Optional.empty());
+    when(fixture.registry.forBlobStoreId(7L)).thenReturn(fixture.storage);
+    byte[] upstream = """
+        apiVersion: v1
+        entries:
+          demo:
+            - name: demo
+              version: 1.0.0
+              urls:
+                - charts/original.tgz
+        """.getBytes(StandardCharsets.UTF_8);
+    respond(fixture.fetcher, new HttpRemoteFetcher.Result(
+        200, Map.of("Content-Type", "text/x-yaml"), new ByteArrayInputStream(upstream)));
+    HelmAssetWriter.Stored stored = stored("index.yaml", "text/x-yaml");
+    when(fixture.writer.writeBytes(
+        eq(runtime), eq(fixture.storage), eq(7L), eq("index.yaml"), any(byte[].class),
+        eq("text/x-yaml"), eq(HelmAssetKind.INDEX), eq(null), any(), any(),
+        eq("proxy"), eq(runtime.proxyRemoteUrl()), eq(false)))
+        .thenReturn(stored);
+
+    MavenResponse response = fixture.service.get(runtime, "index.yaml", true);
+
+    assertEquals(200, response.status());
+    assertEquals(stored.blob().size(), response.contentLength());
+    verify(fixture.proxyStateDao).recordSuccess(eq(runtime.id()), any());
+    verify(fixture.negativeCache).invalidate(runtime, "index.yaml");
+  }
+
+  @Test
+  void usesRemoteUrlRecordedInCachedIndexForPackage() throws Exception {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(RepositoryType.PROXY, 1);
+    CachedAssetMetadata index = snapshot(
+        "index.yaml", Instant.now(),
+        Map.of("remoteUrls", Map.of(
+            "demo-1.0.0.tgz", "https://cdn.example.test/charts/demo.tgz")));
+    when(fixture.cache.find(eq(runtime.id()), anyString(), any()))
+        .thenAnswer(invocation -> invocation.getArgument(1).equals("index.yaml")
+            ? Optional.of(index)
+            : Optional.empty());
+    when(fixture.registry.forBlobStoreId(7L)).thenReturn(fixture.storage);
+    AtomicReference<String> requestedUrl = new AtomicReference<>();
+    doAnswer(invocation -> {
+      HttpRemoteFetcher.Request request = invocation.getArgument(0);
+      requestedUrl.set(request.url());
+      @SuppressWarnings("unchecked")
+      HttpRemoteFetcher.ResultHandler<MavenResponse> handler = invocation.getArgument(2);
+      return handler.handle(new HttpRemoteFetcher.Result(
+          200, Map.of("Content-Type", "application/gzip"),
+          new ByteArrayInputStream(new byte[] {1, 2, 3})));
+    }).when(fixture.fetcher).fetchWithBodyRetry(any(), eq("demo-1.0.0.tgz"), any());
+    HelmAssetWriter.Stored stored = stored("demo-1.0.0.tgz", "application/gzip");
+    when(fixture.writer.write(
+        eq(runtime), eq(fixture.storage), eq(7L), eq("demo-1.0.0.tgz"), any(),
+        eq("application/gzip"), eq(HelmAssetKind.PACKAGE), eq(null), any(), any(),
+        eq("proxy"), eq(runtime.proxyRemoteUrl()), eq(false)))
+        .thenReturn(stored);
+
+    assertEquals(200, fixture.service.get(runtime, "demo-1.0.0.tgz", true).status());
+    assertEquals("https://cdn.example.test/charts/demo.tgz", requestedUrl.get());
+  }
+
+  @Test
+  void handles304AndRemoteNotFound() throws Exception {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(RepositoryType.PROXY, 1);
+    CachedAssetMetadata stale = snapshot("index.yaml", Instant.EPOCH, Map.of());
+    MavenResponse expected = MavenResponse.noBody(200);
+    when(fixture.cache.find(eq(runtime.id()), eq("index.yaml"), any()))
+        .thenReturn(Optional.of(stale));
+    when(fixture.reader.serveSnapshot(stale, false, "index.yaml")).thenReturn(expected);
+    respond(fixture.fetcher, new HttpRemoteFetcher.Result(
+        304, Map.of(), new ByteArrayInputStream(new byte[0])));
+
+    assertSame(expected, fixture.service.get(runtime, "index.yaml", false));
+    verify(fixture.assetDao).touchAssetLastUpdated(eq(stale.assetId()), any());
+    verify(fixture.cache).touchVerified(eq(runtime.id()), eq("index.yaml"), any());
+
+    Fixture missing = fixture();
+    when(missing.cache.find(eq(runtime.id()), eq("index.yaml"), any()))
+        .thenReturn(Optional.empty());
+    respond(missing.fetcher, new HttpRemoteFetcher.Result(
+        404, Map.of(), new ByteArrayInputStream(new byte[0])));
+    assertThrows(MavenExceptions.MavenNotFoundException.class,
+        () -> missing.service.get(runtime, "index.yaml", false));
+    verify(missing.negativeCache).rememberNotFound(runtime, "index.yaml");
+  }
+
+  @Test
+  void rejectsUnsupportedRepositoryAndAssetKinds() throws Exception {
+    Fixture fixture = fixture();
+    assertThrows(MavenExceptions.MethodNotAllowed.class,
+        () -> fixture.service.get(runtime(RepositoryType.HOSTED, 1), "index.yaml", false));
+    assertThrows(MavenExceptions.MavenNotFoundException.class,
+        () -> fixture.service.get(runtime(RepositoryType.PROXY, 1), "demo.tgz.prov", false));
+    assertThrows(MavenExceptions.MavenNotFoundException.class,
+        () -> fixture.service.get(runtime(RepositoryType.PROXY, 1), "README.md", false));
+    respond(fixture.fetcher, new HttpRemoteFetcher.Result(
+        200, Map.of("Content-Type", "text/x-yaml"),
+        new ByteArrayInputStream("apiVersion: v1\nentries: {}\n".getBytes(StandardCharsets.UTF_8))));
+    assertThrows(IllegalStateException.class,
+        () -> fixture.service.get(
+            new RepositoryRuntime(
+                10L, "helm", RepositoryFormat.HELM, RepositoryType.PROXY, "helm", true, null,
+                null, null, null, true, "https://charts.example.test/",
+                1, 1, true, null, List.of()),
+            "index.yaml", false));
+  }
+
+  private static void respond(HttpRemoteFetcher fetcher, HttpRemoteFetcher.Result result)
+      throws IOException {
+    doAnswer(invocation -> {
+      @SuppressWarnings("unchecked")
+      HttpRemoteFetcher.ResultHandler<MavenResponse> handler = invocation.getArgument(2);
+      return handler.handle(result);
+    }).when(fetcher).fetchWithBodyRetry(any(), anyString(), any());
+  }
+
+  private static Fixture fixture() {
+    AssetDao assetDao = mock(AssetDao.class);
+    BlobStorageRegistry registry = mock(BlobStorageRegistry.class);
+    HelmAssetWriter writer = mock(HelmAssetWriter.class);
+    HelmAssetReader reader = mock(HelmAssetReader.class);
+    ProxyStateDao proxyStateDao = mock(ProxyStateDao.class);
+    HttpRemoteFetcher fetcher = mock(HttpRemoteFetcher.class);
+    ProxyNegativeCache negativeCache = mock(ProxyNegativeCache.class);
+    AssetMetadataCache cache = mock(AssetMetadataCache.class);
+    BlobStorage storage = mock(BlobStorage.class);
+    return new Fixture(
+        assetDao, registry, writer, reader, proxyStateDao, fetcher, negativeCache, cache, storage,
+        new HelmProxyService(
+            assetDao, registry, writer, reader, proxyStateDao, fetcher, negativeCache, cache));
+  }
+
+  private static RepositoryRuntime runtime(RepositoryType type, int maxAgeMinutes) {
+    return new RepositoryRuntime(
+        10L, "helm", RepositoryFormat.HELM, type, "helm", true, 7L,
+        null, null, null, true, "https://charts.example.test/",
+        maxAgeMinutes, maxAgeMinutes, true, null, List.of());
+  }
+
+  private static CachedAssetMetadata snapshot(
+      String path, Instant updatedAt, Map<String, Object> attributes) {
+    AssetRecord asset = new AssetRecord(
+        1L, 10L, null, 2L, RepositoryFormat.HELM, path, null,
+        path, path.equals("index.yaml") ? "INDEX" : "PACKAGE",
+        path.equals("index.yaml") ? "text/x-yaml" : "application/gzip",
+        4L, null, updatedAt, attributes);
+    return CachedAssetMetadata.of(asset, blob());
+  }
+
+  private static HelmAssetWriter.Stored stored(String path, String contentType) {
+    AssetRecord asset = new AssetRecord(
+        1L, 10L, null, 2L, RepositoryFormat.HELM, path, null,
+        path, path.equals("index.yaml") ? "INDEX" : "PACKAGE", contentType,
+        4L, null, Instant.now(), Map.of());
+    return new HelmAssetWriter.Stored(
+        asset, blob(), new HelmAssetWriter.Digests("md5", "sha1", "sha256", "sha512", 4),
+        true, null);
+  }
+
+  private static AssetBlobRecord blob() {
+    return new AssetBlobRecord(
+        2L, 7L, "blob://bucket/object", null, "object", null,
+        "sha1", "sha256", "md5", 4, "application/gzip", "proxy", "upstream",
+        Instant.EPOCH, Instant.EPOCH, Map.of());
+  }
+
+  private record Fixture(
+      AssetDao assetDao,
+      BlobStorageRegistry registry,
+      HelmAssetWriter writer,
+      HelmAssetReader reader,
+      ProxyStateDao proxyStateDao,
+      HttpRemoteFetcher fetcher,
+      ProxyNegativeCache negativeCache,
+      AssetMetadataCache cache,
+      BlobStorage storage,
+      HelmProxyService service) {
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/maven/MavenHostedServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/maven/MavenHostedServiceTest.java
@@ -1,0 +1,213 @@
+package com.github.klboke.kkrepo.server.maven;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.core.BlobStorage;
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.mysql.dao.AssetDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.MetadataRebuildDao;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetRecord;
+import com.github.klboke.kkrepo.protocol.maven.path.MavenPath;
+import com.github.klboke.kkrepo.protocol.maven.path.MavenPathParser;
+import com.github.klboke.kkrepo.server.cache.AssetMetadataCache;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class MavenHostedServiceTest {
+  private static final MavenPathParser PARSER = new MavenPathParser();
+
+  @Test
+  void snapshotPutQueuesGaAndGavRebuildMarkers() {
+    Fixture fixture = fixture(false);
+    MavenPath path = path(
+        "com/acme/demo/1.0-SNAPSHOT/demo-1.0-20260713.123456-1.jar");
+    when(fixture.assetDao.findAssetByPath(10L, path.path())).thenReturn(Optional.empty());
+
+    MavenResponse response = fixture.service.put(
+        runtime(RepositoryType.HOSTED, "ALLOW", 7L),
+        path,
+        body("jar"),
+        "application/java-archive",
+        "alice",
+        "127.0.0.1",
+        true);
+
+    assertEquals(201, response.status());
+    verify(fixture.rebuildDao).enqueue(10L, MetadataRebuildScope.ga("com.acme", "demo"));
+    verify(fixture.rebuildDao).enqueue(
+        10L, MetadataRebuildScope.gav("com.acme", "demo", "1.0-SNAPSHOT"));
+  }
+
+  @Test
+  void releasePutQueuesOnlyGaAndHashPutQueuesNothing() {
+    Fixture fixture = fixture(false);
+    RepositoryRuntime runtime = runtime(RepositoryType.HOSTED, "ALLOW", 7L);
+    MavenPath release = path("com/acme/demo/1.0/demo-1.0.jar");
+    when(fixture.assetDao.findAssetByPath(10L, release.path())).thenReturn(Optional.empty());
+
+    fixture.service.put(
+        runtime, release, body("jar"), "application/java-archive", "alice", null, true);
+
+    verify(fixture.rebuildDao).enqueue(10L, MetadataRebuildScope.ga("com.acme", "demo"));
+    verify(fixture.rebuildDao, never())
+        .enqueue(10L, MetadataRebuildScope.gav("com.acme", "demo", "1.0"));
+
+    Fixture checksumFixture = fixture(false);
+    MavenPath checksum = path("com/acme/demo/1.0/demo-1.0.jar.sha1");
+    when(checksumFixture.assetDao.findAssetByPath(10L, checksum.path())).thenReturn(Optional.empty());
+    checksumFixture.service.put(
+        runtime, checksum, body("sha1"), "text/plain", "alice", null, true);
+    verify(checksumFixture.rebuildDao, never()).enqueue(anyLong(), any());
+  }
+
+  @Test
+  void explicitMetadataUploadCancelsPendingScopeMarker() {
+    Fixture fixture = fixture(false);
+    RepositoryRuntime runtime = runtime(RepositoryType.HOSTED, "ALLOW", 7L);
+    MavenPath gaMetadata = path("com/acme/demo/maven-metadata.xml");
+    MavenPath gavMetadata = path("com/acme/demo/1.0-SNAPSHOT/maven-metadata.xml");
+    when(fixture.assetDao.findAssetByPath(eq(10L), any())).thenReturn(Optional.empty());
+
+    fixture.service.put(runtime, gaMetadata, body("<metadata/>"), "application/xml", "alice", null);
+    fixture.service.put(runtime, gavMetadata, body("<metadata/>"), "application/xml", "alice", null);
+
+    verify(fixture.rebuildDao).delete(10L, MetadataRebuildScope.ga("com.acme", "demo"));
+    verify(fixture.rebuildDao).delete(
+        10L, MetadataRebuildScope.gav("com.acme", "demo", "1.0-SNAPSHOT"));
+  }
+
+  @Test
+  void synchronousSnapshotPutRebuildsMetadataInlineWithoutQueueing() {
+    Fixture fixture = fixture(true);
+    RepositoryRuntime runtime = runtime(RepositoryType.HOSTED, "ALLOW", 7L);
+    MavenPath path = path(
+        "com/acme/demo/1.0-SNAPSHOT/demo-1.0-20260713.123456-1.pom");
+    when(fixture.assetDao.findAssetByPath(10L, path.path())).thenReturn(Optional.empty());
+
+    fixture.service.put(runtime, path, body("pom"), "application/xml", "alice", null, true);
+
+    verify(fixture.metadata).rebuildGa(
+        runtime, fixture.storage, 7L, "com.acme", "demo", "alice", null);
+    verify(fixture.metadata).rebuildBaseVersionIfSnapshot(
+        eq(runtime), eq(fixture.storage), eq(7L), any(), eq("alice"), eq(null));
+    verify(fixture.rebuildDao, never()).enqueue(anyLong(), any());
+  }
+
+  @Test
+  void writePolicyAndRepositoryTypeAreEnforcedBeforeStorageWrite() {
+    Fixture fixture = fixture(false);
+    MavenPath path = path("com/acme/demo/1.0/demo-1.0.jar");
+    when(fixture.assetDao.findAssetByPath(10L, path.path()))
+        .thenReturn(Optional.of(mock(AssetRecord.class)));
+
+    assertThrows(MavenExceptions.WritePolicyDenied.class, () ->
+        fixture.service.put(
+            runtime(RepositoryType.HOSTED, "ALLOW_ONCE", 7L),
+            path,
+            body("jar"),
+            "application/java-archive",
+            "alice",
+            null));
+    assertThrows(MavenExceptions.MethodNotAllowed.class, () ->
+        fixture.service.put(
+            runtime(RepositoryType.PROXY, "ALLOW", 7L),
+            path,
+            body("jar"),
+            "application/java-archive",
+            "alice",
+            null));
+
+    verify(fixture.writer, never()).writePrimary(
+        any(), any(), anyLong(), any(), any(), any(), any(), any(), anyMap(), anyBoolean());
+  }
+
+  @Test
+  void deleteReturnsNotFoundWithoutQueueingAndSuccessfulDeleteQueuesMetadata() {
+    Fixture missing = fixture(false);
+    RepositoryRuntime runtime = runtime(RepositoryType.HOSTED, "ALLOW", 7L);
+    MavenPath path = path("com/acme/demo/1.0/demo-1.0.jar");
+    when(missing.writer.deleteAsset(runtime, missing.storage, path)).thenReturn(0);
+
+    assertEquals(404, missing.service.delete(runtime, path).status());
+    verify(missing.rebuildDao, never()).enqueue(anyLong(), any());
+
+    Fixture deleted = fixture(false);
+    when(deleted.writer.deleteAsset(runtime, deleted.storage, path)).thenReturn(1);
+    assertEquals(204, deleted.service.delete(runtime, path).status());
+    verify(deleted.rebuildDao).enqueue(10L, MetadataRebuildScope.ga("com.acme", "demo"));
+  }
+
+  private static Fixture fixture(boolean synchronousMetadata) {
+    AssetDao assetDao = mock(AssetDao.class);
+    BlobStorageRegistry storages = mock(BlobStorageRegistry.class);
+    BlobStorage storage = mock(BlobStorage.class);
+    MavenAssetWriter writer = mock(MavenAssetWriter.class);
+    MavenMetadataService metadata = mock(MavenMetadataService.class);
+    MetadataRebuildDao rebuildDao = mock(MetadataRebuildDao.class);
+    when(storages.forBlobStoreId(7L)).thenReturn(storage);
+    MavenHostedService service = new MavenHostedService(
+        assetDao,
+        storages,
+        writer,
+        metadata,
+        rebuildDao,
+        mock(AssetMetadataCache.class),
+        synchronousMetadata);
+    return new Fixture(assetDao, storage, writer, metadata, rebuildDao, service);
+  }
+
+  private static ByteArrayInputStream body(String value) {
+    return new ByteArrayInputStream(value.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static MavenPath path(String value) {
+    return PARSER.parsePath(value);
+  }
+
+  private static RepositoryRuntime runtime(
+      RepositoryType type,
+      String writePolicy,
+      Long blobStoreId) {
+    return new RepositoryRuntime(
+        10L,
+        "maven-hosted",
+        RepositoryFormat.MAVEN2,
+        type,
+        "maven2-" + type.name().toLowerCase(),
+        true,
+        blobStoreId,
+        writePolicy,
+        "MIXED",
+        "PERMISSIVE",
+        true,
+        type == RepositoryType.PROXY ? "https://repo.example/" : null,
+        null,
+        null,
+        true,
+        null,
+        List.of());
+  }
+
+  private record Fixture(
+      AssetDao assetDao,
+      BlobStorage storage,
+      MavenAssetWriter writer,
+      MavenMetadataService metadata,
+      MetadataRebuildDao rebuildDao,
+      MavenHostedService service) {
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/maven/MavenMetadataServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/maven/MavenMetadataServiceTest.java
@@ -1,0 +1,260 @@
+package com.github.klboke.kkrepo.server.maven;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.core.BlobStorage;
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.mysql.dao.AssetDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.ComponentDao;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetRecord;
+import com.github.klboke.kkrepo.persistence.mysql.model.ComponentRecord;
+import com.github.klboke.kkrepo.protocol.maven.MavenContentType;
+import com.github.klboke.kkrepo.protocol.maven.metadata.MavenMetadataXml;
+import com.github.klboke.kkrepo.protocol.maven.path.Coordinates;
+import com.github.klboke.kkrepo.protocol.maven.path.MavenPath;
+import com.github.klboke.kkrepo.protocol.maven.path.MavenPathParser;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class MavenMetadataServiceTest {
+  private static final MavenPathParser PARSER = new MavenPathParser();
+
+  @Test
+  void emptyArtifactDeletesPreviouslyGeneratedMetadata() {
+    ComponentDao components = mock(ComponentDao.class);
+    AssetDao assets = mock(AssetDao.class);
+    MavenAssetWriter writer = mock(MavenAssetWriter.class);
+    BlobStorage storage = mock(BlobStorage.class);
+    RepositoryRuntime runtime = runtime();
+    when(components.listByGa(10L, "com.acme", "demo")).thenReturn(List.of());
+
+    new MavenMetadataService(components, assets, writer)
+        .rebuildGa(runtime, storage, 7L, "com.acme", "demo", "system", null);
+
+    verify(writer).deleteAsset(
+        eq(runtime),
+        eq(storage),
+        argThatPath("com/acme/demo/maven-metadata.xml"));
+  }
+
+  @Test
+  void artifactMetadataUsesMavenVersionOrderAndLatestNonSnapshotRelease() throws Exception {
+    ComponentDao components = mock(ComponentDao.class);
+    AssetDao assets = mock(AssetDao.class);
+    MavenAssetWriter writer = mock(MavenAssetWriter.class);
+    BlobStorage storage = mock(BlobStorage.class);
+    RepositoryRuntime runtime = runtime();
+    Instant older = Instant.parse("2026-07-12T10:00:00Z");
+    Instant newer = Instant.parse("2026-07-13T11:12:13Z");
+    when(components.listByGa(10L, "com.acme", "demo")).thenReturn(List.of(
+        component(1L, "1.10", older),
+        component(2L, "1.2", newer),
+        component(3L, "2.0-SNAPSHOT", older),
+        component(4L, "2.0", newer)));
+    ArgumentCaptor<byte[]> body = ArgumentCaptor.forClass(byte[].class);
+
+    new MavenMetadataService(components, assets, writer)
+        .rebuildGa(runtime, storage, 7L, "com.acme", "demo", "system", null);
+
+    verify(writer).writeBytes(
+        eq(runtime),
+        eq(storage),
+        eq(7L),
+        argThatPath("com/acme/demo/maven-metadata.xml"),
+        body.capture(),
+        eq(MavenContentType.XML),
+        eq("system"),
+        eq(null));
+    MavenMetadataXml.Parsed parsed = MavenMetadataXml.read(body.getValue());
+    assertEquals(List.of("1.2", "1.10", "2.0-SNAPSHOT", "2.0"), parsed.versions);
+    assertEquals("2.0", parsed.latest);
+    assertEquals("2.0", parsed.release);
+    assertEquals("20260713111213", parsed.lastUpdated);
+  }
+
+  @Test
+  void snapshotOnlyArtifactHasNoRelease() throws Exception {
+    ComponentDao components = mock(ComponentDao.class);
+    AssetDao assets = mock(AssetDao.class);
+    MavenAssetWriter writer = mock(MavenAssetWriter.class);
+    BlobStorage storage = mock(BlobStorage.class);
+    when(components.listByGa(10L, "com.acme", "demo")).thenReturn(List.of(
+        component(1L, "1.0-SNAPSHOT", Instant.parse("2026-07-13T00:00:00Z"))));
+    ArgumentCaptor<byte[]> body = ArgumentCaptor.forClass(byte[].class);
+
+    new MavenMetadataService(components, assets, writer)
+        .rebuildGa(runtime(), storage, 7L, "com.acme", "demo", "system", null);
+
+    verify(writer).writeBytes(any(), any(), eq(7L), any(), body.capture(), any(), any(), any());
+    MavenMetadataXml.Parsed parsed = MavenMetadataXml.read(body.getValue());
+    assertEquals("1.0-SNAPSHOT", parsed.latest);
+    assertNull(parsed.release);
+  }
+
+  @Test
+  void missingSnapshotComponentDeletesBaseVersionMetadata() {
+    ComponentDao components = mock(ComponentDao.class);
+    AssetDao assets = mock(AssetDao.class);
+    MavenAssetWriter writer = mock(MavenAssetWriter.class);
+    BlobStorage storage = mock(BlobStorage.class);
+    Coordinates coords = coordinates(
+        "com/acme/demo/1.0-SNAPSHOT/demo-1.0-SNAPSHOT.jar");
+    when(components.findByGav(10L, "com.acme", "demo", "1.0-SNAPSHOT"))
+        .thenReturn(Optional.empty());
+
+    new MavenMetadataService(components, assets, writer)
+        .rebuildBaseVersionIfSnapshot(runtime(), storage, 7L, coords, "system", null);
+
+    verify(writer).deleteAsset(
+        any(),
+        eq(storage),
+        argThatPath("com/acme/demo/1.0-SNAPSHOT/maven-metadata.xml"));
+  }
+
+  @Test
+  void snapshotMetadataSelectsLatestBuildPerClassifierAndIgnoresChecksums() throws Exception {
+    ComponentDao components = mock(ComponentDao.class);
+    AssetDao assets = mock(AssetDao.class);
+    MavenAssetWriter writer = mock(MavenAssetWriter.class);
+    BlobStorage storage = mock(BlobStorage.class);
+    ComponentRecord component = component(5L, "1.0-SNAPSHOT", Instant.parse("2026-07-13T12:00:00Z"));
+    when(components.findByGav(10L, "com.acme", "demo", "1.0-SNAPSHOT"))
+        .thenReturn(Optional.of(component));
+    Instant first = Instant.parse("2026-07-13T12:34:56Z");
+    Instant second = Instant.parse("2026-07-13T12:35:56Z");
+    when(assets.listAssetsByComponent(5L)).thenReturn(List.of(
+        asset(1L, "com/acme/demo/1.0-SNAPSHOT/demo-1.0-20260713.123456-1.jar", "artifact", first),
+        asset(2L, "com/acme/demo/1.0-SNAPSHOT/demo-1.0-20260713.123556-2.jar", "artifact", second),
+        asset(3L, "com/acme/demo/1.0-SNAPSHOT/demo-1.0-20260713.123556-2-sources.jar", "artifact", second),
+        asset(4L, "com/acme/demo/1.0-SNAPSHOT/demo-1.0-20260713.123556-2.pom", "pom", second),
+        asset(5L, "com/acme/demo/1.0-SNAPSHOT/demo-1.0-20260713.123556-2.jar.sha1", "checksum", second)));
+    ArgumentCaptor<byte[]> body = ArgumentCaptor.forClass(byte[].class);
+
+    new MavenMetadataService(components, assets, writer)
+        .rebuildBaseVersionIfSnapshot(
+            runtime(),
+            storage,
+            7L,
+            coordinates("com/acme/demo/1.0-SNAPSHOT/demo-1.0-SNAPSHOT.jar"),
+            "system",
+            null);
+
+    verify(writer).writeBytes(
+        any(),
+        eq(storage),
+        eq(7L),
+        argThatPath("com/acme/demo/1.0-SNAPSHOT/maven-metadata.xml"),
+        body.capture(),
+        eq(MavenContentType.XML),
+        eq("system"),
+        eq(null));
+    MavenMetadataXml.Parsed parsed = MavenMetadataXml.read(body.getValue());
+    assertEquals("20260713.123556", parsed.snapshotTimestamp);
+    assertEquals(2, parsed.snapshotBuildNumber);
+    assertEquals(3, parsed.snapshotVersions.size());
+    assertTrue(parsed.snapshotVersions.stream().anyMatch(snapshot ->
+        snapshot.classifier == null
+            && "jar".equals(snapshot.extension)
+            && "1.0-20260713.123556-2".equals(snapshot.value)));
+    assertTrue(parsed.snapshotVersions.stream().anyMatch(snapshot ->
+        "sources".equals(snapshot.classifier)
+            && "jar".equals(snapshot.extension)
+            && "1.0-20260713.123556-2".equals(snapshot.value)));
+    assertTrue(parsed.snapshotVersions.stream().noneMatch(snapshot ->
+        snapshot.extension.endsWith("sha1")));
+  }
+
+  @Test
+  void releaseCoordinatesDoNotTriggerSnapshotMetadataWork() {
+    ComponentDao components = mock(ComponentDao.class);
+    MavenAssetWriter writer = mock(MavenAssetWriter.class);
+
+    new MavenMetadataService(components, mock(AssetDao.class), writer)
+        .rebuildBaseVersionIfSnapshot(
+            runtime(),
+            mock(BlobStorage.class),
+            7L,
+            coordinates("com/acme/demo/1.0/demo-1.0.jar"),
+            "system",
+            null);
+
+    org.mockito.Mockito.verifyNoInteractions(components, writer);
+  }
+
+  private static org.mockito.ArgumentMatcher<MavenPath> path(String expected) {
+    return value -> value != null && expected.equals(value.path());
+  }
+
+  private static MavenPath argThatPath(String expected) {
+    return org.mockito.ArgumentMatchers.argThat(path(expected));
+  }
+
+  private static Coordinates coordinates(String path) {
+    return PARSER.parsePath(path).coordinates();
+  }
+
+  private static ComponentRecord component(long id, String version, Instant updatedAt) {
+    return new ComponentRecord(
+        id,
+        10L,
+        RepositoryFormat.MAVEN2,
+        "com.acme",
+        "demo",
+        version,
+        "maven",
+        null,
+        Map.of(),
+        updatedAt);
+  }
+
+  private static AssetRecord asset(long id, String path, String kind, Instant updatedAt) {
+    return new AssetRecord(
+        id,
+        10L,
+        5L,
+        100L + id,
+        RepositoryFormat.MAVEN2,
+        path,
+        null,
+        null,
+        kind,
+        MavenContentType.forFileName(path),
+        100L,
+        null,
+        updatedAt,
+        Map.of());
+  }
+
+  private static RepositoryRuntime runtime() {
+    return new RepositoryRuntime(
+        10L,
+        "maven-hosted",
+        RepositoryFormat.MAVEN2,
+        RepositoryType.HOSTED,
+        "maven2-hosted",
+        true,
+        7L,
+        "ALLOW",
+        "MIXED",
+        "PERMISSIVE",
+        true,
+        null,
+        null,
+        null,
+        true,
+        null,
+        List.of());
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/maven/MetadataRebuildWorkerTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/maven/MetadataRebuildWorkerTest.java
@@ -1,0 +1,206 @@
+package com.github.klboke.kkrepo.server.maven;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.core.BlobStorage;
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.mysql.dao.AssetDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.MetadataRebuildDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.MetadataRebuildDao.Claim;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetRecord;
+import com.github.klboke.kkrepo.server.metrics.KkRepoMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+class MetadataRebuildWorkerTest {
+
+  @Test
+  void disabledWorkerDoesNotClaimMarkers() {
+    MetadataRebuildDao dao = mock(MetadataRebuildDao.class);
+
+    worker(
+        mock(AssetDao.class),
+        dao,
+        mock(MavenMetadataService.class),
+        mock(RepositoryRuntimeRegistry.class),
+        mock(BlobStorageRegistry.class),
+        false).drain();
+
+    verifyNoInteractions(dao);
+  }
+
+  @Test
+  void dispatchesGaAndSnapshotScopes() {
+    AssetDao assetDao = mock(AssetDao.class);
+    MetadataRebuildDao dao = mock(MetadataRebuildDao.class);
+    MavenMetadataService metadata = mock(MavenMetadataService.class);
+    RepositoryRuntimeRegistry runtimes = mock(RepositoryRuntimeRegistry.class);
+    BlobStorageRegistry storages = mock(BlobStorageRegistry.class);
+    RepositoryRuntime runtime = runtime(10L, 7L);
+    BlobStorage storage = mock(BlobStorage.class);
+    Instant requestedAt = Instant.now().minusSeconds(30);
+    when(dao.claim(8)).thenReturn(List.of(
+        new Claim(10L, MetadataRebuildScope.ga("com.acme", "demo"), requestedAt, 0, null),
+        new Claim(10L, MetadataRebuildScope.gav("com.acme", "demo", "1.0-SNAPSHOT"),
+            requestedAt, 0, null)));
+    when(runtimes.resolveById(10L)).thenReturn(Optional.of(runtime));
+    when(storages.forBlobStoreId(7L)).thenReturn(storage);
+    when(assetDao.findAssetByPath(eq(10L), any())).thenReturn(Optional.empty());
+
+    worker(assetDao, dao, metadata, runtimes, storages, true).drain();
+
+    verify(metadata).rebuildGa(runtime, storage, 7L, "com.acme", "demo", "system", null);
+    verify(metadata).rebuildBaseVersionIfSnapshot(
+        eq(runtime),
+        eq(storage),
+        eq(7L),
+        argThat(coords ->
+            coords.snapshot()
+                && "com.acme".equals(coords.groupId())
+                && "demo".equals(coords.artifactId())
+                && "1.0-SNAPSHOT".equals(coords.baseVersion())),
+        eq("system"),
+        eq(null));
+  }
+
+  @Test
+  void skipsMalformedMissingAndSupersededMarkers() {
+    AssetDao assetDao = mock(AssetDao.class);
+    MetadataRebuildDao dao = mock(MetadataRebuildDao.class);
+    MavenMetadataService metadata = mock(MavenMetadataService.class);
+    RepositoryRuntimeRegistry runtimes = mock(RepositoryRuntimeRegistry.class);
+    BlobStorageRegistry storages = mock(BlobStorageRegistry.class);
+    Instant requestedAt = Instant.now().minusSeconds(60);
+    Claim malformed = new Claim(1L, "bad-scope", requestedAt, 0, null);
+    Claim missing = new Claim(2L, MetadataRebuildScope.ga("com.acme", "missing"), requestedAt, 0, null);
+    Claim superseded = new Claim(3L, MetadataRebuildScope.ga("com.acme", "demo"), requestedAt, 0, null);
+    when(dao.claim(8)).thenReturn(List.of(malformed, missing, superseded));
+    when(runtimes.resolveById(2L)).thenReturn(Optional.empty());
+    when(runtimes.resolveById(3L)).thenReturn(Optional.of(runtime(3L, 7L)));
+    when(assetDao.findAssetByPath(3L, "com/acme/demo/maven-metadata.xml"))
+        .thenReturn(Optional.of(metadataAsset(3L, Instant.now())));
+
+    worker(assetDao, dao, metadata, runtimes, storages, true).drain();
+
+    verifyNoInteractions(metadata, storages);
+  }
+
+  @Test
+  void failedItemIsReenqueuedAndLaterClaimStillRuns() {
+    AssetDao assetDao = mock(AssetDao.class);
+    MetadataRebuildDao dao = mock(MetadataRebuildDao.class);
+    MavenMetadataService metadata = mock(MavenMetadataService.class);
+    RepositoryRuntimeRegistry runtimes = mock(RepositoryRuntimeRegistry.class);
+    BlobStorageRegistry storages = mock(BlobStorageRegistry.class);
+    RepositoryRuntime runtime = runtime(10L, 7L);
+    BlobStorage storage = mock(BlobStorage.class);
+    Instant requestedAt = Instant.now().minusSeconds(30);
+    Claim failing = new Claim(10L, MetadataRebuildScope.ga("com.fail", "first"), requestedAt, 0, null);
+    Claim succeeding = new Claim(10L, MetadataRebuildScope.ga("com.ok", "second"), requestedAt, 0, null);
+    when(dao.claim(8)).thenReturn(List.of(failing, succeeding));
+    when(runtimes.resolveById(10L)).thenReturn(Optional.of(runtime));
+    when(storages.forBlobStoreId(7L)).thenReturn(storage);
+    when(assetDao.findAssetByPath(eq(10L), any())).thenReturn(Optional.empty());
+    IllegalStateException failure = new IllegalStateException("write failed");
+    doThrow(failure).when(metadata)
+        .rebuildGa(runtime, storage, 7L, "com.fail", "first", "system", null);
+
+    worker(assetDao, dao, metadata, runtimes, storages, true).drain();
+
+    verify(dao).reenqueueFailure(failing, failure);
+    verify(metadata).rebuildGa(runtime, storage, 7L, "com.ok", "second", "system", null);
+  }
+
+  private static MetadataRebuildWorker worker(
+      AssetDao assetDao,
+      MetadataRebuildDao dao,
+      MavenMetadataService metadata,
+      RepositoryRuntimeRegistry runtimes,
+      BlobStorageRegistry storages,
+      boolean enabled) {
+    return new MetadataRebuildWorker(
+        assetDao,
+        dao,
+        metadata,
+        runtimes,
+        storages,
+        new RecordingTransactionManager(),
+        8,
+        enabled,
+        new KkRepoMetrics(new SimpleMeterRegistry()));
+  }
+
+  private static RepositoryRuntime runtime(long id, Long blobStoreId) {
+    return new RepositoryRuntime(
+        id,
+        "maven-" + id,
+        RepositoryFormat.MAVEN2,
+        RepositoryType.HOSTED,
+        "maven2-hosted",
+        true,
+        blobStoreId,
+        "ALLOW",
+        "MIXED",
+        "PERMISSIVE",
+        true,
+        null,
+        null,
+        null,
+        true,
+        null,
+        List.of());
+  }
+
+  private static AssetRecord metadataAsset(long repositoryId, Instant updatedAt) {
+    String path = "com/acme/demo/maven-metadata.xml";
+    return new AssetRecord(
+        100L,
+        repositoryId,
+        null,
+        200L,
+        RepositoryFormat.MAVEN2,
+        path,
+        null,
+        null,
+        "metadata",
+        "application/xml",
+        20L,
+        null,
+        updatedAt,
+        Map.of());
+  }
+
+  private static final class RecordingTransactionManager implements PlatformTransactionManager {
+    @Override
+    public TransactionStatus getTransaction(TransactionDefinition definition) throws TransactionException {
+      return new SimpleTransactionStatus();
+    }
+
+    @Override
+    public void commit(TransactionStatus status) throws TransactionException {
+    }
+
+    @Override
+    public void rollback(TransactionStatus status) throws TransactionException {
+    }
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/migration/RepositoryDataMigrationWorkerTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/migration/RepositoryDataMigrationWorkerTest.java
@@ -3,14 +3,41 @@ package com.github.klboke.kkrepo.server.migration;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.migration.nexus.NexusRestClient;
+import com.github.klboke.kkrepo.migration.nexus.NexusRestClient.RepositoryAssetMetadata;
+import com.github.klboke.kkrepo.migration.nexus.NexusRestClient.RepositoryAssetPage;
+import com.github.klboke.kkrepo.persistence.mysql.dao.MigrationJobDao;
 import com.github.klboke.kkrepo.persistence.mysql.dao.RepositoryDataMigrationDao;
 import com.github.klboke.kkrepo.persistence.mysql.dao.RepositoryDataMigrationDao.AssetClaim;
+import com.github.klboke.kkrepo.persistence.mysql.model.MigrationJobRecord;
 import com.github.klboke.kkrepo.persistence.mysql.model.RepositoryDataMigrationAssetRecord;
+import com.github.klboke.kkrepo.persistence.mysql.model.RepositoryDataMigrationRepositoryRecord;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpResponse;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
 
 class RepositoryDataMigrationWorkerTest {
   @Test
@@ -86,6 +113,223 @@ class RepositoryDataMigrationWorkerTest {
         claim(10L, 100L, RepositoryFormat.MAVEN2, "packages.json")));
   }
 
+  @Test
+  void discoveryPageFiltersOldAndDynamicAssetsAndPersistsCursor() {
+    Fixture fixture = fixture();
+    try {
+      RepositoryDataMigrationRepositoryRecord repository = repositoryJob(
+          RepositoryFormat.CARGO, Map.of("metadataSince", "2026-01-02T00:00:00Z"));
+      RepositoryAssetPage page = new RepositoryAssetPage(
+          "cargo",
+          null,
+          "de/mo/demo",
+          true,
+          List.of(
+              metadata("config.json", "2026-01-03T00:00:00Z"),
+              metadata("old/crate", "2026-01-01T00:00:00Z"),
+              metadata("de/mo/demo", "2026-01-03T00:00:00Z")),
+          List.of("source warning"));
+      when(fixture.migrationDao.findTargetAssetsByPathHash(eq(9L), any())).thenReturn(Map.of());
+
+      assertTrue((Boolean) invoke(
+          fixture.worker, "processDiscoveryPage",
+          new Class<?>[] {
+              RepositoryDataMigrationRepositoryRecord.class,
+              RepositoryAssetPage.class,
+              Instant.class
+          },
+          repository, page, Instant.parse("2026-01-02T00:00:00Z")));
+
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<List<RepositoryDataMigrationAssetRecord>> records =
+          ArgumentCaptor.forClass(List.class);
+      verify(fixture.migrationDao).upsertDiscoveredAssets(eq(7L), records.capture(), eq(Map.of()));
+      assertEquals(List.of("de/mo/demo"),
+          records.getValue().stream().map(RepositoryDataMigrationAssetRecord::sourcePath).toList());
+      verify(fixture.migrationDao).finishDiscoveryPage(7L, "de/mo/demo", true);
+    } finally {
+      fixture.worker.shutdown();
+    }
+  }
+
+  @Test
+  void packageConcurrencyUsesConfiguredBoundsAndFallback() {
+    Fixture fixture = fixture();
+    try {
+      when(fixture.migrationJobDao.findById(100L)).thenReturn(Optional.of(
+          new MigrationJobRecord(
+              100L, null, "http://nexus", "RUNNING", Map.of("concurrency", 200),
+              Map.of(), null, null)));
+      assertEquals(64, invoke(
+          fixture.worker, "packageConcurrency", new Class<?>[] {Long.class}, 100L));
+
+      when(fixture.migrationJobDao.findById(101L)).thenReturn(Optional.of(
+          new MigrationJobRecord(
+              101L, null, "http://nexus", "RUNNING", Map.of("concurrency", "invalid"),
+              Map.of(), null, null)));
+      assertEquals(8, invoke(
+          fixture.worker, "packageConcurrency", new Class<?>[] {Long.class}, 101L));
+      assertEquals(8, invoke(
+          fixture.worker, "packageConcurrency", new Class<?>[] {Long.class}, (Object) null));
+    } finally {
+      fixture.worker.shutdown();
+    }
+  }
+
+  @Test
+  void migrateOneMarksSuccessfulDownloadAndTargetIds() throws Exception {
+    Fixture fixture = fixture();
+    try {
+      AssetClaim claim = claim(10L, 100L, RepositoryFormat.MAVEN2, "com/acme/app.jar");
+      NexusRestClient client = mock(NexusRestClient.class);
+      @SuppressWarnings("unchecked")
+      HttpResponse<InputStream> response = mock(HttpResponse.class);
+      when(response.statusCode()).thenReturn(200);
+      when(response.headers()).thenReturn(HttpHeaders.of(
+          Map.of("Content-Type", List.of("application/java-archive")), (a, b) -> true));
+      when(response.body()).thenReturn(
+          new ByteArrayInputStream("jar".getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+      when(client.getRepositoryAsset("source", "com/acme/app.jar")).thenReturn(response);
+      when(fixture.writer.write(eq(1L), eq(claim.asset()), any(), eq("application/java-archive"), eq(true)))
+          .thenReturn(new RepositoryDataMigrationWriter.WriteResult(20L, 30L, 40L, "object"));
+
+      invoke(
+          fixture.worker, "migrateOne",
+          new Class<?>[] {AssetClaim.class, NexusRestClient.class, boolean.class},
+          claim, client, true);
+
+      verify(fixture.migrationDao).markAssetMigrated(
+          claim.asset().id(), claim.asset().repositoryJobId(), 20L, 30L, 40L);
+      verify(fixture.migrationDao, never()).markAssetFailed(anyLong(), anyLong(), anyInt(), any());
+    } finally {
+      fixture.worker.shutdown();
+    }
+  }
+
+  @Test
+  void migrateOneMarksHttpFailureAndSkipsDerivedCargoConfig() throws Exception {
+    Fixture fixture = fixture();
+    try {
+      AssetClaim failed = claim(10L, 100L, RepositoryFormat.MAVEN2, "missing.jar");
+      NexusRestClient client = mock(NexusRestClient.class);
+      @SuppressWarnings("unchecked")
+      HttpResponse<InputStream> response = mock(HttpResponse.class);
+      InputStream body = mock(InputStream.class);
+      when(response.statusCode()).thenReturn(404);
+      when(response.body()).thenReturn(body);
+      when(client.getRepositoryAsset("source", "missing.jar")).thenReturn(response);
+
+      invoke(
+          fixture.worker, "migrateOne",
+          new Class<?>[] {AssetClaim.class, NexusRestClient.class, boolean.class},
+          failed, client, true);
+
+      verify(body).close();
+      verify(fixture.migrationDao).markAssetFailed(
+          eq(failed.asset().id()), eq(failed.asset().repositoryJobId()), eq(5),
+          org.mockito.ArgumentMatchers.contains("HTTP 404"));
+
+      AssetClaim skipped = claim(11L, 100L, RepositoryFormat.CARGO, "/config.json");
+      invoke(
+          fixture.worker, "migrateOne",
+          new Class<?>[] {AssetClaim.class, NexusRestClient.class, boolean.class},
+          skipped, client, true);
+      verify(fixture.migrationDao).markAssetMigrated(
+          skipped.asset().id(), skipped.asset().repositoryJobId(), null, null, null);
+      verify(client, never()).getRepositoryAsset("source", "/config.json");
+    } finally {
+      fixture.worker.shutdown();
+    }
+  }
+
+  @Test
+  void metadataEngineRecognizesProfilesAndMigrationAdapters() {
+    assertEquals("ORIENTDB", invokeStatic(
+        "metadataEngine", new Class<?>[] {Map.class},
+        Map.of("migrationPlan", Map.of("adapter", "NexusOrientDbAdapter"))));
+    assertEquals("DATASTORE_H2", invokeStatic(
+        "metadataEngine", new Class<?>[] {Map.class},
+        Map.of("migrationPlan", Map.of("adapter", "NexusDatastoreH2Adapter"))));
+    assertEquals("DATASTORE_POSTGRESQL", invokeStatic(
+        "metadataEngine", new Class<?>[] {Map.class},
+        Map.of("migrationPlan", Map.of("adapter", "NexusDatastorePostgresqlAdapter"))));
+    assertEquals("CUSTOM", invokeStatic(
+        "metadataEngine", new Class<?>[] {Map.class},
+        Map.of("sourceProfile", Map.of("metadataEngine", "CUSTOM"))));
+    assertEquals("UNKNOWN", invokeStatic(
+        "metadataEngine", new Class<?>[] {Map.class}, Map.of()));
+  }
+
+  private static Fixture fixture() {
+    MigrationJobDao migrationJobDao = mock(MigrationJobDao.class);
+    RepositoryDataMigrationDao migrationDao = mock(RepositoryDataMigrationDao.class);
+    RepositoryDataMigrationService migrationService = mock(RepositoryDataMigrationService.class);
+    RepositoryDataMigrationWriter writer = mock(RepositoryDataMigrationWriter.class);
+    PlatformTransactionManager transactions = mock(PlatformTransactionManager.class);
+    when(transactions.getTransaction(any(TransactionDefinition.class)))
+        .thenReturn(mock(TransactionStatus.class));
+    return new Fixture(
+        migrationJobDao,
+        migrationDao,
+        writer,
+        new RepositoryDataMigrationWorker(
+            new ObjectMapper(), migrationJobDao, migrationDao, migrationService, writer, transactions));
+  }
+
+  private static RepositoryDataMigrationRepositoryRecord repositoryJob(
+      RepositoryFormat format, Map<String, Object> options) {
+    return new RepositoryDataMigrationRepositoryRecord(
+        7L, 100L, "source", "target", 9L, format,
+        RepositoryDataMigrationDao.REPOSITORY_DISCOVERING, null, 100,
+        0, 0, 0, 0, null, null, options, null, null);
+  }
+
+  private static RepositoryAssetMetadata metadata(String path, String updatedAt) {
+    return new RepositoryAssetMetadata(
+        "source", "asset-" + path, null, path, "cargo", null,
+        "demo", "1.0.0", "asset", "application/octet-stream", 1L,
+        null, updatedAt, null, null, updatedAt, "admin", null, Map.of(), Map.of());
+  }
+
+  private static Object invoke(
+      Object target, String methodName, Class<?>[] parameterTypes, Object... args) {
+    try {
+      Method method = target.getClass().getDeclaredMethod(methodName, parameterTypes);
+      method.setAccessible(true);
+      return method.invoke(target, args);
+    } catch (InvocationTargetException e) {
+      if (e.getCause() instanceof RuntimeException runtime) {
+        throw runtime;
+      }
+      throw new IllegalStateException(e.getCause());
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static Object invokeStatic(
+      String methodName, Class<?>[] parameterTypes, Object... args) {
+    try {
+      Method method = RepositoryDataMigrationWorker.class.getDeclaredMethod(methodName, parameterTypes);
+      method.setAccessible(true);
+      return method.invoke(null, args);
+    } catch (InvocationTargetException e) {
+      if (e.getCause() instanceof RuntimeException runtime) {
+        throw runtime;
+      }
+      throw new IllegalStateException(e.getCause());
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private record Fixture(
+      MigrationJobDao migrationJobDao,
+      RepositoryDataMigrationDao migrationDao,
+      RepositoryDataMigrationWriter writer,
+      RepositoryDataMigrationWorker worker) {
+  }
+
   private static AssetClaim claim(long repositoryJobId, long migrationJobId, String path) {
     return claim(repositoryJobId, migrationJobId, RepositoryFormat.MAVEN2, path);
   }
@@ -96,7 +340,7 @@ class RepositoryDataMigrationWorkerTest {
       RepositoryFormat format,
       String path) {
     RepositoryDataMigrationAssetRecord asset = new RepositoryDataMigrationAssetRecord(
-        null,
+        repositoryJobId + 1000,
         repositoryJobId,
         null,
         null,

--- a/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmHostedServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmHostedServiceTest.java
@@ -25,12 +25,16 @@ import com.github.klboke.kkrepo.server.cache.AssetMetadataCache;
 import com.github.klboke.kkrepo.server.maven.BlobStorageRegistry;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.mock.web.MockMultipartFile;
@@ -157,6 +161,103 @@ class NpmHostedServiceTest {
         "alice", null).status());
   }
 
+  @Test
+  void multipartTarballUploadCreatesVersionDistAndLatestTag() throws Exception {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime("ALLOW", 7L);
+    when(fixture.assetDao.findAssetByPath(10L, "demo")).thenReturn(Optional.empty());
+    when(fixture.assetDao.findAssetByPath(10L, "demo/-/demo-1.0.0.tgz"))
+        .thenReturn(Optional.empty());
+    when(fixture.writer.writeTarball(
+        eq(runtime), eq(fixture.storage), eq(7L), eq(PACKAGE), eq("1.0.0"),
+        eq("demo-1.0.0.tgz"), any(), eq("application/gzip"), eq("alice"), eq("127.0.0.1"),
+        eq(Map.of())))
+        .thenReturn(new NpmAssetWriter.Stored(
+            null,
+            null,
+            new NpmAssetWriter.Digests("md5", "sha1-value", "sha256", "sha512", 123L),
+            true,
+            null));
+    MockMultipartFile upload = new MockMultipartFile(
+        "asset",
+        "demo-1.0.0.tgz",
+        "application/gzip",
+        tarball("package/package.json", """
+            {"name":"demo","version":"1.0.0","description":"demo package"}
+            """));
+
+    assertEquals(201, fixture.service.uploadTarball(
+        runtime, upload, "alice", "127.0.0.1").status());
+
+    ArgumentCaptor<byte[]> json = ArgumentCaptor.forClass(byte[].class);
+    verify(fixture.writer).writePackageRoot(
+        eq(runtime), eq(fixture.storage), eq(7L), eq(PACKAGE),
+        json.capture(), eq("alice"), eq("127.0.0.1"));
+    Map<String, Object> stored = fixture.mapper.readValue(json.getValue(), MAP);
+    assertEquals("1.0.0", map(stored.get("dist-tags")).get("latest"));
+    Map<String, Object> version = map(map(stored.get("versions")).get("1.0.0"));
+    assertEquals("demo-1.0.0.tgz", map(version.get("dist")).get("tarball"));
+    assertEquals("sha1-value", map(version.get("dist")).get("shasum"));
+    assertNotNull(stored.get("_rev"));
+  }
+
+  @Test
+  void multipartTarballRequiresPackageJsonNameAndVersion() throws Exception {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime("ALLOW", 7L);
+
+    assertThrows(NpmExceptions.BadRequestException.class, () -> fixture.service.uploadTarball(
+        runtime,
+        new MockMultipartFile(
+            "asset", "demo-1.0.0.tgz", "application/gzip",
+            tarball("package/README.md", "readme")),
+        "alice",
+        null));
+    assertThrows(NpmExceptions.BadRequestException.class, () -> fixture.service.uploadTarball(
+        runtime,
+        new MockMultipartFile(
+            "asset", "demo-1.0.0.tgz", "application/gzip",
+            tarball("package/package.json", "{\"name\":\"demo\"}")),
+        "alice",
+        null));
+
+    verify(fixture.writer, never()).writeTarball(
+        any(), any(), anyLong(), any(), anyString(), anyString(), any(),
+        anyString(), anyString(), any(), any());
+  }
+
+  @Test
+  void deletingTarballRemovesVersionAndTagsThatPointToIt() throws Exception {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime("ALLOW", 7L);
+    stubPackageRoot(fixture, """
+        {
+          "name":"demo",
+          "_rev":"2-existing",
+          "versions":{
+            "1.0.0":{"name":"demo","version":"1.0.0",
+              "dist":{"tarball":"demo-1.0.0.tgz"}},
+            "2.0.0":{"name":"demo","version":"2.0.0",
+              "dist":{"tarball":"demo-2.0.0.tgz"}}
+          },
+          "dist-tags":{"latest":"2.0.0","beta":"2.0.0","stable":"1.0.0"}
+        }
+        """);
+    when(fixture.writer.deletePath(
+        runtime, fixture.storage, "demo/-/demo-2.0.0.tgz")).thenReturn(1);
+
+    assertEquals(200, fixture.service.deleteTarball(
+        runtime, PACKAGE, "demo-2.0.0.tgz", "2-existing").status());
+
+    ArgumentCaptor<byte[]> json = ArgumentCaptor.forClass(byte[].class);
+    verify(fixture.writer).writePackageRoot(
+        eq(runtime), eq(fixture.storage), eq(7L), eq(PACKAGE),
+        json.capture(), eq("system"), eq(null));
+    Map<String, Object> stored = fixture.mapper.readValue(json.getValue(), MAP);
+    assertEquals(List.of("1.0.0"), map(stored.get("versions")).keySet().stream().toList());
+    assertEquals(Map.of("stable", "1.0.0"), map(stored.get("dist-tags")));
+  }
+
   private static void stubPackageRoot(Fixture fixture, String json) {
     AssetRecord asset = new AssetRecord(
         1L, 10L, 2L, 3L, RepositoryFormat.NPM, "demo", null,
@@ -170,6 +271,25 @@ class NpmHostedServiceTest {
     when(fixture.assetDao.findBlobById(3L)).thenReturn(Optional.of(blob));
     when(fixture.storage.get(any())).thenAnswer(invocation -> Optional.of(
         new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> map(Object value) {
+    return (Map<String, Object>) value;
+  }
+
+  private static byte[] tarball(String entryName, String content) throws Exception {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (GzipCompressorOutputStream gzip = new GzipCompressorOutputStream(bytes);
+        TarArchiveOutputStream tar = new TarArchiveOutputStream(gzip)) {
+      byte[] body = content.getBytes(StandardCharsets.UTF_8);
+      TarArchiveEntry entry = new TarArchiveEntry(entryName);
+      entry.setSize(body.length);
+      tar.putArchiveEntry(entry);
+      tar.write(body);
+      tar.closeArchiveEntry();
+    }
+    return bytes.toByteArray();
   }
 
   private static Fixture fixture() {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmHostedServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmHostedServiceTest.java
@@ -1,0 +1,208 @@
+package com.github.klboke.kkrepo.server.npm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.klboke.kkrepo.core.BlobStorage;
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.mysql.dao.AssetDao;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetBlobRecord;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetRecord;
+import com.github.klboke.kkrepo.protocol.npm.NpmPackageId;
+import com.github.klboke.kkrepo.server.cache.AssetMetadataCache;
+import com.github.klboke.kkrepo.server.maven.BlobStorageRegistry;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.mock.web.MockMultipartFile;
+
+class NpmHostedServiceTest {
+  private static final TypeReference<Map<String, Object>> MAP = new TypeReference<>() {
+  };
+  private static final NpmPackageId PACKAGE = NpmPackageId.parse("demo");
+
+  @Test
+  void publishesPackageRootAndAttachmentWithGeneratedRevision() throws Exception {
+    Fixture fixture = fixture();
+    when(fixture.assetDao.findAssetByPath(10L, "demo")).thenReturn(Optional.empty());
+    when(fixture.assetDao.findAssetByPath(10L, "demo/-/demo-1.0.0.tgz"))
+        .thenReturn(Optional.empty());
+    String attachment = Base64.getEncoder()
+        .encodeToString("tarball".getBytes(StandardCharsets.UTF_8));
+    String body = """
+        {
+          "name":"demo",
+          "versions":{"1.0.0":{"name":"demo","version":"1.0.0",
+            "dist":{"tarball":"demo-1.0.0.tgz"}}},
+          "dist-tags":{"latest":"1.0.0"},
+          "_attachments":{"demo-1.0.0.tgz":{"data":"%s","content_type":"application/octet-stream"}}
+        }
+        """.formatted(attachment);
+
+    assertEquals(200, fixture.service.putPackage(
+        runtime("ALLOW", 7L), PACKAGE, null,
+        new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)),
+        "alice", "127.0.0.1").status());
+
+    verify(fixture.writer).writeTarball(
+        eq(runtime("ALLOW", 7L)), eq(fixture.storage), eq(7L), eq(PACKAGE),
+        eq("1.0.0"), eq("demo-1.0.0.tgz"), any(), eq("application/octet-stream"),
+        eq("alice"), eq("127.0.0.1"), eq(Map.of()));
+    ArgumentCaptor<byte[]> json = ArgumentCaptor.forClass(byte[].class);
+    verify(fixture.writer).writePackageRoot(
+        eq(runtime("ALLOW", 7L)), eq(fixture.storage), eq(7L), eq(PACKAGE),
+        json.capture(), eq("alice"), eq("127.0.0.1"));
+    Map<String, Object> stored = fixture.mapper.readValue(json.getValue(), MAP);
+    assertNotNull(stored.get("_rev"));
+    assertEquals(null, stored.get("_attachments"));
+  }
+
+  @Test
+  void rejectsPackageNameAndRevisionMismatches() {
+    Fixture fixture = fixture();
+    assertThrows(NpmExceptions.BadRequestException.class, () -> fixture.service.putPackage(
+        runtime("ALLOW", 7L), PACKAGE, null,
+        new ByteArrayInputStream("{\"name\":\"other\"}".getBytes(StandardCharsets.UTF_8)),
+        "alice", null));
+
+    stubPackageRoot(fixture, """
+        {"name":"demo","_rev":"2-existing","versions":{},"dist-tags":{}}
+        """);
+    assertThrows(NpmExceptions.BadRequestException.class, () -> fixture.service.putPackage(
+        runtime("ALLOW", 7L), PACKAGE, "1-stale",
+        new ByteArrayInputStream("{\"name\":\"demo\"}".getBytes(StandardCharsets.UTF_8)),
+        "alice", null));
+    verify(fixture.writer, never()).writePackageRoot(
+        any(), any(), anyLong(), any(), any(), anyString(), any());
+  }
+
+  @Test
+  void validatesAttachmentsBeforeWritingAnyBlob() {
+    Fixture fixture = fixture();
+    when(fixture.assetDao.findAssetByPath(10L, "demo")).thenReturn(Optional.empty());
+    String body = """
+        {"name":"demo","versions":{},
+         "_attachments":{"demo-1.0.0.tgz":{"data":"dGFyYmFsbA=="}}}
+        """;
+
+    assertThrows(NpmExceptions.BadRequestException.class, () -> fixture.service.putPackage(
+        runtime("ALLOW", 7L), PACKAGE, null,
+        new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)),
+        "alice", null));
+
+    verify(fixture.registry, never()).forBlobStoreId(anyLong());
+    verify(fixture.writer, never()).writeTarball(
+        any(), any(), anyLong(), any(), anyString(), anyString(), any(),
+        anyString(), anyString(), any(), any());
+  }
+
+  @Test
+  void enforcesHostedWriteAndDeletePolicies() {
+    Fixture fixture = fixture();
+    assertThrows(NpmExceptions.MethodNotAllowed.class, () -> fixture.service.putPackage(
+        proxyRuntime(), PACKAGE, null,
+        new ByteArrayInputStream("{}".getBytes(StandardCharsets.UTF_8)), "alice", null));
+    assertThrows(NpmExceptions.WritePolicyDenied.class, () -> fixture.service.putPackage(
+        runtime("DENY", 7L), PACKAGE, null,
+        new ByteArrayInputStream("{\"name\":\"demo\"}".getBytes(StandardCharsets.UTF_8)),
+        "alice", null));
+    assertThrows(NpmExceptions.WritePolicyDenied.class,
+        () -> fixture.service.deletePackage(runtime("DENY", 7L), PACKAGE, null));
+    assertThrows(IllegalStateException.class, () -> fixture.service.putPackage(
+        runtime("ALLOW", null), PACKAGE, null,
+        new ByteArrayInputStream("{\"name\":\"demo\"}".getBytes(StandardCharsets.UTF_8)),
+        "alice", null));
+  }
+
+  @Test
+  void validatesDistTagsAndMultipartUploads() throws Exception {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime("ALLOW", 7L);
+    assertThrows(NpmExceptions.BadRequestException.class, () -> fixture.service.putDistTag(
+        runtime, PACKAGE, "latest",
+        new ByteArrayInputStream("\"1.0.0\"".getBytes(StandardCharsets.UTF_8)),
+        "alice", null));
+    assertThrows(NpmExceptions.BadRequestException.class, () -> fixture.service.deleteDistTag(
+        runtime, PACKAGE, "latest", "alice", null));
+    assertThrows(NpmExceptions.BadRequestException.class,
+        () -> fixture.service.uploadTarball(runtime, null, "alice", null));
+    assertThrows(NpmExceptions.BadRequestException.class,
+        () -> fixture.service.uploadTarball(
+            runtime,
+            new MockMultipartFile("asset", "demo.zip", "application/zip", new byte[] {1}),
+            "alice", null));
+
+    assertEquals(200, fixture.service.putDistTag(
+        runtime, PACKAGE, "beta",
+        new ByteArrayInputStream("\"1.0.0\"".getBytes(StandardCharsets.UTF_8)),
+        "alice", null).status());
+  }
+
+  private static void stubPackageRoot(Fixture fixture, String json) {
+    AssetRecord asset = new AssetRecord(
+        1L, 10L, 2L, 3L, RepositoryFormat.NPM, "demo", null,
+        "demo", "package-root", "application/json", (long) json.length(),
+        null, Instant.EPOCH, Map.of());
+    AssetBlobRecord blob = new AssetBlobRecord(
+        3L, 7L, "blob://bucket/demo", null, "demo", null,
+        "sha1", "sha256", "md5", (long) json.length(), "application/json",
+        "alice", null, Instant.EPOCH, Instant.EPOCH, Map.of());
+    when(fixture.assetDao.findAssetByPath(10L, "demo")).thenReturn(Optional.of(asset));
+    when(fixture.assetDao.findBlobById(3L)).thenReturn(Optional.of(blob));
+    when(fixture.storage.get(any())).thenAnswer(invocation -> Optional.of(
+        new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))));
+  }
+
+  private static Fixture fixture() {
+    AssetDao assetDao = mock(AssetDao.class);
+    BlobStorageRegistry registry = mock(BlobStorageRegistry.class);
+    NpmAssetWriter writer = mock(NpmAssetWriter.class);
+    BlobStorage storage = mock(BlobStorage.class);
+    ObjectMapper mapper = new ObjectMapper();
+    when(registry.forBlobStoreId(7L)).thenReturn(storage);
+    return new Fixture(
+        assetDao, registry, writer, storage, mapper,
+        new NpmHostedService(assetDao, registry, writer, mapper, mock(AssetMetadataCache.class)));
+  }
+
+  private static RepositoryRuntime runtime(String writePolicy, Long blobStoreId) {
+    return new RepositoryRuntime(
+        10L, "npm-hosted", RepositoryFormat.NPM, RepositoryType.HOSTED, "npm-hosted", true,
+        blobStoreId, writePolicy, null, null, true, null, null, null, null, null, List.of());
+  }
+
+  private static RepositoryRuntime proxyRuntime() {
+    return new RepositoryRuntime(
+        10L, "npm-proxy", RepositoryFormat.NPM, RepositoryType.PROXY, "npm-proxy", true,
+        7L, null, null, null, true, "https://registry.npmjs.org/",
+        60, 60, true, null, List.of());
+  }
+
+  private record Fixture(
+      AssetDao assetDao,
+      BlobStorageRegistry registry,
+      NpmAssetWriter writer,
+      BlobStorage storage,
+      ObjectMapper mapper,
+      NpmHostedService service) {
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmProxyRuntimeTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmProxyRuntimeTest.java
@@ -1,0 +1,266 @@
+package com.github.klboke.kkrepo.server.npm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.klboke.kkrepo.core.BlobStorage;
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.mysql.dao.AssetDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.ProxyStateDao;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetBlobRecord;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetRecord;
+import com.github.klboke.kkrepo.protocol.npm.NpmPackageId;
+import com.github.klboke.kkrepo.protocol.npm.NpmPath;
+import com.github.klboke.kkrepo.server.cache.AssetMetadataCache;
+import com.github.klboke.kkrepo.server.cache.CachedAssetMetadata;
+import com.github.klboke.kkrepo.server.maven.BlobStorageRegistry;
+import com.github.klboke.kkrepo.server.maven.HttpRemoteFetcher;
+import com.github.klboke.kkrepo.server.maven.MavenResponse;
+import com.github.klboke.kkrepo.server.maven.ProxyNegativeCache;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class NpmProxyRuntimeTest {
+  private static final NpmPackageId PACKAGE = NpmPackageId.parse("demo");
+  private static final String TARBALL = "demo-1.0.0.tgz";
+  private static final String TARBALL_PATH = "demo/-/" + TARBALL;
+
+  @Test
+  void servesFreshPackageAndTarballFromHostedCache() throws Exception {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(60, 7L);
+    CachedAssetMetadata packageRoot = snapshot("demo", Instant.now(), "package-root", Map.of());
+    CachedAssetMetadata tarball = snapshot(TARBALL_PATH, Instant.now(), "tarball", Map.of());
+    when(fixture.cache.find(eq(10L), anyString(), any()))
+        .thenAnswer(invocation -> Optional.of(
+            invocation.getArgument(1).equals("demo") ? packageRoot : tarball));
+    MavenResponse packageResponse = MavenResponse.noBody(200);
+    MavenResponse tarballResponse = MavenResponse.noBody(200);
+    when(fixture.hosted.getPackage(
+        runtime, PACKAGE, "http://localhost/repository/npm", true, NpmPackumentVariant.FULL))
+        .thenReturn(packageResponse);
+    when(fixture.hosted.getTarball(runtime, PACKAGE, TARBALL, false))
+        .thenReturn(tarballResponse);
+
+    assertSame(packageResponse, fixture.service.getPackage(
+        runtime, PACKAGE, "http://localhost/repository/npm", true));
+    assertSame(tarballResponse, fixture.service.getTarball(runtime, PACKAGE, TARBALL, false));
+    verify(fixture.fetcher, never()).fetchWithBodyRetry(any(), anyString(), any());
+  }
+
+  @Test
+  void fetchesPackumentRewritesTarballUrlsAndSupportsInstallVariant() throws Exception {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(1, 7L);
+    when(fixture.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.empty());
+    when(fixture.registry.forBlobStoreId(7L)).thenReturn(fixture.storage);
+    respond(fixture.fetcher, new HttpRemoteFetcher.Result(
+        200, Map.of("Content-Type", "application/json", "ETag", "\"root\""),
+        new ByteArrayInputStream("""
+            {"name":"demo","dist-tags":{"latest":"1.0.0"},"versions":{
+              "1.0.0":{"name":"demo","version":"1.0.0",
+                "dist":{"tarball":"https://registry.npmjs.org/demo/-/demo-1.0.0.tgz"}}
+            }}
+            """.getBytes(StandardCharsets.UTF_8))));
+    when(fixture.writer.writePackageRoot(
+        eq(runtime), eq(fixture.storage), eq(7L), eq(PACKAGE), any(),
+        eq("proxy"), eq(runtime.proxyRemoteUrl()), eq(Map.of("remoteEtag", "root"))))
+        .thenReturn(stored("demo", "package-root", "application/json"));
+
+    MavenResponse response = fixture.service.getPackage(
+        runtime, PACKAGE, "http://localhost/repository/npm", false,
+        NpmPackumentVariant.INSTALL_V1);
+    String json = new String(response.body().readAllBytes(), StandardCharsets.UTF_8);
+
+    assertTrue(json.contains("http://localhost/repository/npm/demo/-/demo-1.0.0.tgz"));
+    assertEquals("application/json", response.contentType());
+    verify(fixture.proxyStateDao).recordSuccess(eq(10L), any());
+    verify(fixture.negativeCache).invalidate(runtime, "demo");
+  }
+
+  @Test
+  void cachesTarballForHeadAndInfersVersion() throws Exception {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(1, 7L);
+    when(fixture.cache.find(eq(10L), eq(TARBALL_PATH), any())).thenReturn(Optional.empty());
+    when(fixture.registry.forBlobStoreId(7L)).thenReturn(fixture.storage);
+    respond(fixture.fetcher, new HttpRemoteFetcher.Result(
+        200, Map.of("Content-Type", "application/octet-stream", "ETag", "\"tar\""),
+        new ByteArrayInputStream("tarball".getBytes(StandardCharsets.UTF_8))));
+    when(fixture.writer.writeTarball(
+        eq(runtime), eq(fixture.storage), eq(7L), eq(PACKAGE), eq("1.0.0"), eq(TARBALL),
+        any(), eq("application/octet-stream"), eq("proxy"), eq(runtime.proxyRemoteUrl()),
+        eq(Map.of("remoteEtag", "tar")), eq(false)))
+        .thenReturn(stored(TARBALL_PATH, "tarball", "application/octet-stream"));
+
+    MavenResponse response = fixture.service.getTarball(runtime, PACKAGE, TARBALL, true);
+
+    assertEquals(200, response.status());
+    assertEquals(7L, response.contentLength());
+    verify(fixture.negativeCache).invalidate(runtime, TARBALL_PATH);
+  }
+
+  @Test
+  void handlesNotModifiedRemoteMissAndStaleFailureFallback() throws Exception {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(1, 7L);
+    CachedAssetMetadata stale = snapshot(
+        "demo", Instant.EPOCH, "package-root",
+        Map.of("remoteEtag", "etag", "remoteLastModified", "invalid"));
+    MavenResponse expected = MavenResponse.noBody(200);
+    when(fixture.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.of(stale));
+    when(fixture.hosted.getPackage(
+        runtime, PACKAGE, "base", true, NpmPackumentVariant.FULL)).thenReturn(expected);
+    respond(fixture.fetcher, new HttpRemoteFetcher.Result(
+        304, Map.of(), new ByteArrayInputStream(new byte[0])));
+
+    assertSame(expected, fixture.service.getPackage(runtime, PACKAGE, "base", true));
+    verify(fixture.assetDao).touchAssetLastUpdated(eq(1L), any());
+    verify(fixture.cache).touchVerified(eq(10L), eq("demo"), any(), eq(null));
+
+    Fixture missing = fixture();
+    when(missing.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.empty());
+    respond(missing.fetcher, new HttpRemoteFetcher.Result(
+        404, Map.of(), new ByteArrayInputStream(new byte[0])));
+    assertThrows(NpmExceptions.NpmNotFoundException.class,
+        () -> missing.service.getPackage(runtime, PACKAGE, "base", false));
+    verify(missing.negativeCache).rememberNotFound(runtime, "demo");
+
+    Fixture failed = fixture();
+    when(failed.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.of(stale));
+    when(failed.hosted.getPackage(
+        runtime, PACKAGE, "base", false, NpmPackumentVariant.FULL)).thenReturn(expected);
+    respond(failed.fetcher, new HttpRemoteFetcher.Result(
+        503, Map.of(), new ByteArrayInputStream(new byte[0])));
+    assertSame(expected, failed.service.getPackage(runtime, PACKAGE, "base", false));
+    verify(failed.proxyStateDao).recordFailure(eq(10L), eq(30L), anyString(), any());
+  }
+
+  @Test
+  void validatesNegativeCacheRuntimeKindContentAndBlobStore() throws Exception {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(1, 7L);
+    when(fixture.cache.find(eq(10L), eq(TARBALL_PATH), any())).thenReturn(Optional.empty());
+    when(fixture.negativeCache.isNotFoundCached(runtime, TARBALL_PATH)).thenReturn(true);
+    assertThrows(NpmExceptions.NpmNotFoundException.class,
+        () -> fixture.service.getTarball(runtime, PACKAGE, TARBALL, false));
+    assertThrows(IllegalStateException.class, () -> fixture.service.get(
+        hostedRuntime(),
+        new NpmPath(NpmPath.Kind.PACKAGE_ROOT, "demo", PACKAGE, null, null, null, null),
+        "base", false));
+
+    Fixture html = fixture();
+    when(html.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.empty());
+    respond(html.fetcher, new HttpRemoteFetcher.Result(
+        200, Map.of("Content-Type", "text/html"),
+        new ByteArrayInputStream("<html>login</html>".getBytes(StandardCharsets.UTF_8))));
+    assertThrows(NpmExceptions.NpmNotFoundException.class,
+        () -> html.service.getPackage(runtime, PACKAGE, "base", false));
+
+    Fixture noStore = fixture();
+    when(noStore.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.empty());
+    respond(noStore.fetcher, new HttpRemoteFetcher.Result(
+        200, Map.of("Content-Type", "application/json"),
+        new ByteArrayInputStream("{\"name\":\"demo\"}".getBytes(StandardCharsets.UTF_8))));
+    assertThrows(IllegalStateException.class,
+        () -> noStore.service.getPackage(runtime(1, null), PACKAGE, "base", false));
+  }
+
+  private static void respond(HttpRemoteFetcher fetcher, HttpRemoteFetcher.Result result)
+      throws IOException {
+    doAnswer(invocation -> {
+      @SuppressWarnings("unchecked")
+      HttpRemoteFetcher.ResultHandler<Object> handler = invocation.getArgument(2);
+      return handler.handle(result);
+    }).when(fetcher).fetchWithBodyRetry(any(), anyString(), any());
+  }
+
+  private static Fixture fixture() {
+    AssetDao assetDao = mock(AssetDao.class);
+    BlobStorageRegistry registry = mock(BlobStorageRegistry.class);
+    NpmAssetWriter writer = mock(NpmAssetWriter.class);
+    ProxyStateDao proxyStateDao = mock(ProxyStateDao.class);
+    HttpRemoteFetcher fetcher = mock(HttpRemoteFetcher.class);
+    NpmHostedService hosted = mock(NpmHostedService.class);
+    ProxyNegativeCache negativeCache = mock(ProxyNegativeCache.class);
+    AssetMetadataCache cache = mock(AssetMetadataCache.class);
+    BlobStorage storage = mock(BlobStorage.class);
+    return new Fixture(
+        assetDao, registry, writer, proxyStateDao, fetcher, hosted, negativeCache, cache,
+        storage, new NpmProxyService(
+            assetDao, registry, writer, proxyStateDao, fetcher, hosted, new ObjectMapper(),
+            negativeCache, cache, null));
+  }
+
+  private static RepositoryRuntime runtime(int maxAgeMinutes, Long blobStoreId) {
+    return new RepositoryRuntime(
+        10L, "npm", RepositoryFormat.NPM, RepositoryType.PROXY, "npm", true, blobStoreId,
+        null, null, null, true, "https://registry.npmjs.org/",
+        maxAgeMinutes, maxAgeMinutes, true, null, List.of());
+  }
+
+  private static RepositoryRuntime hostedRuntime() {
+    return new RepositoryRuntime(
+        10L, "npm", RepositoryFormat.NPM, RepositoryType.HOSTED, "npm", true, 7L,
+        "ALLOW", null, null, true, null, null, null, null, null, List.of());
+  }
+
+  private static CachedAssetMetadata snapshot(
+      String path, Instant updatedAt, String kind, Map<String, Object> blobAttributes) {
+    AssetRecord asset = new AssetRecord(
+        1L, 10L, 3L, 2L, RepositoryFormat.NPM, path, null,
+        path.substring(path.lastIndexOf('/') + 1), kind,
+        "tarball".equals(kind) ? "application/octet-stream" : "application/json",
+        7L, null, updatedAt, Map.of());
+    return CachedAssetMetadata.of(asset, blob(blobAttributes));
+  }
+
+  private static NpmAssetWriter.Stored stored(String path, String kind, String contentType) {
+    AssetRecord asset = new AssetRecord(
+        1L, 10L, 3L, 2L, RepositoryFormat.NPM, path, null,
+        path.substring(path.lastIndexOf('/') + 1), kind, contentType,
+        7L, null, Instant.now(), Map.of());
+    return new NpmAssetWriter.Stored(
+        asset, blob(Map.of()), new NpmAssetWriter.Digests("md5", "sha1", "sha256", "sha512", 7L),
+        true, null);
+  }
+
+  private static AssetBlobRecord blob(Map<String, Object> attributes) {
+    return new AssetBlobRecord(
+        2L, 7L, "blob://bucket/object", null, "object", null,
+        "sha1", "sha256", "md5", 7L, "application/octet-stream",
+        "proxy", "upstream", Instant.EPOCH, Instant.EPOCH, attributes);
+  }
+
+  private record Fixture(
+      AssetDao assetDao,
+      BlobStorageRegistry registry,
+      NpmAssetWriter writer,
+      ProxyStateDao proxyStateDao,
+      HttpRemoteFetcher fetcher,
+      NpmHostedService hosted,
+      ProxyNegativeCache negativeCache,
+      AssetMetadataCache cache,
+      BlobStorage storage,
+      NpmProxyService service) {
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmSearchServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmSearchServiceTest.java
@@ -1,0 +1,221 @@
+package com.github.klboke.kkrepo.server.npm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.mysql.dao.ComponentDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.ComponentDao.ComponentSearchRow;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class NpmSearchServiceTest {
+
+  @Test
+  void hostedSearchBuildsScopedPackageResultAndTiming() {
+    ComponentDao components = mock(ComponentDao.class);
+    NpmHostedService hosted = mock(NpmHostedService.class);
+    NpmProxyService proxy = mock(NpmProxyService.class);
+    RepositoryRuntime runtime = hosted(1L, "npm-hosted");
+    when(components.searchByRepositoryIds(List.of(1L), "client", 20))
+        .thenReturn(List.of(row(11L, 1L, "scope", "client", "1.2.3")));
+
+    Map<String, Object> response =
+        new NpmSearchService(components, hosted, proxy)
+            .search(runtime, "client", 20, "https://repo.example/repository/npm-hosted");
+
+    assertEquals(1, response.get("total"));
+    assertTrue(String.valueOf(response.get("time")).endsWith("ms"));
+    Map<String, Object> item = objects(response).get(0);
+    Map<String, Object> pkg = map(item.get("package"));
+    assertEquals("@scope/client", pkg.get("name"));
+    assertEquals("1.2.3", pkg.get("version"));
+    assertEquals(
+        "https://repo.example/repository/npm-hosted/@scope/client",
+        map(pkg.get("links")).get("npm"));
+    assertEquals(1.0, item.get("searchScore"));
+  }
+
+  @Test
+  void proxySearchDelegatesWithoutRewritingResponse() {
+    ComponentDao components = mock(ComponentDao.class);
+    NpmHostedService hosted = mock(NpmHostedService.class);
+    NpmProxyService proxy = mock(NpmProxyService.class);
+    RepositoryRuntime runtime = proxy(2L, "npm-proxy");
+    Map<String, Object> upstream = Map.of("objects", List.of(), "total", 42);
+    when(proxy.search(runtime, "demo", 5)).thenReturn(upstream);
+
+    Map<String, Object> response =
+        new NpmSearchService(components, hosted, proxy)
+            .search(runtime, "demo", 5, "https://repo.example/repository/npm-proxy");
+
+    assertSame(upstream, response);
+  }
+
+  @Test
+  void groupSearchPreservesMemberOrderDeduplicatesNamesAndHonorsLimit() {
+    ComponentDao components = mock(ComponentDao.class);
+    NpmHostedService hosted = mock(NpmHostedService.class);
+    NpmProxyService proxy = mock(NpmProxyService.class);
+    RepositoryRuntime hostedMember = hosted(1L, "hosted");
+    RepositoryRuntime proxyMember = proxy(2L, "proxy");
+    RepositoryRuntime group = group(10L, List.of(hostedMember, proxyMember));
+    when(components.searchByRepositoryIds(List.of(1L), "demo", 2))
+        .thenReturn(List.of(row(1L, 1L, null, "demo", "1.0.0")));
+    when(proxy.search(proxyMember, "demo", 1))
+        .thenReturn(Map.of(
+            "objects", List.of(searchItem("demo"), searchItem("other")),
+            "total", 2));
+
+    Map<String, Object> response =
+        new NpmSearchService(components, hosted, proxy)
+            .search(group, "demo", 2, "https://repo.example/repository/npm-group");
+
+    assertEquals(2, response.get("total"));
+    assertEquals(List.of("demo", "other"), objects(response).stream()
+        .map(item -> map(item.get("package")).get("name").toString())
+        .toList());
+    verify(proxy).search(proxyMember, "demo", 1);
+  }
+
+  @Test
+  void malformedMemberObjectsAreSkippedAndLaterMembersStillContribute() {
+    ComponentDao components = mock(ComponentDao.class);
+    NpmHostedService hosted = mock(NpmHostedService.class);
+    NpmProxyService proxy = mock(NpmProxyService.class);
+    RepositoryRuntime first = proxy(1L, "first");
+    RepositoryRuntime second = proxy(2L, "second");
+    RepositoryRuntime group = group(10L, List.of(first, second));
+    when(proxy.search(first, "demo", 3)).thenReturn(Map.of("objects", "not-an-array"));
+    when(proxy.search(second, "demo", 3))
+        .thenReturn(Map.of("objects", List.of(
+            Map.of("score", 1),
+            Map.of("package", Map.of()),
+            searchItem("valid"))));
+
+    Map<String, Object> response =
+        new NpmSearchService(components, hosted, proxy)
+            .search(group, "demo", 3, "https://repo.example/repository/npm-group");
+
+    assertEquals(1, response.get("total"));
+    assertEquals("valid", map(objects(response).get(0).get("package")).get("name"));
+  }
+
+  @Test
+  void legacyIndexRecursesNestedGroupsAndEmitsEachPackageOnce() {
+    ComponentDao components = mock(ComponentDao.class);
+    NpmHostedService hosted = mock(NpmHostedService.class);
+    NpmProxyService proxy = mock(NpmProxyService.class);
+    RepositoryRuntime first = hosted(1L, "first");
+    RepositoryRuntime second = hosted(2L, "second");
+    RepositoryRuntime nested = group(11L, List.of(second));
+    RepositoryRuntime root = group(10L, List.of(first, nested));
+    when(components.searchByRepositoryIds(List.of(1L, 2L), "", 300))
+        .thenReturn(List.of(
+            row(1L, 1L, null, "demo", "1.0.0"),
+            row(2L, 2L, null, "demo", "2.0.0"),
+            row(3L, 2L, "scope", "client", "3.0.0"),
+            row(4L, 99L, null, "orphan", "1.0.0")));
+    when(hosted.packageRoot(eq(first), any()))
+        .thenReturn(Optional.of(packageRoot("demo", "1.0.0")));
+    when(hosted.packageRoot(eq(second), any()))
+        .thenReturn(Optional.of(packageRoot("@scope/client", "3.0.0")));
+
+    Map<String, Object> response = new NpmSearchService(components, hosted, proxy).legacyIndex(root);
+
+    assertTrue(response.containsKey("_updated"));
+    assertTrue(response.containsKey("demo"));
+    assertTrue(response.containsKey("@scope/client"));
+    assertEquals(3, response.size());
+  }
+
+  private static ComponentSearchRow row(
+      long id,
+      long repositoryId,
+      String namespace,
+      String name,
+      String version) {
+    return new ComponentSearchRow(
+        id,
+        repositoryId,
+        "repo-" + repositoryId,
+        RepositoryFormat.NPM,
+        namespace,
+        name,
+        version,
+        "package",
+        Instant.parse("2026-07-13T10:00:00Z"),
+        null);
+  }
+
+  private static Map<String, Object> packageRoot(String name, String version) {
+    Map<String, Object> root = new LinkedHashMap<>();
+    root.put("name", name);
+    root.put("dist-tags", Map.of("latest", version));
+    root.put("versions", Map.of(version, Map.of("name", name, "version", version)));
+    return root;
+  }
+
+  private static Map<String, Object> searchItem(String name) {
+    return Map.of("package", Map.of("name", name), "score", Map.of(), "searchScore", 1.0);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<Map<String, Object>> objects(Map<String, Object> response) {
+    return (List<Map<String, Object>>) response.get("objects");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> map(Object value) {
+    return (Map<String, Object>) value;
+  }
+
+  private static RepositoryRuntime hosted(long id, String name) {
+    return runtime(id, name, RepositoryType.HOSTED, List.of());
+  }
+
+  private static RepositoryRuntime proxy(long id, String name) {
+    return runtime(id, name, RepositoryType.PROXY, List.of());
+  }
+
+  private static RepositoryRuntime group(long id, List<RepositoryRuntime> members) {
+    return runtime(id, "npm-group", RepositoryType.GROUP, members);
+  }
+
+  private static RepositoryRuntime runtime(
+      long id,
+      String name,
+      RepositoryType type,
+      List<RepositoryRuntime> members) {
+    return new RepositoryRuntime(
+        id,
+        name,
+        RepositoryFormat.NPM,
+        type,
+        "npm-" + type.name().toLowerCase(),
+        true,
+        7L,
+        "ALLOW",
+        null,
+        null,
+        true,
+        type == RepositoryType.PROXY ? "https://registry.npmjs.org/" : null,
+        60,
+        60,
+        true,
+        null,
+        members);
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiHostedServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiHostedServiceTest.java
@@ -1,6 +1,7 @@
 package com.github.klboke.kkrepo.server.pypi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.github.klboke.kkrepo.core.BlobObjectMetadata;
@@ -17,11 +18,17 @@ import com.github.klboke.kkrepo.server.cache.AssetMetadataCache;
 import com.github.klboke.kkrepo.server.maven.BlobStorageRegistry;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import com.github.klboke.kkrepo.server.support.InMemorySharedCache;
+import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.HexFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockMultipartFile;
 
@@ -65,16 +72,174 @@ class PypiHostedServiceTest {
         indexRebuildDao.enqueues);
   }
 
+  @Test
+  void validatesUploadActionFieldsDigestAndWritePolicy() throws Exception {
+    RecordingWriter writer = new RecordingWriter();
+    PypiHostedService service = service(new EmptyAssetDao(), new RecordingIndexRebuildDao(), writer);
+    MockMultipartFile content = new MockMultipartFile(
+        "content", "demo-1.0.0.tar.gz", "application/gzip", "payload".getBytes());
+
+    assertThrows(PypiExceptions.MethodNotAllowed.class, () -> service.upload(
+        runtime(RepositoryType.PROXY, "ALLOW", 1L), Map.of(":action", "file_upload"),
+        content, null, "admin", null));
+    assertThrows(PypiExceptions.BadRequestException.class,
+        () -> service.upload(runtime(), Map.of(), content, null, "admin", null));
+    assertThrows(PypiExceptions.BadRequestException.class, () -> service.upload(
+        runtime(), Map.of(":action", "file_upload", "name", "demo"),
+        content, null, "admin", null));
+    assertThrows(PypiExceptions.BadRequestException.class, () -> service.upload(
+        runtime(), Map.of(
+            ":action", "file_upload", "name", "demo", "version", "1.0.0",
+            "md5_digest", "deadbeef"),
+        content, null, "admin", null));
+    assertThrows(PypiExceptions.WritePolicyDenied.class, () -> service.upload(
+        runtime(RepositoryType.HOSTED, "DENY", 1L),
+        Map.of(":action", "file_upload", "name", "demo", "version", "1.0.0"),
+        content, null, "admin", null));
+    assertEquals(0, writer.packageWrites);
+  }
+
+  @Test
+  void uploadWritesPackageAndSignatureWhenMd5Matches() throws Exception {
+    RecordingWriter writer = new RecordingWriter();
+    RecordingIndexRebuildDao rebuilds = new RecordingIndexRebuildDao();
+    PypiHostedService service = service(new EmptyAssetDao(), rebuilds, writer);
+    byte[] payload = "payload".getBytes(StandardCharsets.UTF_8);
+    MockMultipartFile content = new MockMultipartFile(
+        "content", "../demo_pkg-1.0.0.tar.gz", "application/gzip", payload);
+    MockMultipartFile signature = new MockMultipartFile(
+        "gpg_signature", "demo_pkg-1.0.0.tar.gz.asc",
+        "application/pgp-signature", "signature".getBytes(StandardCharsets.UTF_8));
+
+    PypiResponse response = service.upload(
+        runtime(),
+        Map.of(
+            ":action", "file_upload",
+            "name", "Demo_Pkg",
+            "version", "1.0.0",
+            "md5_digest", HexFormat.of().formatHex(MessageDigest.getInstance("MD5").digest(payload))),
+        content,
+        signature,
+        "admin",
+        "127.0.0.1");
+
+    assertEquals(200, response.status());
+    assertEquals(2, writer.packageWrites);
+    assertEquals(List.of("package", "package-signature"), writer.kinds);
+    assertEquals(List.of(
+        "packages/demo-pkg/1.0.0/demo_pkg-1.0.0.tar.gz",
+        "packages/demo-pkg/1.0.0/demo_pkg-1.0.0.tar.gz.asc"), writer.paths);
+    assertEquals(2, rebuilds.enqueues.size());
+  }
+
+  @Test
+  void uploadAssetReadsWheelMetadataAndFallsBackToFilename() throws Exception {
+    RecordingWriter writer = new RecordingWriter();
+    PypiHostedService service = service(new EmptyAssetDao(), new RecordingIndexRebuildDao(), writer);
+    byte[] wheel = wheel("""
+        Metadata-Version: 2.3
+        Name: Demo_Pkg
+        Version: 2.0.0
+        Summary: wheel metadata
+        Requires-Python: >=3.11
+        """);
+
+    service.uploadAsset(
+        runtime(),
+        new MockMultipartFile(
+            "asset", "ignored-0.0.1-py3-none-any.whl", "application/zip", wheel),
+        "admin",
+        null);
+    service.uploadAsset(
+        runtime(),
+        new MockMultipartFile(
+            "asset", "fallback_pkg-3.1.4.zip", "application/zip", emptyZip()),
+        "admin",
+        null);
+
+    assertEquals(List.of(
+        "packages/demo-pkg/2.0.0/ignored-0.0.1-py3-none-any.whl",
+        "packages/fallback-pkg/3.1.4/fallback_pkg-3.1.4.zip"), writer.paths);
+    assertEquals("wheel metadata", writer.attributes.getFirst().get("summary"));
+    assertEquals(">=3.11", writer.attributes.getFirst().get("requires_python"));
+  }
+
+  @Test
+  void uploadAssetRejectsUnknownCoordinatesAndExistingAsset() {
+    RecordingWriter writer = new RecordingWriter();
+    EmptyAssetDao empty = new EmptyAssetDao();
+    PypiHostedService service = service(empty, new RecordingIndexRebuildDao(), writer);
+    assertThrows(PypiExceptions.BadRequestException.class, () -> service.uploadAsset(
+        runtime(),
+        new MockMultipartFile("asset", "unknown.whl", "application/zip", emptyZip()),
+        "admin", null));
+
+    EmptyAssetDao existing = new EmptyAssetDao() {
+      @Override
+      public Optional<AssetRecord> findAssetByPath(long repositoryId, String path) {
+        return path.startsWith("packages/")
+            ? Optional.of(new AssetRecord(
+                1L, repositoryId, null, null, RepositoryFormat.PYPI, path, null,
+                "demo-1.0.0.whl", "package", "application/zip", 1L,
+                null, null, Map.of()))
+            : Optional.empty();
+      }
+    };
+    assertThrows(PypiExceptions.WritePolicyDenied.class, () -> service(
+        existing, new RecordingIndexRebuildDao(), writer).uploadAsset(
+            runtime(),
+            new MockMultipartFile(
+                "asset", "demo-1.0.0.whl", "application/zip", emptyZip()),
+            "admin", null));
+  }
+
+  private static PypiHostedService service(
+      AssetDao assetDao, RecordingIndexRebuildDao rebuildDao, RecordingWriter writer) {
+    AssetMetadataCache cache = new AssetMetadataCache(new InMemorySharedCache(), false, 0, 0);
+    FixedBlobStorageRegistry registry = new FixedBlobStorageRegistry();
+    return new PypiHostedService(
+        assetDao,
+        new EmptyComponentDao(),
+        rebuildDao,
+        registry,
+        writer,
+        new PypiAssetReader(assetDao, registry),
+        cache,
+        0);
+  }
+
+  private static byte[] wheel(String metadata) throws Exception {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ZipOutputStream zip = new ZipOutputStream(bytes)) {
+      zip.putNextEntry(new ZipEntry("demo_pkg-2.0.0.dist-info/METADATA"));
+      zip.write(metadata.getBytes(StandardCharsets.UTF_8));
+      zip.closeEntry();
+    }
+    return bytes.toByteArray();
+  }
+
+  private static byte[] emptyZip() throws Exception {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ZipOutputStream ignored = new ZipOutputStream(bytes)) {
+    }
+    return bytes.toByteArray();
+  }
+
   private static RepositoryRuntime runtime() {
+    return runtime(RepositoryType.HOSTED, "ALLOW", 1L);
+  }
+
+  private static RepositoryRuntime runtime(
+      RepositoryType type, String writePolicy, Long blobStoreId) {
     return new RepositoryRuntime(
         10,
-        "pypi-hosted",
+        type == RepositoryType.HOSTED ? "pypi-hosted" : "pypi-proxy",
         RepositoryFormat.PYPI,
-        RepositoryType.HOSTED,
-        "pypi-hosted",
+        type,
+        type == RepositoryType.HOSTED ? "pypi-hosted" : "pypi-proxy",
         true,
-        1L,
-        "ALLOW",
+        blobStoreId,
+        writePolicy,
         null,
         null,
         true,
@@ -128,6 +293,9 @@ class PypiHostedServiceTest {
   private static class RecordingWriter extends PypiAssetWriter {
     int packageWrites;
     int indexWrites;
+    final List<String> paths = new ArrayList<>();
+    final List<String> kinds = new ArrayList<>();
+    final List<Map<String, Object>> attributes = new ArrayList<>();
 
     RecordingWriter() {
       super(null, null, null, new AssetMetadataCache(new InMemorySharedCache(), false, 0, 0),
@@ -149,8 +317,9 @@ class PypiHostedServiceTest {
         String createdBy,
         String createdByIp) {
       packageWrites++;
-      assertEquals("packages/demo-pkg/1.0.0/demo_pkg-1.0.0.tar.gz", path);
-      assertEquals("package", kind);
+      paths.add(path);
+      kinds.add(kind);
+      attributes.add(assetAttributes);
       return null;
     }
 

--- a/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiProxyServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiProxyServiceTest.java
@@ -1,0 +1,266 @@
+package com.github.klboke.kkrepo.server.pypi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.core.BlobStorage;
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.mysql.dao.AssetDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.ProxyStateDao;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetBlobRecord;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetRecord;
+import com.github.klboke.kkrepo.server.cache.AssetMetadataCache;
+import com.github.klboke.kkrepo.server.cache.CachedAssetMetadata;
+import com.github.klboke.kkrepo.server.maven.BlobStorageRegistry;
+import com.github.klboke.kkrepo.server.maven.HttpRemoteFetcher;
+import com.github.klboke.kkrepo.server.maven.ProxyNegativeCache;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class PypiProxyServiceTest {
+  @Test
+  void servesFreshCacheAndBlockedStaleFallback() throws Exception {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(60, 7L);
+    CachedAssetMetadata fresh = snapshot("simple/demo/", Instant.now(), Map.of());
+    PypiResponse expected = PypiResponse.noBody(200);
+    when(fixture.cache.find(eq(10L), eq("simple/demo/"), any()))
+        .thenReturn(Optional.of(fresh));
+    when(fixture.reader.serveSnapshot(fresh, true, "simple/demo/")).thenReturn(expected);
+
+    assertSame(expected, fixture.service.getIndex(runtime, "Demo", true));
+    verify(fixture.fetcher, never()).fetchWithBodyRetry(any(), anyString(), any());
+
+    CachedAssetMetadata stale = snapshot("simple/demo/", Instant.EPOCH, Map.of());
+    when(fixture.cache.find(eq(10L), eq("simple/demo/"), any()))
+        .thenReturn(Optional.of(stale));
+    when(fixture.proxyStateDao.isBlocked(eq(10L), any())).thenReturn(true);
+    when(fixture.reader.serveSnapshot(stale, false, "simple/demo/")).thenReturn(expected);
+    assertSame(expected, fixture.service.getIndex(runtime(1, 7L), "demo", false));
+  }
+
+  @Test
+  void rewritesAndCachesRemoteProjectIndex() throws Exception {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(1, 7L);
+    when(fixture.cache.find(eq(10L), eq("simple/demo/"), any()))
+        .thenReturn(Optional.empty());
+    when(fixture.registry.forBlobStoreId(7L)).thenReturn(fixture.storage);
+    respond(fixture.fetcher, new HttpRemoteFetcher.Result(
+        200, Map.of("Content-Type", "text/html"),
+        new ByteArrayInputStream("""
+            <html><body>
+            <a href="../../files/demo-1.0.0.whl#sha256=abc"
+               data-requires-python="&gt;=3.11">demo-1.0.0.whl</a>
+            </body></html>
+            """.getBytes(StandardCharsets.UTF_8))));
+    AtomicReference<String> written = new AtomicReference<>();
+    doAnswer(invocation -> {
+      written.set(new String(
+          ((java.io.InputStream) invocation.getArgument(4)).readAllBytes(),
+          StandardCharsets.UTF_8));
+      return stored("simple/demo/", "text/html");
+    }).when(fixture.writer).write(
+        eq(runtime), eq(fixture.storage), eq(7L), eq("simple/demo/"), any(),
+        eq("text/html"), eq("index"), eq(null), any(), any(),
+        eq("proxy"), eq(runtime.proxyRemoteUrl()), eq(false));
+
+    PypiResponse response = fixture.service.getIndex(runtime, "Demo", true);
+
+    assertEquals(200, response.status());
+    assertTrue(written.get().contains("../../packages/demo/1.0.0/demo-1.0.0.whl#sha256=abc"));
+    assertTrue(written.get().contains("data-requires-python=\"&gt;=3.11\""));
+    verify(fixture.proxyStateDao).recordSuccess(eq(10L), any());
+    verify(fixture.negativeCache).invalidate(runtime, "simple/demo/");
+  }
+
+  @Test
+  void resolvesPackageUrlFromRemoteIndexAndCachesPackage() throws Exception {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(1, 7L);
+    String packagePath = "packages/demo/1.0.0/demo-1.0.0.whl";
+    when(fixture.cache.find(eq(10L), eq(packagePath), any())).thenReturn(Optional.empty());
+    when(fixture.registry.forBlobStoreId(7L)).thenReturn(fixture.storage);
+    AtomicReference<String> packageUrl = new AtomicReference<>();
+    doAnswer(invocation -> {
+      HttpRemoteFetcher.Request request = invocation.getArgument(0);
+      String path = invocation.getArgument(1);
+      @SuppressWarnings("unchecked")
+      HttpRemoteFetcher.ResultHandler<PypiResponse> handler = invocation.getArgument(2);
+      if (path.startsWith("simple/")) {
+        return handler.handle(new HttpRemoteFetcher.Result(
+            200, Map.of(),
+            new ByteArrayInputStream("""
+                <a href="../../files/demo-1.0.0.whl#sha256=abc">demo-1.0.0.whl</a>
+                """.getBytes(StandardCharsets.UTF_8))));
+      }
+      packageUrl.set(request.url());
+      return handler.handle(new HttpRemoteFetcher.Result(
+          200, Map.of("Content-Type", "application/zip", "ETag", "\"wheel\""),
+          new ByteArrayInputStream("wheel".getBytes(StandardCharsets.UTF_8))));
+    }).when(fixture.fetcher).fetchWithBodyRetry(any(), anyString(), any());
+    when(fixture.writer.write(
+        eq(runtime), eq(fixture.storage), eq(7L), eq(packagePath), any(),
+        eq("application/zip"), eq("package"), any(), any(), any(),
+        eq("proxy"), eq(runtime.proxyRemoteUrl()), eq(false)))
+        .thenReturn(stored(packagePath, "application/zip"));
+
+    assertEquals(200, fixture.service.getPackage(runtime, packagePath, true).status());
+    assertEquals("https://pypi.example.test/files/demo-1.0.0.whl", packageUrl.get());
+    verify(fixture.writer).write(
+        eq(runtime), eq(fixture.storage), eq(7L), eq(packagePath), any(),
+        eq("application/zip"), eq("package"),
+        eq(new PypiAssetWriter.PackageCoordinate("demo", "demo", "1.0.0", null)),
+        any(), eq(Map.of("remoteEtag", "wheel")),
+        eq("proxy"), eq(runtime.proxyRemoteUrl()), eq(false));
+  }
+
+  @Test
+  void handlesNotModifiedMissAndUpstreamFailure() throws Exception {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(1, 7L);
+    CachedAssetMetadata stale = snapshot("simple/", Instant.EPOCH, Map.of());
+    PypiResponse expected = PypiResponse.noBody(200);
+    when(fixture.cache.find(eq(10L), eq("simple/"), any())).thenReturn(Optional.of(stale));
+    when(fixture.reader.serveSnapshot(stale, true, "simple/")).thenReturn(expected);
+    respond(fixture.fetcher, new HttpRemoteFetcher.Result(
+        304, Map.of(), new ByteArrayInputStream(new byte[0])));
+
+    assertSame(expected, fixture.service.getRootIndex(runtime, true));
+    verify(fixture.assetDao).touchAssetLastUpdated(eq(1L), any());
+    verify(fixture.cache).touchVerified(eq(10L), eq("simple/"), any(), eq(null));
+
+    Fixture missing = fixture();
+    when(missing.cache.find(eq(10L), eq("simple/demo/"), any()))
+        .thenReturn(Optional.empty());
+    respond(missing.fetcher, new HttpRemoteFetcher.Result(
+        404, Map.of(), new ByteArrayInputStream(new byte[0])));
+    assertThrows(PypiExceptions.PypiNotFoundException.class,
+        () -> missing.service.getIndex(runtime, "demo", false));
+    verify(missing.negativeCache).rememberNotFound(runtime, "simple/demo/");
+
+    Fixture failed = fixture();
+    when(failed.cache.find(eq(10L), eq("simple/"), any())).thenReturn(Optional.empty());
+    respond(failed.fetcher, new HttpRemoteFetcher.Result(
+        503, Map.of(), new ByteArrayInputStream(new byte[0])));
+    assertThrows(PypiExceptions.BadUpstreamException.class,
+        () -> failed.service.getRootIndex(runtime, false));
+    verify(failed.proxyStateDao).recordFailure(eq(10L), eq(30L), anyString(), any());
+  }
+
+  @Test
+  void validatesRuntimeNegativeCacheAndBlobStore() throws Exception {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(1, 7L);
+    when(fixture.cache.find(eq(10L), eq("simple/demo/"), any()))
+        .thenReturn(Optional.empty());
+    when(fixture.negativeCache.isNotFoundCached(runtime, "simple/demo/")).thenReturn(true);
+    assertThrows(PypiExceptions.PypiNotFoundException.class,
+        () -> fixture.service.getIndex(runtime, "demo", false));
+    assertThrows(IllegalStateException.class,
+        () -> fixture.service.getIndex(
+            new RepositoryRuntime(
+                10L, "pypi", RepositoryFormat.PYPI, RepositoryType.HOSTED, "pypi", true, 7L,
+                "ALLOW", null, null, true, null, 1, 1, true, null, List.of()),
+            "demo", false));
+
+    Fixture noStore = fixture();
+    when(noStore.cache.find(eq(10L), eq("simple/"), any())).thenReturn(Optional.empty());
+    respond(noStore.fetcher, new HttpRemoteFetcher.Result(
+        200, Map.of(),
+        new ByteArrayInputStream("<a href=\"demo/\">demo</a>".getBytes(StandardCharsets.UTF_8))));
+    assertThrows(IllegalStateException.class,
+        () -> noStore.service.getRootIndex(runtime(1, null), false));
+  }
+
+  private static void respond(HttpRemoteFetcher fetcher, HttpRemoteFetcher.Result result)
+      throws IOException {
+    doAnswer(invocation -> {
+      @SuppressWarnings("unchecked")
+      HttpRemoteFetcher.ResultHandler<PypiResponse> handler = invocation.getArgument(2);
+      return handler.handle(result);
+    }).when(fetcher).fetchWithBodyRetry(any(), anyString(), any());
+  }
+
+  private static Fixture fixture() {
+    AssetDao assetDao = mock(AssetDao.class);
+    BlobStorageRegistry registry = mock(BlobStorageRegistry.class);
+    PypiAssetWriter writer = mock(PypiAssetWriter.class);
+    PypiAssetReader reader = mock(PypiAssetReader.class);
+    ProxyStateDao proxyStateDao = mock(ProxyStateDao.class);
+    HttpRemoteFetcher fetcher = mock(HttpRemoteFetcher.class);
+    ProxyNegativeCache negativeCache = mock(ProxyNegativeCache.class);
+    AssetMetadataCache cache = mock(AssetMetadataCache.class);
+    BlobStorage storage = mock(BlobStorage.class);
+    return new Fixture(
+        assetDao, registry, writer, reader, proxyStateDao, fetcher, negativeCache, cache,
+        storage, new PypiProxyService(
+            assetDao, registry, writer, reader, proxyStateDao, fetcher, negativeCache, cache, null));
+  }
+
+  private static RepositoryRuntime runtime(int maxAgeMinutes, Long blobStoreId) {
+    return new RepositoryRuntime(
+        10L, "pypi", RepositoryFormat.PYPI, RepositoryType.PROXY, "pypi", true, blobStoreId,
+        null, null, null, true, "https://pypi.example.test/",
+        maxAgeMinutes, maxAgeMinutes, true, null, List.of());
+  }
+
+  private static CachedAssetMetadata snapshot(
+      String path, Instant updatedAt, Map<String, Object> attributes) {
+    AssetRecord asset = new AssetRecord(
+        1L, 10L, null, 2L, RepositoryFormat.PYPI, path, null,
+        PypiPaths.fileName(path), path.startsWith("simple/") ? "index" : "package",
+        path.startsWith("simple/") ? "text/html" : "application/zip",
+        5L, null, updatedAt, attributes);
+    return CachedAssetMetadata.of(asset, blob());
+  }
+
+  private static PypiAssetWriter.Stored stored(String path, String contentType) {
+    AssetRecord asset = new AssetRecord(
+        1L, 10L, null, 2L, RepositoryFormat.PYPI, path, null,
+        PypiPaths.fileName(path), path.startsWith("simple/") ? "index" : "package",
+        contentType, 5L, null, Instant.now(), Map.of());
+    return new PypiAssetWriter.Stored(
+        asset, blob(), new PypiAssetWriter.Digests("md5", "sha1", "sha256", "sha512", 5L),
+        true, null);
+  }
+
+  private static AssetBlobRecord blob() {
+    return new AssetBlobRecord(
+        2L, 7L, "blob://bucket/object", null, "object", null,
+        "sha1", "sha256", "md5", 5L, "application/octet-stream",
+        "proxy", "upstream", Instant.EPOCH, Instant.EPOCH, Map.of());
+  }
+
+  private record Fixture(
+      AssetDao assetDao,
+      BlobStorageRegistry registry,
+      PypiAssetWriter writer,
+      PypiAssetReader reader,
+      ProxyStateDao proxyStateDao,
+      HttpRemoteFetcher fetcher,
+      ProxyNegativeCache negativeCache,
+      AssetMetadataCache cache,
+      BlobStorage storage,
+      PypiProxyService service) {
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/raw/RawAssetReaderTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/raw/RawAssetReaderTest.java
@@ -1,0 +1,99 @@
+package com.github.klboke.kkrepo.server.raw;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.core.BlobReference;
+import com.github.klboke.kkrepo.core.BlobStorage;
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.persistence.mysql.dao.AssetDao;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetBlobRecord;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetRecord;
+import com.github.klboke.kkrepo.server.cache.CachedAssetMetadata;
+import com.github.klboke.kkrepo.server.maven.BlobStorageRegistry;
+import com.github.klboke.kkrepo.server.maven.MavenExceptions;
+import com.github.klboke.kkrepo.server.maven.MavenResponse;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class RawAssetReaderTest {
+  @Test
+  void servesHeadWithoutOpeningBlobStorage() {
+    AssetDao assetDao = mock(AssetDao.class);
+    BlobStorageRegistry registry = mock(BlobStorageRegistry.class);
+    AssetBlobRecord blob = blob();
+    when(assetDao.findBlobById(2L)).thenReturn(Optional.of(blob));
+
+    MavenResponse response = new RawAssetReader(assetDao, registry)
+        .serve(asset(), true, "docs/readme.txt", "ATTACHMENT");
+
+    assertEquals(200, response.status());
+    assertFalse(response.hasBody());
+    assertEquals(4, response.contentLength());
+    assertEquals("text/plain", response.contentType());
+    assertEquals("sha1", response.etag());
+    verify(registry, never()).forBlobStoreId(any(Long.class));
+  }
+
+  @Test
+  void lazilyStreamsBlobAndNormalizesDisposition() throws Exception {
+    AssetDao assetDao = mock(AssetDao.class);
+    BlobStorageRegistry registry = mock(BlobStorageRegistry.class);
+    BlobStorage storage = mock(BlobStorage.class);
+    when(registry.forBlobStoreId(7L)).thenReturn(storage);
+    when(storage.get(any(BlobReference.class)))
+        .thenReturn(Optional.of(new ByteArrayInputStream("body".getBytes(StandardCharsets.UTF_8))));
+
+    MavenResponse response = new RawAssetReader(assetDao, registry)
+        .serveSnapshot(CachedAssetMetadata.of(asset(), blob()), false, "docs/readme.txt", "INLINE");
+
+    assertTrue(response.hasBody());
+    assertEquals("body", new String(response.body().readAllBytes(), StandardCharsets.UTF_8));
+    assertEquals("inline", response.headers().get("Content-Disposition"));
+  }
+
+  @Test
+  void reportsMissingMetadataAndPhysicalObjects() {
+    AssetDao assetDao = mock(AssetDao.class);
+    BlobStorageRegistry registry = mock(BlobStorageRegistry.class);
+    RawAssetReader reader = new RawAssetReader(assetDao, registry);
+
+    AssetRecord missingBinding = new AssetRecord(
+        1L, 10L, null, null, RepositoryFormat.RAW, "missing.txt", null,
+        "missing.txt", "raw", "text/plain", 4L, null, Instant.EPOCH, Map.of());
+    assertThrows(MavenExceptions.MavenNotFoundException.class,
+        () -> reader.serve(missingBinding, false, "missing.txt", null));
+
+    when(assetDao.findBlobById(2L)).thenReturn(Optional.of(blob()));
+    BlobStorage storage = mock(BlobStorage.class);
+    when(registry.forBlobStoreId(7L)).thenReturn(storage);
+    when(storage.get(any(BlobReference.class))).thenReturn(Optional.empty());
+    MavenResponse response = reader.serve(asset(), false, "docs/readme.txt", null);
+    assertThrows(MavenExceptions.MavenNotFoundException.class, response::body);
+  }
+
+  private static AssetRecord asset() {
+    return new AssetRecord(
+        1L, 10L, null, 2L, RepositoryFormat.RAW, "docs/readme.txt", null,
+        "readme.txt", "raw", "text/plain", 4L, null,
+        Instant.parse("2026-07-13T00:00:00Z"), Map.of());
+  }
+
+  private static AssetBlobRecord blob() {
+    return new AssetBlobRecord(
+        2L, 7L, "blob://bucket/object-key", null, "object-key", null,
+        "sha1", "sha256", "md5", 4, "text/plain", "user", "127.0.0.1",
+        Instant.EPOCH, Instant.EPOCH, Map.of());
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/raw/RawAssetWriterTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/raw/RawAssetWriterTest.java
@@ -1,0 +1,80 @@
+package com.github.klboke.kkrepo.server.raw;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.core.BlobStorage;
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.mysql.dao.AssetDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.BrowseNodeDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.ComponentDao;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetRecord;
+import com.github.klboke.kkrepo.server.cache.AssetMetadataCache;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class RawAssetWriterTest {
+  @Test
+  void deleteMissingAssetIsNoOp() {
+    Fixture fixture = fixture();
+
+    assertEquals(0, fixture.writer.deleteAsset(runtime(), mock(BlobStorage.class), "missing"));
+
+    verifyNoInteractions(fixture.componentDao, fixture.browseNodeDao, fixture.cache);
+  }
+
+  @Test
+  void deletesAssetMetadataAndUnreferencedBlob() {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime();
+    AssetRecord asset = new AssetRecord(
+        11L, runtime.id(), 22L, 33L, RepositoryFormat.RAW, "docs/file.txt", null,
+        "file.txt", "raw", "text/plain", 4L, null, Instant.EPOCH, Map.of());
+    when(fixture.assetDao.findAssetByPath(runtime.id(), "docs/file.txt"))
+        .thenReturn(Optional.of(asset));
+
+    assertEquals(1, fixture.writer.deleteAsset(
+        runtime, mock(BlobStorage.class), "docs/file.txt"));
+
+    verify(fixture.browseNodeDao).deleteByAssetId(11L);
+    verify(fixture.assetDao).deleteAssetById(11L);
+    verify(fixture.assetDao).markBlobDeletedIfUnreferenced(33L, "asset unlinked");
+    verify(fixture.componentDao).deleteIfNoAssets(22L);
+    verify(fixture.cache).evictAfterCommit(runtime.id(), "docs/file.txt");
+  }
+
+  private static Fixture fixture() {
+    AssetDao assetDao = mock(AssetDao.class);
+    ComponentDao componentDao = mock(ComponentDao.class);
+    BrowseNodeDao browseNodeDao = mock(BrowseNodeDao.class);
+    AssetMetadataCache cache = mock(AssetMetadataCache.class);
+    return new Fixture(
+        assetDao,
+        componentDao,
+        browseNodeDao,
+        cache,
+        new RawAssetWriter(assetDao, componentDao, browseNodeDao, cache, null));
+  }
+
+  private static RepositoryRuntime runtime() {
+    return new RepositoryRuntime(
+        1L, "raw", RepositoryFormat.RAW, RepositoryType.HOSTED, "raw", true, 1L,
+        "ALLOW", null, null, true, null, 60, 60, true, "ATTACHMENT", List.of());
+  }
+
+  private record Fixture(
+      AssetDao assetDao,
+      ComponentDao componentDao,
+      BrowseNodeDao browseNodeDao,
+      AssetMetadataCache cache,
+      RawAssetWriter writer) {
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/raw/RawAssetWriterTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/raw/RawAssetWriterTest.java
@@ -1,32 +1,178 @@
 package com.github.klboke.kkrepo.server.raw;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.github.klboke.kkrepo.core.BlobReference;
 import com.github.klboke.kkrepo.core.BlobStorage;
 import com.github.klboke.kkrepo.core.RepositoryFormat;
 import com.github.klboke.kkrepo.core.RepositoryType;
 import com.github.klboke.kkrepo.persistence.mysql.dao.AssetDao;
 import com.github.klboke.kkrepo.persistence.mysql.dao.BrowseNodeDao;
 import com.github.klboke.kkrepo.persistence.mysql.dao.ComponentDao;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetBlobRecord;
 import com.github.klboke.kkrepo.persistence.mysql.model.AssetRecord;
 import com.github.klboke.kkrepo.server.cache.AssetMetadataCache;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import org.junit.jupiter.api.Test;
 
 class RawAssetWriterTest {
+  private static final String PATH = "docs/file.txt";
+
+  @Test
+  void writesNewAssetWithDigestsAttributesAndResponseBody() throws Exception {
+    Fixture fixture = fixture();
+    stubUploadedBlob(fixture);
+    when(fixture.assetDao.findAssetByPath(1L, PATH)).thenReturn(Optional.empty());
+    when(fixture.componentDao.upsertReturningId(any())).thenReturn(22L);
+    when(fixture.assetDao.tryInsertAsset(any())).thenReturn(OptionalLong.of(11L));
+
+    RawAssetWriter.Stored stored = fixture.writer.write(
+        runtime(), fixture.storage, 1L, PATH,
+        new ByteArrayInputStream("body".getBytes(StandardCharsets.UTF_8)),
+        null, Map.of("remoteEtag", "etag"), "alice", "127.0.0.1", true);
+
+    assertTrue(stored.created());
+    assertEquals(11L, stored.asset().id());
+    assertEquals("application/octet-stream", stored.asset().contentType());
+    assertEquals(4L, stored.digests().size());
+    assertNotNull(stored.digests().sha512());
+    assertEquals("etag", stored.blob().attributes().get("remoteEtag"));
+    assertEquals("body",
+        new String(stored.openBody().readAllBytes(), StandardCharsets.UTF_8));
+    verify(fixture.browseNodeDao).upsertPathAncestors(1L, PATH, 11L, 22L);
+    verify(fixture.cache).evictAfterCommit(1L, PATH);
+  }
+
+  @Test
+  void replacesExistingAssetAndMarksOldBlobDeleted() {
+    Fixture fixture = fixture();
+    stubUploadedBlob(fixture);
+    AssetRecord existing = asset(11L, 33L);
+    when(fixture.assetDao.findAssetByPath(1L, PATH)).thenReturn(Optional.of(existing));
+    when(fixture.assetDao.findBlobById(33L)).thenReturn(Optional.of(blob(33L, "old")));
+    when(fixture.componentDao.upsertReturningId(any())).thenReturn(22L);
+
+    RawAssetWriter.Stored stored = fixture.writer.write(
+        runtime(), fixture.storage, 1L, PATH,
+        new ByteArrayInputStream("body".getBytes(StandardCharsets.UTF_8)),
+        "text/plain", Map.of(), "alice", "127.0.0.1");
+
+    assertFalse(stored.created());
+    assertEquals(2L, stored.asset().assetBlobId());
+    verify(fixture.assetDao).updateAssetBlobBindingAndMetadata(
+        eq(11L), eq(22L), eq(2L), eq("raw"), eq("text/plain"),
+        eq(4L), any(Instant.class), eq(Map.of("path", PATH)));
+    verify(fixture.assetDao).markBlobDeletedIfUnreferenced(33L, "asset replaced");
+  }
+
+  @Test
+  void updatesConcurrentInsertWinner() {
+    Fixture fixture = fixture();
+    stubUploadedBlob(fixture);
+    AssetRecord winner = asset(12L, 44L);
+    when(fixture.assetDao.findAssetByPath(1L, PATH))
+        .thenReturn(Optional.empty(), Optional.of(winner));
+    when(fixture.assetDao.findBlobById(44L)).thenReturn(Optional.of(blob(44L, "winner")));
+    when(fixture.componentDao.upsertReturningId(any())).thenReturn(22L);
+    when(fixture.assetDao.tryInsertAsset(any())).thenReturn(OptionalLong.empty());
+
+    RawAssetWriter.Stored stored = fixture.writer.write(
+        runtime(), fixture.storage, 1L, PATH,
+        new ByteArrayInputStream("body".getBytes(StandardCharsets.UTF_8)),
+        "text/plain", Map.of(), "alice", "127.0.0.1");
+
+    assertFalse(stored.created());
+    assertEquals(12L, stored.asset().id());
+    verify(fixture.assetDao).markBlobDeletedIfUnreferenced(44L, "asset replaced");
+  }
+
+  @Test
+  void reusesLiveBlobAndRecoversDeletedBlobWithExtraAttributes() {
+    Fixture reusable = fixture();
+    AssetBlobRecord live = blob(5L, "shared");
+    when(reusable.assetDao.findReusableBlobBySha256(eq(1L), anyString(), eq(4L)))
+        .thenReturn(Optional.of(live));
+    when(reusable.assetDao.findAssetByPath(1L, PATH)).thenReturn(Optional.empty());
+    when(reusable.componentDao.upsertReturningId(any())).thenReturn(22L);
+    when(reusable.assetDao.tryInsertAsset(any())).thenReturn(OptionalLong.of(11L));
+
+    RawAssetWriter.Stored reused = reusable.writer.write(
+        runtime(), reusable.storage, 1L, PATH,
+        new ByteArrayInputStream("body".getBytes(StandardCharsets.UTF_8)),
+        "text/plain", Map.of(), "alice", "127.0.0.1");
+
+    assertEquals(5L, reused.blob().id());
+    verify(reusable.storage, never()).putFile(anyString(), anyString(), any(), anyString());
+
+    Fixture recovered = fixture();
+    BlobReference uploaded = new BlobReference("bucket", "uploaded", "sha256", 4L);
+    when(recovered.storage.putFile(eq("raw"), eq(PATH), any(Path.class), anyString()))
+        .thenReturn(uploaded);
+    when(recovered.assetDao.recoverDeletedBlobBySha256(eq(1L), anyString(), eq(4L)))
+        .thenReturn(Optional.of(live));
+    when(recovered.assetDao.findAssetByPath(1L, PATH)).thenReturn(Optional.empty());
+    when(recovered.componentDao.upsertReturningId(any())).thenReturn(22L);
+    when(recovered.assetDao.tryInsertAsset(any())).thenReturn(OptionalLong.of(11L));
+    when(recovered.assetDao.hasLiveBlobForObjectKeyHash(eq(1L), any())).thenReturn(false);
+
+    RawAssetWriter.Stored restored = recovered.writer.write(
+        runtime(), recovered.storage, 1L, PATH,
+        new ByteArrayInputStream("body".getBytes(StandardCharsets.UTF_8)),
+        "text/plain", Map.of("remoteEtag", "etag"), "proxy", "upstream");
+
+    assertEquals("etag", restored.blob().attributes().get("remoteEtag"));
+    assertNotNull(restored.blob().attributes().get("sha512"));
+    verify(recovered.assetDao).updateBlobAttributes(eq(5L), any());
+    verify(recovered.storage).delete(uploaded);
+  }
+
+  @Test
+  void cleansUploadedBlobWhenMetadataPersistenceFails() {
+    Fixture fixture = fixture();
+    BlobReference uploaded = new BlobReference("bucket", "uploaded", "sha256", 4L);
+    when(fixture.assetDao.findReusableBlobBySha256(eq(1L), anyString(), eq(4L)))
+        .thenReturn(Optional.empty());
+    when(fixture.storage.putFile(eq("raw"), eq(PATH), any(Path.class), anyString()))
+        .thenReturn(uploaded);
+    when(fixture.assetDao.findAssetByPath(1L, PATH)).thenReturn(Optional.empty());
+    when(fixture.assetDao.insertBlobOrFindExisting(any()))
+        .thenThrow(new IllegalStateException("database unavailable"));
+    when(fixture.assetDao.hasLiveBlobForObjectKeyHash(eq(1L), any())).thenReturn(false);
+
+    assertThrows(IllegalStateException.class, () -> fixture.writer.write(
+        runtime(), fixture.storage, 1L, PATH,
+        new ByteArrayInputStream("body".getBytes(StandardCharsets.UTF_8)),
+        "text/plain", Map.of(), "alice", "127.0.0.1"));
+
+    verify(fixture.storage).delete(uploaded);
+  }
+
   @Test
   void deleteMissingAssetIsNoOp() {
     Fixture fixture = fixture();
 
-    assertEquals(0, fixture.writer.deleteAsset(runtime(), mock(BlobStorage.class), "missing"));
+    assertEquals(0, fixture.writer.deleteAsset(runtime(), fixture.storage, "missing"));
 
     verifyNoInteractions(fixture.componentDao, fixture.browseNodeDao, fixture.cache);
   }
@@ -42,7 +188,7 @@ class RawAssetWriterTest {
         .thenReturn(Optional.of(asset));
 
     assertEquals(1, fixture.writer.deleteAsset(
-        runtime, mock(BlobStorage.class), "docs/file.txt"));
+        runtime, fixture.storage, "docs/file.txt"));
 
     verify(fixture.browseNodeDao).deleteByAssetId(11L);
     verify(fixture.assetDao).deleteAssetById(11L);
@@ -56,12 +202,24 @@ class RawAssetWriterTest {
     ComponentDao componentDao = mock(ComponentDao.class);
     BrowseNodeDao browseNodeDao = mock(BrowseNodeDao.class);
     AssetMetadataCache cache = mock(AssetMetadataCache.class);
+    BlobStorage storage = mock(BlobStorage.class);
     return new Fixture(
         assetDao,
         componentDao,
         browseNodeDao,
         cache,
+        storage,
         new RawAssetWriter(assetDao, componentDao, browseNodeDao, cache, null));
+  }
+
+  private static void stubUploadedBlob(Fixture fixture) {
+    when(fixture.assetDao.findReusableBlobBySha256(eq(1L), anyString(), anyLong()))
+        .thenReturn(Optional.empty());
+    when(fixture.storage.putFile(eq("raw"), anyString(), any(Path.class), anyString()))
+        .thenAnswer(invocation -> new BlobReference(
+            "bucket", invocation.getArgument(1), invocation.getArgument(3), 4L));
+    when(fixture.assetDao.insertBlobOrFindExisting(any()))
+        .thenAnswer(invocation -> ((AssetBlobRecord) invocation.getArgument(0)).withId(2L));
   }
 
   private static RepositoryRuntime runtime() {
@@ -70,11 +228,25 @@ class RawAssetWriterTest {
         "ALLOW", null, null, true, null, 60, 60, true, "ATTACHMENT", List.of());
   }
 
+  private static AssetRecord asset(long id, long blobId) {
+    return new AssetRecord(
+        id, 1L, 22L, blobId, RepositoryFormat.RAW, PATH, null,
+        "file.txt", "raw", "text/plain", 4L, null, Instant.EPOCH, Map.of());
+  }
+
+  private static AssetBlobRecord blob(long id, String objectKey) {
+    return new AssetBlobRecord(
+        id, 1L, "blob://bucket/" + objectKey, null, objectKey, null,
+        "sha1", "sha256", "md5", 4L, "text/plain", "user", "127.0.0.1",
+        Instant.EPOCH, Instant.EPOCH, Map.of());
+  }
+
   private record Fixture(
       AssetDao assetDao,
       ComponentDao componentDao,
       BrowseNodeDao browseNodeDao,
       AssetMetadataCache cache,
+      BlobStorage storage,
       RawAssetWriter writer) {
   }
 }

--- a/server/src/test/java/com/github/klboke/kkrepo/server/raw/RawGroupServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/raw/RawGroupServiceTest.java
@@ -1,0 +1,61 @@
+package com.github.klboke.kkrepo.server.raw;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.server.maven.MavenExceptions;
+import com.github.klboke.kkrepo.server.maven.MavenResponse;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RawGroupServiceTest {
+  @Test
+  void probesMembersInOrderAndRecursesIntoNestedGroups() {
+    RawHostedService hosted = mock(RawHostedService.class);
+    RawProxyService proxy = mock(RawProxyService.class);
+    RawGroupService service = new RawGroupService(hosted, proxy);
+    RepositoryRuntime hostedMissing = runtime(1, "hosted-missing", RepositoryType.HOSTED, List.of());
+    RepositoryRuntime proxyBroken = runtime(2, "proxy-broken", RepositoryType.PROXY, List.of());
+    RepositoryRuntime hostedUnsupported = runtime(3, "hosted-unsupported", RepositoryType.HOSTED, List.of());
+    RepositoryRuntime proxySuccess = runtime(4, "proxy-success", RepositoryType.PROXY, List.of());
+    RepositoryRuntime nested = runtime(5, "nested", RepositoryType.GROUP, List.of(proxySuccess));
+    RepositoryRuntime group = runtime(
+        6, "all", RepositoryType.GROUP,
+        List.of(hostedMissing, proxyBroken, hostedUnsupported, nested));
+    MavenResponse expected = MavenResponse.noBody(200);
+
+    when(hosted.get(hostedMissing, "docs/file.txt", false))
+        .thenThrow(new MavenExceptions.MavenNotFoundException("missing"));
+    when(proxy.get(proxyBroken, "docs/file.txt", false))
+        .thenThrow(new MavenExceptions.BadUpstreamException("offline"));
+    when(hosted.get(hostedUnsupported, "docs/file.txt", false))
+        .thenThrow(new MavenExceptions.MethodNotAllowed("unsupported"));
+    when(proxy.get(proxySuccess, "docs/file.txt", false)).thenReturn(expected);
+
+    assertSame(expected, service.get(group, "docs/file.txt", false));
+  }
+
+  @Test
+  void rejectsNonGroupsAndEmptyGroups() {
+    RawGroupService service = new RawGroupService(
+        mock(RawHostedService.class), mock(RawProxyService.class));
+
+    assertThrows(IllegalStateException.class,
+        () -> service.get(runtime(1, "hosted", RepositoryType.HOSTED, List.of()), "file", false));
+    assertThrows(MavenExceptions.MavenNotFoundException.class,
+        () -> service.get(runtime(2, "empty", RepositoryType.GROUP, List.of()), "file", false));
+  }
+
+  private static RepositoryRuntime runtime(
+      long id, String name, RepositoryType type, List<RepositoryRuntime> members) {
+    return new RepositoryRuntime(
+        id, name, RepositoryFormat.RAW, type, "raw", true, 1L,
+        "ALLOW", null, null, true, "https://upstream.example.test/",
+        60, 60, true, "ATTACHMENT", members);
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/raw/RawHostedServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/raw/RawHostedServiceTest.java
@@ -1,0 +1,152 @@
+package com.github.klboke.kkrepo.server.raw;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.core.BlobStorage;
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.mysql.dao.AssetDao;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetRecord;
+import com.github.klboke.kkrepo.server.cache.AssetMetadataCache;
+import com.github.klboke.kkrepo.server.cache.CachedAssetMetadata;
+import com.github.klboke.kkrepo.server.maven.BlobStorageRegistry;
+import com.github.klboke.kkrepo.server.maven.MavenExceptions;
+import com.github.klboke.kkrepo.server.maven.MavenResponse;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import java.io.ByteArrayInputStream;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class RawHostedServiceTest {
+  @Test
+  void normalizesAssetAndDirectoryPaths() {
+    assertTrue(RawHostedService.isDirectoryRequest(null));
+    assertTrue(RawHostedService.isDirectoryRequest(" "));
+    assertTrue(RawHostedService.isDirectoryRequest("docs/"));
+    assertFalse(RawHostedService.isDirectoryRequest("docs/file.txt"));
+    assertEquals("docs/file.txt", RawHostedService.normalizeAssetPath(" //docs///file.txt/ "));
+    assertEquals("docs", RawHostedService.normalizeDirectoryPath("///docs///"));
+    assertArrayEquals(
+        new String[] {"index.html", "index.htm"},
+        RawHostedService.indexCandidates(""));
+    assertArrayEquals(
+        new String[] {"docs/index.html", "docs/index.htm"},
+        RawHostedService.indexCandidates("docs"));
+    assertThrows(MavenExceptions.MavenNotFoundException.class,
+        () -> RawHostedService.normalizeAssetPath("///"));
+  }
+
+  @Test
+  void servesDirectoryIndexFallback() {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(RepositoryType.HOSTED, 1L, "ALLOW");
+    CachedAssetMetadata snapshot = snapshot("docs/index.htm");
+    MavenResponse expected = MavenResponse.noBody(200);
+    when(fixture.cache.find(eq(runtime.id()), any(String.class), any()))
+        .thenAnswer(invocation -> invocation.getArgument(1).equals("docs/index.htm")
+            ? Optional.of(snapshot)
+            : Optional.empty());
+    when(fixture.reader.serveSnapshot(
+        snapshot, true, "docs/index.htm", "ATTACHMENT")).thenReturn(expected);
+
+    assertSame(expected, fixture.service.get(runtime, "/docs/", true));
+  }
+
+  @Test
+  void enforcesRepositoryTypeWritePolicyAndBlobAssignment() {
+    Fixture fixture = fixture();
+    ByteArrayInputStream body = new ByteArrayInputStream(new byte[] {1});
+
+    assertThrows(MavenExceptions.MethodNotAllowed.class,
+        () -> fixture.service.get(runtime(RepositoryType.PROXY, 1L, "ALLOW"), "file", false));
+    assertThrows(MavenExceptions.WritePolicyDenied.class,
+        () -> fixture.service.put(
+            runtime(RepositoryType.HOSTED, 1L, "DENY"), "file", body,
+            null, "user", "127.0.0.1"));
+
+    RepositoryRuntime allowOnce = runtime(RepositoryType.HOSTED, 1L, "ALLOW_ONCE");
+    when(fixture.assetDao.findAssetByPath(allowOnce.id(), "file"))
+        .thenReturn(Optional.of(snapshot("file").toAssetRecord()));
+    assertThrows(MavenExceptions.WritePolicyDenied.class,
+        () -> fixture.service.put(
+            allowOnce, "file", new ByteArrayInputStream(new byte[] {1}),
+            null, "user", "127.0.0.1"));
+
+    assertThrows(IllegalStateException.class,
+        () -> fixture.service.putInternal(
+            runtime(RepositoryType.HOSTED, null, "ALLOW"), "file",
+            new ByteArrayInputStream(new byte[] {1}), null, null, "user", "127.0.0.1"));
+  }
+
+  @Test
+  void delegatesInternalWritesAndMapsDeleteResults() {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(RepositoryType.HOSTED, 1L, "ALLOW");
+    BlobStorage storage = mock(BlobStorage.class);
+    when(fixture.registry.forBlobStoreId(1L)).thenReturn(storage);
+    when(fixture.writer.deleteAsset(runtime, storage, "file")).thenReturn(0, 1);
+
+    MavenResponse created = fixture.service.putInternal(
+        runtime, "/file", new ByteArrayInputStream(new byte[] {1}),
+        "text/plain", null, "user", "127.0.0.1");
+    assertEquals(201, created.status());
+    verify(fixture.writer).write(
+        eq(runtime), eq(storage), eq(1L), eq("file"), any(),
+        eq("text/plain"), eq(Map.of()), eq("user"), eq("127.0.0.1"));
+
+    assertEquals(404, fixture.service.delete(runtime, "file").status());
+    assertEquals(204, fixture.service.delete(runtime, "file").status());
+  }
+
+  private static Fixture fixture() {
+    AssetDao assetDao = mock(AssetDao.class);
+    BlobStorageRegistry registry = mock(BlobStorageRegistry.class);
+    RawAssetWriter writer = mock(RawAssetWriter.class);
+    RawAssetReader reader = mock(RawAssetReader.class);
+    AssetMetadataCache cache = mock(AssetMetadataCache.class);
+    return new Fixture(
+        assetDao,
+        registry,
+        writer,
+        reader,
+        cache,
+        new RawHostedService(assetDao, registry, writer, reader, cache));
+  }
+
+  private static RepositoryRuntime runtime(
+      RepositoryType type, Long blobStoreId, String writePolicy) {
+    return new RepositoryRuntime(
+        1L, "raw", RepositoryFormat.RAW, type, "raw", true, blobStoreId,
+        writePolicy, null, null, true, "https://upstream.example.test/",
+        60, 60, true, "ATTACHMENT", List.of());
+  }
+
+  private static CachedAssetMetadata snapshot(String path) {
+    AssetRecord asset = new AssetRecord(
+        1L, 1L, null, 2L, RepositoryFormat.RAW, path, null, path, "raw",
+        "text/plain", 1L, null, Instant.EPOCH, Map.of());
+    return CachedAssetMetadata.of(asset, null);
+  }
+
+  private record Fixture(
+      AssetDao assetDao,
+      BlobStorageRegistry registry,
+      RawAssetWriter writer,
+      RawAssetReader reader,
+      AssetMetadataCache cache,
+      RawHostedService service) {
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/raw/RawProxyServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/raw/RawProxyServiceTest.java
@@ -2,13 +2,33 @@ package com.github.klboke.kkrepo.server.raw;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.github.klboke.kkrepo.core.RepositoryFormat;
 import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.mysql.dao.AssetDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.ProxyStateDao;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetBlobRecord;
+import com.github.klboke.kkrepo.persistence.mysql.model.AssetRecord;
+import com.github.klboke.kkrepo.server.cache.AssetMetadataCache;
+import com.github.klboke.kkrepo.server.cache.CachedAssetMetadata;
+import com.github.klboke.kkrepo.server.maven.BlobStorageRegistry;
 import com.github.klboke.kkrepo.server.maven.HttpRemoteFetcher;
+import com.github.klboke.kkrepo.server.maven.MavenExceptions;
+import com.github.klboke.kkrepo.server.maven.MavenResponse;
+import com.github.klboke.kkrepo.server.maven.ProxyNegativeCache;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class RawProxyServiceTest {
@@ -46,5 +66,130 @@ class RawProxyServiceTest {
     assertEquals("composer-proxy", request.repository());
     assertEquals("COMPOSER", request.format());
     assertEquals(lastModified, request.lastModified());
+  }
+
+  @Test
+  void servesFreshCachedAssetWithoutConsultingUpstreamState() {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(RepositoryType.PROXY, 60);
+    CachedAssetMetadata cached = snapshot(Instant.now().plusSeconds(60));
+    MavenResponse expected = MavenResponse.noBody(200);
+    when(fixture.cache.find(eq(runtime.id()), eq("file.txt"), any()))
+        .thenReturn(Optional.of(cached));
+    when(fixture.reader.serveSnapshot(cached, false, "file.txt", "ATTACHMENT"))
+        .thenReturn(expected);
+
+    assertSame(expected, fixture.service.get(runtime, "file.txt", false));
+
+    verify(fixture.negativeCache, never()).isNotFoundCached(runtime, "file.txt");
+    verify(fixture.proxyStateDao, never()).isBlocked(eq(runtime.id()), any());
+  }
+
+  @Test
+  void honorsNegativeCacheBeforeCheckingCircuitBreaker() {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(RepositoryType.PROXY, 60);
+    when(fixture.cache.find(eq(runtime.id()), eq("missing.txt"), any()))
+        .thenReturn(Optional.empty());
+    when(fixture.negativeCache.isNotFoundCached(runtime, "missing.txt")).thenReturn(true);
+
+    assertThrows(MavenExceptions.MavenNotFoundException.class,
+        () -> fixture.service.getAsset(runtime, "missing.txt", false));
+
+    verify(fixture.proxyStateDao, never()).isBlocked(eq(runtime.id()), any());
+  }
+
+  @Test
+  void servesStaleCacheWhileUpstreamIsBlocked() {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(RepositoryType.PROXY, 1);
+    CachedAssetMetadata cached = snapshot(Instant.EPOCH);
+    MavenResponse expected = MavenResponse.noBody(200);
+    when(fixture.cache.find(eq(runtime.id()), eq("file.txt"), any()))
+        .thenReturn(Optional.of(cached));
+    when(fixture.proxyStateDao.isBlocked(eq(runtime.id()), any())).thenReturn(true);
+    when(fixture.reader.serveSnapshot(cached, true, "file.txt", "ATTACHMENT"))
+        .thenReturn(expected);
+
+    assertSame(expected, fixture.service.getAsset(runtime, "file.txt", true));
+  }
+
+  @Test
+  void reportsBlockedUpstreamWhenNoCacheExists() {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(RepositoryType.PROXY, 1);
+    when(fixture.cache.find(eq(runtime.id()), eq("file.txt"), any()))
+        .thenReturn(Optional.empty());
+    when(fixture.proxyStateDao.isBlocked(eq(runtime.id()), any())).thenReturn(true);
+
+    assertThrows(MavenExceptions.BadUpstreamException.class,
+        () -> fixture.service.getAssetFromUrl(
+            runtime, "file.txt", "https://cdn.example.test/file.txt", false));
+  }
+
+  @Test
+  void rejectsNonProxyRepositories() {
+    Fixture fixture = fixture();
+
+    assertThrows(MavenExceptions.MethodNotAllowed.class,
+        () -> fixture.service.get(runtime(RepositoryType.HOSTED, 60), "file.txt", false));
+  }
+
+  private static Fixture fixture() {
+    AssetDao assetDao = mock(AssetDao.class);
+    BlobStorageRegistry registry = mock(BlobStorageRegistry.class);
+    RawAssetWriter writer = mock(RawAssetWriter.class);
+    RawAssetReader reader = mock(RawAssetReader.class);
+    ProxyStateDao proxyStateDao = mock(ProxyStateDao.class);
+    HttpRemoteFetcher fetcher = mock(HttpRemoteFetcher.class);
+    ProxyNegativeCache negativeCache = mock(ProxyNegativeCache.class);
+    AssetMetadataCache cache = mock(AssetMetadataCache.class);
+    return new Fixture(
+        proxyStateDao,
+        reader,
+        negativeCache,
+        cache,
+        new RawProxyService(
+            assetDao, registry, writer, reader, proxyStateDao, fetcher, negativeCache, cache));
+  }
+
+  private static RepositoryRuntime runtime(RepositoryType type, int maxAgeMinutes) {
+    return new RepositoryRuntime(
+        10L,
+        "raw-proxy",
+        RepositoryFormat.RAW,
+        type,
+        "raw",
+        true,
+        1L,
+        null,
+        null,
+        null,
+        true,
+        "https://upstream.example.test/",
+        maxAgeMinutes,
+        maxAgeMinutes,
+        true,
+        "ATTACHMENT",
+        List.of());
+  }
+
+  private static CachedAssetMetadata snapshot(Instant updatedAt) {
+    AssetRecord asset = new AssetRecord(
+        1L, 10L, null, 2L, RepositoryFormat.RAW, "file.txt", null,
+        "file.txt", "raw", "text/plain", 4L, null, updatedAt, Map.of());
+    AssetBlobRecord blob = new AssetBlobRecord(
+        2L, 1L, "blob://bucket/file.txt", null, "file.txt", null,
+        "sha1", "sha256", "md5", 4, "text/plain", "proxy", "upstream",
+        Instant.EPOCH, updatedAt, Map.of());
+    return CachedAssetMetadata.of(asset, blob);
+  }
+
+  private record Fixture(
+      ProxyStateDao proxyStateDao,
+      RawAssetReader reader,
+      ProxyNegativeCache negativeCache,
+      AssetMetadataCache cache,
+      RawProxyService service) {
   }
 }

--- a/server/src/test/java/com/github/klboke/kkrepo/server/repository/RepositoryIndexRebuildWorkerTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/repository/RepositoryIndexRebuildWorkerTest.java
@@ -1,0 +1,217 @@
+package com.github.klboke.kkrepo.server.repository;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.core.BlobStorage;
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.mysql.dao.RepositoryIndexRebuildDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.RepositoryIndexRebuildDao.Claim;
+import com.github.klboke.kkrepo.server.helm.HelmHostedService;
+import com.github.klboke.kkrepo.server.maven.BlobStorageRegistry;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
+import com.github.klboke.kkrepo.server.metrics.KkRepoMetrics;
+import com.github.klboke.kkrepo.server.pypi.PypiHostedService;
+import com.github.klboke.kkrepo.server.rubygems.RubygemsService;
+import com.github.klboke.kkrepo.server.yum.YumService;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+class RepositoryIndexRebuildWorkerTest {
+
+  @Test
+  void disabledWorkerDoesNotClaimMarkers() {
+    RepositoryIndexRebuildDao dao = mock(RepositoryIndexRebuildDao.class);
+
+    worker(
+        dao,
+        mock(RepositoryRuntimeRegistry.class),
+        mock(BlobStorageRegistry.class),
+        mock(HelmHostedService.class),
+        mock(PypiHostedService.class),
+        mock(YumService.class),
+        mock(RubygemsService.class),
+        false).drain();
+
+    verifyNoInteractions(dao);
+  }
+
+  @Test
+  void dispatchesSupportedHostedIndexKinds() {
+    RepositoryIndexRebuildDao dao = mock(RepositoryIndexRebuildDao.class);
+    RepositoryRuntimeRegistry runtimes = mock(RepositoryRuntimeRegistry.class);
+    BlobStorageRegistry storages = mock(BlobStorageRegistry.class);
+    HelmHostedService helm = mock(HelmHostedService.class);
+    PypiHostedService pypi = mock(PypiHostedService.class);
+    YumService yum = mock(YumService.class);
+    RubygemsService rubygems = mock(RubygemsService.class);
+    BlobStorage storage = mock(BlobStorage.class);
+    RepositoryRuntime helmRuntime = runtime(1L, RepositoryFormat.HELM, 7L);
+    RepositoryRuntime pypiRuntime = runtime(2L, RepositoryFormat.PYPI, 7L);
+    RepositoryRuntime yumRuntime = runtime(3L, RepositoryFormat.YUM, 7L);
+    RepositoryRuntime rubygemsRuntime = runtime(4L, RepositoryFormat.RUBYGEMS, 7L);
+    Instant now = Instant.now();
+    when(dao.claim(8)).thenReturn(List.of(
+        claim(1L, RepositoryIndexRebuildDao.HELM_INDEX, null, now),
+        claim(2L, RepositoryIndexRebuildDao.PYPI_ROOT, null, now),
+        claim(2L, RepositoryIndexRebuildDao.PYPI_PROJECT, "demo", now),
+        claim(3L, RepositoryIndexRebuildDao.YUM_METADATA, null, now),
+        claim(4L, RepositoryIndexRebuildDao.RUBYGEMS_METADATA, null, now)));
+    when(runtimes.resolveById(1L)).thenReturn(Optional.of(helmRuntime));
+    when(runtimes.resolveById(2L)).thenReturn(Optional.of(pypiRuntime));
+    when(runtimes.resolveById(3L)).thenReturn(Optional.of(yumRuntime));
+    when(runtimes.resolveById(4L)).thenReturn(Optional.of(rubygemsRuntime));
+    when(storages.forBlobStoreId(7L)).thenReturn(storage);
+
+    worker(dao, runtimes, storages, helm, pypi, yum, rubygems, true).drain();
+
+    verify(helm).rebuildIndex(helmRuntime, storage, 7L, "system", null);
+    verify(pypi).rebuildRootIndex(pypiRuntime, storage, 7L, "system", null);
+    verify(pypi).rebuildProjectIndex(pypiRuntime, storage, 7L, "demo", "system", null);
+    verify(yum).rebuildMetadata(yumRuntime, "system", null);
+    verify(rubygems).rebuildGeneratedMetadata(rubygemsRuntime);
+  }
+
+  @Test
+  void ignoresMissingNonHostedWrongFormatAndBlankProjectClaims() {
+    RepositoryIndexRebuildDao dao = mock(RepositoryIndexRebuildDao.class);
+    RepositoryRuntimeRegistry runtimes = mock(RepositoryRuntimeRegistry.class);
+    BlobStorageRegistry storages = mock(BlobStorageRegistry.class);
+    HelmHostedService helm = mock(HelmHostedService.class);
+    PypiHostedService pypi = mock(PypiHostedService.class);
+    YumService yum = mock(YumService.class);
+    RubygemsService rubygems = mock(RubygemsService.class);
+    Instant now = Instant.now();
+    when(dao.claim(8)).thenReturn(List.of(
+        claim(1L, RepositoryIndexRebuildDao.HELM_INDEX, null, now),
+        claim(2L, RepositoryIndexRebuildDao.HELM_INDEX, null, now),
+        claim(3L, RepositoryIndexRebuildDao.HELM_INDEX, null, now),
+        claim(4L, RepositoryIndexRebuildDao.PYPI_PROJECT, " ", now),
+        claim(5L, "unknown", null, now)));
+    when(runtimes.resolveById(1L)).thenReturn(Optional.empty());
+    when(runtimes.resolveById(2L)).thenReturn(Optional.of(
+        runtime(2L, RepositoryFormat.HELM, RepositoryType.PROXY, 7L)));
+    when(runtimes.resolveById(3L)).thenReturn(Optional.of(runtime(3L, RepositoryFormat.PYPI, 7L)));
+    when(runtimes.resolveById(4L)).thenReturn(Optional.of(runtime(4L, RepositoryFormat.PYPI, 7L)));
+    when(runtimes.resolveById(5L)).thenReturn(Optional.of(runtime(5L, RepositoryFormat.HELM, 7L)));
+
+    worker(dao, runtimes, storages, helm, pypi, yum, rubygems, true).drain();
+
+    verifyNoInteractions(helm, pypi, yum, rubygems, storages);
+  }
+
+  @Test
+  void failedItemIsReenqueuedAndLaterClaimStillRuns() {
+    RepositoryIndexRebuildDao dao = mock(RepositoryIndexRebuildDao.class);
+    RepositoryRuntimeRegistry runtimes = mock(RepositoryRuntimeRegistry.class);
+    BlobStorageRegistry storages = mock(BlobStorageRegistry.class);
+    HelmHostedService helm = mock(HelmHostedService.class);
+    PypiHostedService pypi = mock(PypiHostedService.class);
+    YumService yum = mock(YumService.class);
+    RubygemsService rubygems = mock(RubygemsService.class);
+    BlobStorage storage = mock(BlobStorage.class);
+    RepositoryRuntime helmRuntime = runtime(1L, RepositoryFormat.HELM, 7L);
+    RepositoryRuntime pypiRuntime = runtime(2L, RepositoryFormat.PYPI, 7L);
+    Instant now = Instant.now();
+    Claim failing = claim(1L, RepositoryIndexRebuildDao.HELM_INDEX, null, now);
+    Claim succeeding = claim(2L, RepositoryIndexRebuildDao.PYPI_ROOT, null, now);
+    when(dao.claim(8)).thenReturn(List.of(failing, succeeding));
+    when(runtimes.resolveById(1L)).thenReturn(Optional.of(helmRuntime));
+    when(runtimes.resolveById(2L)).thenReturn(Optional.of(pypiRuntime));
+    when(storages.forBlobStoreId(7L)).thenReturn(storage);
+    IllegalStateException failure = new IllegalStateException("index write failed");
+    doThrow(failure).when(helm).rebuildIndex(helmRuntime, storage, 7L, "system", null);
+
+    worker(dao, runtimes, storages, helm, pypi, yum, rubygems, true).drain();
+
+    verify(dao).reenqueueFailure(failing, failure);
+    verify(pypi).rebuildRootIndex(pypiRuntime, storage, 7L, "system", null);
+  }
+
+  private static RepositoryIndexRebuildWorker worker(
+      RepositoryIndexRebuildDao dao,
+      RepositoryRuntimeRegistry runtimes,
+      BlobStorageRegistry storages,
+      HelmHostedService helm,
+      PypiHostedService pypi,
+      YumService yum,
+      RubygemsService rubygems,
+      boolean enabled) {
+    return new RepositoryIndexRebuildWorker(
+        dao,
+        runtimes,
+        storages,
+        helm,
+        pypi,
+        yum,
+        rubygems,
+        new RecordingTransactionManager(),
+        8,
+        enabled,
+        new KkRepoMetrics(new SimpleMeterRegistry()));
+  }
+
+  private static Claim claim(long repositoryId, String kind, String scope, Instant requestedAt) {
+    return new Claim(repositoryId, kind, scope, requestedAt, 0, null);
+  }
+
+  private static RepositoryRuntime runtime(long id, RepositoryFormat format, Long blobStoreId) {
+    return runtime(id, format, RepositoryType.HOSTED, blobStoreId);
+  }
+
+  private static RepositoryRuntime runtime(
+      long id,
+      RepositoryFormat format,
+      RepositoryType type,
+      Long blobStoreId) {
+    return new RepositoryRuntime(
+        id,
+        format.id() + "-" + id,
+        format,
+        type,
+        format.id() + "-" + type.name().toLowerCase(),
+        true,
+        blobStoreId,
+        "ALLOW",
+        null,
+        null,
+        true,
+        null,
+        null,
+        null,
+        true,
+        null,
+        List.of());
+  }
+
+  private static final class RecordingTransactionManager implements PlatformTransactionManager {
+    @Override
+    public TransactionStatus getTransaction(TransactionDefinition definition) throws TransactionException {
+      return new SimpleTransactionStatus();
+    }
+
+    @Override
+    public void commit(TransactionStatus status) throws TransactionException {
+    }
+
+    @Override
+    public void rollback(TransactionStatus status) throws TransactionException {
+    }
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/security/ManagementAuditFilterTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/security/ManagementAuditFilterTest.java
@@ -1,0 +1,148 @@
+package com.github.klboke.kkrepo.server.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.github.klboke.kkrepo.persistence.mysql.dao.SecurityAuditDao;
+import com.github.klboke.kkrepo.persistence.mysql.dao.SecurityAuditDao.AuditLogRecord;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class ManagementAuditFilterTest {
+
+  @Test
+  void successfulMutationRecordsActorPermissionContextPathAndTrustedClientAddress() throws Exception {
+    SecurityAuditDao auditDao = mock(SecurityAuditDao.class);
+    ManagementAuditFilter filter = filter(auditDao, "127.0.0.1", false);
+    MockHttpServletRequest request =
+        new MockHttpServletRequest("POST", "/kkrepo/internal/security/users");
+    request.setContextPath("/kkrepo");
+    request.setRemoteAddr("127.0.0.1");
+    request.addHeader("X-Forwarded-For", "203.0.113.7, 10.0.0.1");
+    request.setAttribute(
+        AuthenticatedSubject.REQUEST_ATTRIBUTE,
+        new AuthenticatedSubject("api_key", "alice", "local", 33L, null));
+    request.setAttribute(SecurityManagementFilter.REQUESTED_PERMISSION_ATTRIBUTE, "security:user:update");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    filter.doFilter(request, response, (req, resp) -> ((HttpServletResponse) resp).setStatus(201));
+
+    ArgumentCaptor<AuditLogRecord> record = ArgumentCaptor.forClass(AuditLogRecord.class);
+    verify(auditDao).insert(record.capture());
+    assertEquals("api_key", record.getValue().actorSource());
+    assertEquals("alice", record.getValue().actorUserId());
+    assertEquals("local", record.getValue().actorRealmId());
+    assertEquals(33L, record.getValue().actorApiKeyId());
+    assertEquals("203.0.113.7", record.getValue().remoteAddr());
+    assertEquals("POST", record.getValue().method());
+    assertEquals("/internal/security/users", record.getValue().path());
+    assertEquals("security:user:update", record.getValue().permission());
+    assertEquals(201, record.getValue().status());
+    assertEquals("SUCCESS", record.getValue().outcome());
+    assertTrue(record.getValue().details().isEmpty());
+  }
+
+  @Test
+  void readAndNonManagementRequestsAreNotAudited() throws Exception {
+    SecurityAuditDao auditDao = mock(SecurityAuditDao.class);
+    ManagementAuditFilter filter = filter(auditDao, "", false);
+
+    filter.doFilter(
+        new MockHttpServletRequest("GET", "/internal/security/users"),
+        new MockHttpServletResponse(),
+        (req, resp) -> {
+        });
+    filter.doFilter(
+        new MockHttpServletRequest("POST", "/repository/maven-releases/a.jar"),
+        new MockHttpServletResponse(),
+        (req, resp) -> {
+        });
+
+    verify(auditDao, never()).insert(any());
+  }
+
+  @Test
+  void sendErrorAndThrownFailureAreRecordedAsFailures() throws Exception {
+    SecurityAuditDao auditDao = mock(SecurityAuditDao.class);
+    ManagementAuditFilter filter = filter(auditDao, "", false);
+    MockHttpServletRequest rejected =
+        new MockHttpServletRequest("DELETE", "/service/rest/v1/security/users/alice");
+    rejected.setRemoteAddr("198.51.100.5");
+
+    filter.doFilter(
+        rejected,
+        new MockHttpServletResponse(),
+        (req, resp) -> ((HttpServletResponse) resp).sendError(403, "denied"));
+
+    MockHttpServletRequest failed =
+        new MockHttpServletRequest("POST", "/internal/repositories");
+    failed.setRemoteAddr("198.51.100.6");
+    IllegalStateException failure = new IllegalStateException("database unavailable");
+    assertThrows(IllegalStateException.class, () ->
+        filter.doFilter(failed, new MockHttpServletResponse(), (req, resp) -> {
+          throw failure;
+        }));
+
+    ArgumentCaptor<AuditLogRecord> records = ArgumentCaptor.forClass(AuditLogRecord.class);
+    verify(auditDao, org.mockito.Mockito.times(2)).insert(records.capture());
+    assertEquals(403, records.getAllValues().get(0).status());
+    assertEquals("FAILURE", records.getAllValues().get(0).outcome());
+    assertTrue(records.getAllValues().get(0).details().isEmpty());
+    assertEquals(200, records.getAllValues().get(1).status());
+    assertEquals("FAILURE", records.getAllValues().get(1).outcome());
+    assertEquals("IllegalStateException", records.getAllValues().get(1).details().get("error"));
+  }
+
+  @Test
+  void auditPersistenceFailureDoesNotChangeManagementResponse() throws Exception {
+    SecurityAuditDao auditDao = mock(SecurityAuditDao.class);
+    doThrow(new IllegalStateException("audit unavailable")).when(auditDao).insert(any());
+    ManagementAuditFilter filter = filter(auditDao, "", true);
+    MockHttpServletRequest request =
+        new MockHttpServletRequest("POST", "/service/extdirect");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    filter.doFilter(request, response, (req, resp) -> ((HttpServletResponse) resp).setStatus(204));
+
+    assertEquals(204, response.getStatus());
+    verify(auditDao).insert(any());
+  }
+
+  @Test
+  void servletFailureIsRethrownAfterAudit() throws Exception {
+    SecurityAuditDao auditDao = mock(SecurityAuditDao.class);
+    ManagementAuditFilter filter = filter(auditDao, "", false);
+    MockHttpServletRequest request =
+        new MockHttpServletRequest("PATCH", "/internal/security/roles/admin");
+    ServletException failure = new ServletException("role update failed");
+
+    assertThrows(ServletException.class, () ->
+        filter.doFilter(request, new MockHttpServletResponse(), (req, resp) -> {
+          throw failure;
+        }));
+
+    ArgumentCaptor<AuditLogRecord> record = ArgumentCaptor.forClass(AuditLogRecord.class);
+    verify(auditDao).insert(record.capture());
+    assertEquals("ServletException", record.getValue().details().get("error"));
+  }
+
+  private static ManagementAuditFilter filter(
+      SecurityAuditDao auditDao,
+      String trustedProxies,
+      boolean legacyUiEnabled) {
+    return new ManagementAuditFilter(
+        auditDao,
+        new ForwardedHeaderPolicy(trustedProxies),
+        new NexusLegacyUiCompatibility(legacyUiEnabled));
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/security/SecurityRateLimitFilterTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/security/SecurityRateLimitFilterTest.java
@@ -1,0 +1,161 @@
+package com.github.klboke.kkrepo.server.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.github.klboke.kkrepo.server.metrics.KkRepoMetrics;
+import com.github.klboke.kkrepo.server.support.InMemorySharedCache;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class SecurityRateLimitFilterTest {
+
+  @Test
+  void repeatedLoginIsBlockedWithRetryHeaderAndMetric() throws Exception {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    SecurityRateLimitFilter filter = filter(
+        1, 1, new InMemorySharedCache(), new ForwardedHeaderPolicy(""), registry, false);
+    CountingChain chain = new CountingChain();
+
+    MockHttpServletResponse first = invoke(
+        filter, request("POST", "/internal/security/login", "198.51.100.10"), chain);
+    MockHttpServletResponse second = invoke(
+        filter, request("POST", "/internal/security/login", "198.51.100.10"), chain);
+
+    assertEquals(200, first.getStatus());
+    assertEquals(429, second.getStatus());
+    assertEquals("60", second.getHeader("Retry-After"));
+    assertEquals(1, chain.calls);
+    var counter = registry.find("kkrepo_rate_limit_blocked_total")
+        .tag("type", "login")
+        .counter();
+    assertNotNull(counter);
+    assertEquals(1.0, counter.count());
+  }
+
+  @Test
+  void bootstrapAndLoginUseIndependentCounters() throws Exception {
+    SecurityRateLimitFilter filter = filter(
+        1, 1, new InMemorySharedCache(), new ForwardedHeaderPolicy(""),
+        new SimpleMeterRegistry(), false);
+    CountingChain chain = new CountingChain();
+
+    MockHttpServletResponse login = invoke(
+        filter, request("POST", "/internal/security/login", "198.51.100.20"), chain);
+    MockHttpServletResponse bootstrap = invoke(
+        filter, request("POST", "/internal/security/bootstrap/admin", "198.51.100.20"), chain);
+
+    assertEquals(200, login.getStatus());
+    assertEquals(200, bootstrap.getStatus());
+    assertEquals(2, chain.calls);
+  }
+
+  @Test
+  void managementAuthRequiresPresentedCredentialsAndUsesTrustedForwardedAddress() throws Exception {
+    InMemorySharedCache cache = new InMemorySharedCache();
+    SecurityRateLimitFilter filter = filter(
+        1, 1, cache, new ForwardedHeaderPolicy("127.0.0.1"),
+        new SimpleMeterRegistry(), false);
+    CountingChain chain = new CountingChain();
+    MockHttpServletRequest first = request(
+        "POST", "/service/rest/v1/security/users", "127.0.0.1");
+    first.addHeader("Authorization", "Basic abc");
+    first.addHeader("X-Forwarded-For", "203.0.113.9, 10.0.0.1");
+    MockHttpServletRequest second = request(
+        "POST", "/service/rest/v1/security/users", "127.0.0.1");
+    second.addHeader("X-Nexus-Plus-Token", "token");
+    second.addHeader("X-Forwarded-For", "203.0.113.9");
+    MockHttpServletRequest noCredentials = request(
+        "POST", "/service/rest/v1/security/users", "127.0.0.1");
+    noCredentials.addHeader("X-Forwarded-For", "203.0.113.9");
+
+    assertEquals(200, invoke(filter, first, chain).getStatus());
+    assertEquals(429, invoke(filter, second, chain).getStatus());
+    assertEquals(200, invoke(filter, noCredentials, chain).getStatus());
+    assertEquals(2, chain.calls);
+  }
+
+  @Test
+  void untrustedForwardedHeaderDoesNotMergeDifferentRemoteClients() throws Exception {
+    SecurityRateLimitFilter filter = filter(
+        1, 1, new InMemorySharedCache(), new ForwardedHeaderPolicy("127.0.0.1"),
+        new SimpleMeterRegistry(), false);
+    CountingChain chain = new CountingChain();
+    MockHttpServletRequest first = request("POST", "/internal/security/login", "198.51.100.30");
+    first.addHeader("X-Forwarded-For", "203.0.113.50");
+    MockHttpServletRequest second = request("POST", "/internal/security/login", "198.51.100.31");
+    second.addHeader("X-Forwarded-For", "203.0.113.50");
+
+    assertEquals(200, invoke(filter, first, chain).getStatus());
+    assertEquals(200, invoke(filter, second, chain).getStatus());
+    assertEquals(2, chain.calls);
+  }
+
+  @Test
+  void nonPositiveLimitsDisableBlockingAndLegacyLoginCanBeLimited() throws Exception {
+    SecurityRateLimitFilter unlimited = filter(
+        0, 0, new InMemorySharedCache(), new ForwardedHeaderPolicy(""),
+        new SimpleMeterRegistry(), false);
+    CountingChain unlimitedChain = new CountingChain();
+    for (int i = 0; i < 3; i++) {
+      assertEquals(200, invoke(
+          unlimited,
+          request("POST", "/internal/security/login", "198.51.100.40"),
+          unlimitedChain).getStatus());
+    }
+    assertEquals(3, unlimitedChain.calls);
+
+    SecurityRateLimitFilter legacy = filter(
+        1, 1, new InMemorySharedCache(), new ForwardedHeaderPolicy(""),
+        new SimpleMeterRegistry(), true);
+    CountingChain legacyChain = new CountingChain();
+    assertEquals(200, invoke(
+        legacy, request("POST", "/service/rapture/session", "198.51.100.41"), legacyChain).getStatus());
+    assertEquals(429, invoke(
+        legacy, request("POST", "/service/rapture/session", "198.51.100.41"), legacyChain).getStatus());
+  }
+
+  private static SecurityRateLimitFilter filter(
+      int loginLimit,
+      int bootstrapLimit,
+      InMemorySharedCache cache,
+      ForwardedHeaderPolicy forwardedHeaderPolicy,
+      SimpleMeterRegistry registry,
+      boolean legacyUiEnabled) {
+    return new SecurityRateLimitFilter(
+        loginLimit,
+        bootstrapLimit,
+        "X-Nexus-Plus-Token",
+        cache,
+        forwardedHeaderPolicy,
+        new KkRepoMetrics(registry),
+        new NexusLegacyUiCompatibility(legacyUiEnabled));
+  }
+
+  private static MockHttpServletRequest request(String method, String uri, String remoteAddress) {
+    MockHttpServletRequest request = new MockHttpServletRequest(method, uri);
+    request.setRemoteAddr(remoteAddress);
+    return request;
+  }
+
+  private static MockHttpServletResponse invoke(
+      SecurityRateLimitFilter filter,
+      MockHttpServletRequest request,
+      CountingChain chain) throws Exception {
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    filter.doFilter(request, response, chain);
+    return response;
+  }
+
+  private static final class CountingChain implements FilterChain {
+    private int calls;
+
+    @Override
+    public void doFilter(jakarta.servlet.ServletRequest request, jakarta.servlet.ServletResponse response) {
+      calls++;
+    }
+  }
+}

--- a/storage-s3/pom.xml
+++ b/storage-s3/pom.xml
@@ -46,5 +46,10 @@
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/storage-s3/src/test/java/com/github/klboke/kkrepo/storage/s3/OssNativeBlobStorageTest.java
+++ b/storage-s3/src/test/java/com/github/klboke/kkrepo/storage/s3/OssNativeBlobStorageTest.java
@@ -1,0 +1,193 @@
+package com.github.klboke.kkrepo.storage.s3;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aliyun.sdk.service.oss2.OSSClient;
+import com.aliyun.sdk.service.oss2.exceptions.ServiceException;
+import com.aliyun.sdk.service.oss2.models.AbortMultipartUploadRequest;
+import com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadRequest;
+import com.aliyun.sdk.service.oss2.models.GetObjectRequest;
+import com.aliyun.sdk.service.oss2.models.GetObjectResult;
+import com.aliyun.sdk.service.oss2.models.HeadObjectRequest;
+import com.aliyun.sdk.service.oss2.models.HeadObjectResult;
+import com.aliyun.sdk.service.oss2.models.InitiateMultipartUpload;
+import com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadRequest;
+import com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadResult;
+import com.aliyun.sdk.service.oss2.models.PutObjectRequest;
+import com.aliyun.sdk.service.oss2.models.UploadPartRequest;
+import com.aliyun.sdk.service.oss2.models.UploadPartResult;
+import com.github.klboke.kkrepo.core.BlobObjectMetadata;
+import com.github.klboke.kkrepo.core.BlobRangeReader;
+import com.github.klboke.kkrepo.core.BlobReference;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+
+class OssNativeBlobStorageTest {
+  @TempDir
+  Path tempDir;
+
+  @Test
+  void putOmitsBlankMetadataAndUploadsOriginalBytes() {
+    OSSClient client = mock(OSSClient.class);
+    OssNativeBlobStorage storage = new OssNativeBlobStorage(client, config(64 * 1024 * 1024L));
+    byte[] bytes = "oss-body".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    try {
+      BlobReference reference = storage.put(
+          "raw\nhosted", "files/data.bin", new ByteArrayInputStream(bytes), bytes.length, "");
+
+      ArgumentCaptor<PutObjectRequest> request = ArgumentCaptor.forClass(PutObjectRequest.class);
+      verify(client).putObject(request.capture());
+      assertEquals("raw_hosted", request.getValue().metadata().get("repository"));
+      assertFalse(request.getValue().metadata().containsKey("sha256"));
+      assertArrayEquals(bytes, request.getValue().body().toBytes());
+      assertEquals(bytes.length, reference.size());
+    } finally {
+      storage.close();
+    }
+  }
+
+  @Test
+  void getRangeStatDeleteAndResultCloseUseNativeSdkSemantics() throws Exception {
+    OSSClient client = mock(OSSClient.class);
+    AtomicReference<GetObjectRequest> lastGet = new AtomicReference<>();
+    AtomicReference<GetObjectResult> lastResult = new AtomicReference<>();
+    when(client.getObject(any(GetObjectRequest.class))).thenAnswer(invocation -> {
+      GetObjectRequest request = invocation.getArgument(0);
+      lastGet.set(request);
+      GetObjectResult result = mock(GetObjectResult.class);
+      byte[] bytes = request.range() == null
+          ? "0123456789".getBytes(java.nio.charset.StandardCharsets.US_ASCII)
+          : "234".getBytes(java.nio.charset.StandardCharsets.US_ASCII);
+      when(result.body()).thenReturn(new ByteArrayInputStream(bytes));
+      lastResult.set(result);
+      return result;
+    });
+    HeadObjectResult head = mock(HeadObjectResult.class);
+    when(head.metadata()).thenReturn(Map.of("sha256", "e".repeat(64)));
+    when(head.contentLength()).thenReturn(10L);
+    when(head.eTag()).thenReturn("etag");
+    when(head.contentType()).thenReturn("application/octet-stream");
+    when(head.lastModified()).thenReturn("Fri, 02 Jan 2026 03:04:05 GMT");
+    when(client.headObject(any(HeadObjectRequest.class))).thenReturn(head);
+    OssNativeBlobStorage storage = new OssNativeBlobStorage(client, config(64 * 1024 * 1024L));
+    BlobReference reference = new BlobReference("bucket", "prefix/object", "old", 1);
+    try {
+      InputStream full = storage.get(reference).orElseThrow();
+      GetObjectResult fullResult = lastResult.get();
+      assertEquals("0123456789", new String(full.readAllBytes(), java.nio.charset.StandardCharsets.US_ASCII));
+      BlobRangeReader rangeReader = assertInstanceOf(BlobRangeReader.class, full);
+      full.close();
+      verify(fullResult).close();
+
+      try (InputStream range = rangeReader.openRange(2, 3)) {
+        assertEquals("234", new String(range.readAllBytes(), java.nio.charset.StandardCharsets.US_ASCII));
+      }
+      assertEquals("bytes=2-4", lastGet.get().range());
+
+      BlobObjectMetadata metadata = storage.stat(reference).orElseThrow();
+      assertEquals(10, metadata.reference().size());
+      assertEquals("e".repeat(64), metadata.reference().sha256());
+      assertEquals(Instant.parse("2026-01-02T03:04:05Z"), metadata.lastModified());
+      assertTrue(storage.exists(reference));
+
+      storage.delete(reference);
+      verify(client).deleteObject(any(com.aliyun.sdk.service.oss2.models.DeleteObjectRequest.class));
+    } finally {
+      storage.close();
+    }
+  }
+
+  @Test
+  void missingObjectsNestedErrorsAndInvalidRangesAreHandled() throws Exception {
+    OSSClient client = mock(OSSClient.class);
+    ServiceException missing = ServiceException.newBuilder().statusCode(404).build();
+    when(client.getObject(any(GetObjectRequest.class))).thenThrow(new IllegalStateException(missing));
+    when(client.headObject(any(HeadObjectRequest.class))).thenThrow(missing);
+    OssNativeBlobStorage storage = new OssNativeBlobStorage(client, config(64 * 1024 * 1024L));
+    BlobReference reference = new BlobReference("bucket", "missing", "a", 1);
+    try {
+      assertTrue(OssNativeBlobStorage.isNotFound(new IllegalStateException(missing)));
+      assertFalse(OssNativeBlobStorage.isNotFound(new IllegalArgumentException("other")));
+      assertTrue(storage.get(reference).isEmpty());
+      assertTrue(storage.getRange(reference, 0, 1).isEmpty());
+      assertTrue(storage.stat(reference).isEmpty());
+      assertFalse(storage.exists(reference));
+      assertEquals(0, storage.getRange(reference, 0, 0).orElseThrow().readAllBytes().length);
+      assertThrows(IllegalArgumentException.class, () -> storage.getRange(reference, -1, 1));
+      assertThrows(IllegalArgumentException.class, () -> storage.getRange(reference, 1, -1));
+    } finally {
+      storage.close();
+    }
+  }
+
+  @Test
+  void multipartFileUploadCompletesAllParts() throws Exception {
+    OSSClient client = mock(OSSClient.class);
+    InitiateMultipartUploadResult initiated = mock(InitiateMultipartUploadResult.class);
+    InitiateMultipartUpload details = InitiateMultipartUpload.newBuilder()
+        .bucket("bucket")
+        .key("key")
+        .uploadId("upload-1")
+        .build();
+    when(initiated.initiateMultipartUpload()).thenReturn(details);
+    when(client.initiateMultipartUpload(any(InitiateMultipartUploadRequest.class))).thenReturn(initiated);
+    when(client.uploadPart(any(UploadPartRequest.class))).thenAnswer(invocation -> {
+      UploadPartRequest request = invocation.getArgument(0);
+      UploadPartResult result = mock(UploadPartResult.class);
+      when(result.eTag()).thenReturn("etag-" + request.partNumber());
+      return result;
+    });
+    Path file = tempDir.resolve("large-oss.bin");
+    Files.write(file, new byte[6 * 1024 * 1024]);
+    OssNativeBlobStorage storage = new OssNativeBlobStorage(client, config(1));
+    try {
+      BlobReference reference = storage.putFile("raw", "large.bin", file, "f".repeat(64));
+
+      assertEquals(Files.size(file), reference.size());
+      ArgumentCaptor<CompleteMultipartUploadRequest> completed =
+          ArgumentCaptor.forClass(CompleteMultipartUploadRequest.class);
+      verify(client).completeMultipartUpload(completed.capture());
+      assertEquals(
+          List.of(1L, 2L),
+          completed.getValue().completeMultipartUpload().parts().stream()
+              .map(part -> part.partNumber()).toList());
+      verify(client, never()).abortMultipartUpload(any(AbortMultipartUploadRequest.class));
+    } finally {
+      storage.close();
+    }
+  }
+
+  private static S3BlobStoreConfig config(long multipartThreshold) {
+    return S3BlobStoreConfig.of(
+        1,
+        "oss-test",
+        "https://oss-cn-hangzhou.aliyuncs.com",
+        "cn-hangzhou",
+        "bucket",
+        "prefix",
+        Map.of(
+            "engine", S3BlobStoreConfig.ENGINE_OSS_NATIVE,
+            "multipartThresholdBytes", multipartThreshold,
+            "multipartPartSizeBytes", 5L * 1024 * 1024,
+            "multipartConcurrency", 2));
+  }
+}

--- a/storage-s3/src/test/java/com/github/klboke/kkrepo/storage/s3/S3BlobStorageTest.java
+++ b/storage-s3/src/test/java/com/github/klboke/kkrepo/storage/s3/S3BlobStorageTest.java
@@ -1,0 +1,241 @@
+package com.github.klboke.kkrepo.storage.s3;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.core.BlobObjectMetadata;
+import com.github.klboke.kkrepo.core.BlobRangeReader;
+import com.github.klboke.kkrepo.core.BlobReference;
+import java.io.ByteArrayInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
+
+class S3BlobStorageTest {
+  @TempDir
+  Path tempDir;
+
+  @Test
+  void putUploadsReplayableAndOneShotStreamsWithSanitizedMetadata() throws Exception {
+    S3Client client = mock(S3Client.class);
+    List<byte[]> uploaded = new ArrayList<>();
+    when(client.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenAnswer(invocation -> {
+      RequestBody body = invocation.getArgument(1);
+      try (InputStream in = body.contentStreamProvider().newStream()) {
+        uploaded.add(in.readAllBytes());
+      }
+      return PutObjectResponse.builder().build();
+    });
+    S3BlobStorage storage = new S3BlobStorage(client, config(64 * 1024 * 1024L));
+    try {
+      byte[] first = "first".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+      byte[] second = "second".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+      BlobReference firstRef = storage.put(
+          "maven\nhosted", "com/acme/a.jar", new ByteArrayInputStream(first), first.length, "a".repeat(64));
+      BlobReference secondRef = storage.put(
+          "raw", "files/data.bin", oneShot(second), second.length, "b".repeat(64));
+
+      assertEquals(List.of(first.length, second.length), uploaded.stream().map(bytes -> bytes.length).toList());
+      assertArrayEquals(first, uploaded.get(0));
+      assertArrayEquals(second, uploaded.get(1));
+      assertTrue(firstRef.objectKey().contains("a".repeat(64)));
+      assertTrue(secondRef.objectKey().contains("b".repeat(64)));
+
+      ArgumentCaptor<PutObjectRequest> requests = ArgumentCaptor.forClass(PutObjectRequest.class);
+      verify(client, atLeastOnce()).putObject(requests.capture(), any(RequestBody.class));
+      assertEquals("maven_hosted", requests.getAllValues().get(0).metadata().get("repository"));
+      assertEquals("com/acme/a.jar", requests.getAllValues().get(0).metadata().get("logical-path"));
+    } finally {
+      storage.close();
+    }
+  }
+
+  @Test
+  void getRangeStatAndDeletePreserveBlobSemantics() throws Exception {
+    S3Client client = mock(S3Client.class);
+    AtomicReference<GetObjectRequest> lastGet = new AtomicReference<>();
+    when(client.getObject(any(GetObjectRequest.class))).thenAnswer(invocation -> {
+      GetObjectRequest request = invocation.getArgument(0);
+      lastGet.set(request);
+      byte[] bytes = request.range() == null
+          ? "0123456789".getBytes(java.nio.charset.StandardCharsets.US_ASCII)
+          : "3456".getBytes(java.nio.charset.StandardCharsets.US_ASCII);
+      return new ResponseInputStream<>(
+          GetObjectResponse.builder().contentLength((long) bytes.length).build(),
+          new ByteArrayInputStream(bytes));
+    });
+    Instant modified = Instant.parse("2026-01-02T03:04:05Z");
+    when(client.headObject(any(HeadObjectRequest.class))).thenReturn(HeadObjectResponse.builder()
+        .contentLength(10L)
+        .eTag("\"etag\"")
+        .contentType("application/octet-stream")
+        .lastModified(modified)
+        .metadata(Map.of("sha256", "f".repeat(64)))
+        .build());
+    S3BlobStorage storage = new S3BlobStorage(client, config(64 * 1024 * 1024L));
+    BlobReference reference = new BlobReference("bucket", "prefix/object", "old", 1);
+    try {
+      try (InputStream full = storage.get(reference).orElseThrow()) {
+        assertEquals("0123456789", new String(full.readAllBytes(), java.nio.charset.StandardCharsets.US_ASCII));
+        BlobRangeReader rangeReader = assertInstanceOf(BlobRangeReader.class, full);
+        try (InputStream range = rangeReader.openRange(3, 4)) {
+          assertEquals("3456", new String(range.readAllBytes(), java.nio.charset.StandardCharsets.US_ASCII));
+        }
+      }
+      assertEquals("bytes=3-6", lastGet.get().range());
+
+      BlobObjectMetadata metadata = storage.stat(reference).orElseThrow();
+      assertEquals(10, metadata.reference().size());
+      assertEquals("f".repeat(64), metadata.reference().sha256());
+      assertEquals("\"etag\"", metadata.eTag());
+      assertEquals(modified, metadata.lastModified());
+      assertTrue(storage.exists(reference));
+
+      storage.delete(reference);
+      ArgumentCaptor<DeleteObjectRequest> deleted = ArgumentCaptor.forClass(DeleteObjectRequest.class);
+      verify(client).deleteObject(deleted.capture());
+      assertEquals("prefix/object", deleted.getValue().key());
+    } finally {
+      storage.close();
+    }
+  }
+
+  @Test
+  void missingObjectsAndInvalidRangesAreHandledWithoutMaskingOtherErrors() {
+    S3Client client = mock(S3Client.class);
+    when(client.getObject(any(GetObjectRequest.class)))
+        .thenThrow(NoSuchKeyException.builder().message("missing").build());
+    when(client.headObject(any(HeadObjectRequest.class)))
+        .thenThrow(S3Exception.builder().statusCode(404).message("missing").build());
+    S3BlobStorage storage = new S3BlobStorage(client, config(64 * 1024 * 1024L));
+    BlobReference reference = new BlobReference("bucket", "missing", "a", 1);
+    try {
+      assertTrue(storage.get(reference).isEmpty());
+      assertTrue(storage.getRange(reference, 0, 1).isEmpty());
+      assertTrue(storage.stat(reference).isEmpty());
+      assertFalse(storage.exists(reference));
+      assertEquals(0, storage.getRange(reference, 0, 0).orElseThrow().readAllBytes().length);
+      assertThrows(IllegalArgumentException.class, () -> storage.getRange(reference, -1, 1));
+      assertThrows(IllegalArgumentException.class, () -> storage.getRange(reference, 0, -1));
+    } catch (IOException e) {
+      throw new AssertionError(e);
+    } finally {
+      storage.close();
+    }
+  }
+
+  @Test
+  void multipartFileUploadCompletesSortedParts() throws Exception {
+    S3Client client = mock(S3Client.class);
+    when(client.createMultipartUpload(any(CreateMultipartUploadRequest.class)))
+        .thenReturn(CreateMultipartUploadResponse.builder().uploadId("upload-1").build());
+    when(client.uploadPart(any(UploadPartRequest.class), any(RequestBody.class))).thenAnswer(invocation -> {
+      UploadPartRequest request = invocation.getArgument(0);
+      return UploadPartResponse.builder().eTag("etag-" + request.partNumber()).build();
+    });
+    when(client.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+        .thenReturn(CompleteMultipartUploadResponse.builder().build());
+    Path file = tempDir.resolve("large.bin");
+    Files.write(file, new byte[6 * 1024 * 1024]);
+    S3BlobStorage storage = new S3BlobStorage(client, config(1));
+    try {
+      BlobReference reference = storage.putFile("maven", "large.bin", file, "c".repeat(64));
+
+      assertEquals(Files.size(file), reference.size());
+      ArgumentCaptor<CompleteMultipartUploadRequest> completed =
+          ArgumentCaptor.forClass(CompleteMultipartUploadRequest.class);
+      verify(client).completeMultipartUpload(completed.capture());
+      assertEquals(
+          List.of(1, 2),
+          completed.getValue().multipartUpload().parts().stream().map(part -> part.partNumber()).toList());
+      verify(client, never()).abortMultipartUpload(any(AbortMultipartUploadRequest.class));
+    } finally {
+      storage.close();
+    }
+  }
+
+  @Test
+  void multipartFailureAbortsUploadAndSurfacesOriginalError() throws Exception {
+    S3Client client = mock(S3Client.class);
+    when(client.createMultipartUpload(any(CreateMultipartUploadRequest.class)))
+        .thenReturn(CreateMultipartUploadResponse.builder().uploadId("upload-2").build());
+    S3Exception.Builder failureBuilder = S3Exception.builder();
+    failureBuilder.statusCode(500);
+    failureBuilder.message("upload failed");
+    S3Exception failure = (S3Exception) failureBuilder.build();
+    when(client.uploadPart(any(UploadPartRequest.class), any(RequestBody.class))).thenThrow(failure);
+    Path file = tempDir.resolve("large-failure.bin");
+    Files.write(file, new byte[6 * 1024 * 1024]);
+    S3BlobStorage storage = new S3BlobStorage(client, config(1));
+    try {
+      assertEquals(failure, assertThrows(
+          S3Exception.class,
+          () -> storage.putFile("maven", "large.bin", file, "d".repeat(64))));
+      verify(client).abortMultipartUpload(any(AbortMultipartUploadRequest.class));
+    } finally {
+      storage.close();
+    }
+  }
+
+  private static S3BlobStoreConfig config(long multipartThreshold) {
+    return S3BlobStoreConfig.of(
+        1,
+        "test",
+        "http://localhost:9000",
+        "us-east-1",
+        "bucket",
+        "prefix",
+        Map.of(
+            "multipartThresholdBytes", multipartThreshold,
+            "multipartPartSizeBytes", 5L * 1024 * 1024,
+            "multipartConcurrency", 2));
+  }
+
+  private static InputStream oneShot(byte[] bytes) {
+    return new FilterInputStream(new ByteArrayInputStream(bytes)) {
+      @Override
+      public boolean markSupported() {
+        return false;
+      }
+    };
+  }
+}

--- a/storage-s3/src/test/java/com/github/klboke/kkrepo/storage/s3/S3BlobStoreConfigTest.java
+++ b/storage-s3/src/test/java/com/github/klboke/kkrepo/storage/s3/S3BlobStoreConfigTest.java
@@ -1,0 +1,73 @@
+package com.github.klboke.kkrepo.storage.s3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class S3BlobStoreConfigTest {
+  @Test
+  void attributesAreParsedNormalizedAndClamped() {
+    S3BlobStoreConfig config = S3BlobStoreConfig.of(
+        7,
+        "store",
+        "https://example.test",
+        "us-east-1",
+        "bucket",
+        null,
+        Map.of(
+            "engine", "oss",
+            "pathStyleAccess", "false",
+            "maxConnections", "0",
+            "connectionTimeoutMs", "bad",
+            "socketTimeoutMs", 0,
+            "connectionAcquisitionTimeoutMs", -1,
+            "tcpKeepAlive", false,
+            "multipartThresholdBytes", -10,
+            "multipartPartSizeBytes", 1,
+            "multipartConcurrency", 0));
+
+    assertEquals(S3BlobStoreConfig.ENGINE_OSS_NATIVE, config.engine());
+    assertTrue(config.usesOssNative());
+    assertFalse(config.pathStyleAccess());
+    assertEquals(1, config.maxConnections());
+    assertEquals(5000, config.connectionTimeoutMs());
+    assertEquals(1, config.socketTimeoutMs());
+    assertEquals(1, config.connectionAcquisitionTimeoutMs());
+    assertEquals(0, config.multipartThresholdBytes());
+    assertEquals(5L * 1024 * 1024, config.multipartPartSizeBytes());
+    assertEquals(1, config.multipartConcurrency());
+    assertTrue(config.signature().contains("oss-native|https://example.test"));
+  }
+
+  @Test
+  void equalityIncludesCredentialsAndOperationalSettings() {
+    S3BlobStoreConfig first = config("secret-one", 4);
+    S3BlobStoreConfig same = config("secret-one", 4);
+    S3BlobStoreConfig changedSecret = config("secret-two", 4);
+    S3BlobStoreConfig changedConcurrency = config("secret-one", 8);
+
+    assertEquals(first, same);
+    assertEquals(first.hashCode(), same.hashCode());
+    assertNotEquals(first, changedSecret);
+    assertNotEquals(first, changedConcurrency);
+    assertNotEquals(first.signature(), changedSecret.signature());
+  }
+
+  private static S3BlobStoreConfig config(String secret, int concurrency) {
+    return S3BlobStoreConfig.of(
+        1,
+        "store",
+        "https://s3.example.test",
+        "us-east-1",
+        "bucket",
+        "prefix",
+        Map.of(
+            "accessKey", "access",
+            "secretKey", secret,
+            "multipartConcurrency", concurrency));
+  }
+}


### PR DESCRIPTION
## Summary

- add MySQL 8 integration tests for asset, security, Docker registry, and repository migration DAOs
- cover S3 and native OSS upload, multipart, range, stat, delete, and error paths
- cover Helm and Go server runtime parsing, cache, proxy fallback, persistence, concurrency, and cleanup paths
- cover Raw writer upload, replacement, blob reuse, concurrent insert, response-file, and failure cleanup paths
- cover npm hosted/proxy publish, revision, attachment, dist-tag, packument, tarball, search, cache, and upstream behavior
- cover PyPI hosted/proxy metadata extraction, digest validation, simple-index rewriting, package resolution, cache, and upstream behavior
- cover browse content deletion authorization, group-member validation, Maven checksum cleanup, npm/PyPI invalidation, and index rebuilds
- cover repository migration discovery filtering, cursor persistence, concurrency bounds, download success/failure, and derived-asset skipping
- cover blob GC, Maven metadata rebuild, and repository index rebuild worker claim, retry, dispatch, and stale-work behavior
- cover security rate limiting and management audit success, failure, trusted-proxy, and persistence-failure paths
- cover Maven hosted write policies, metadata marker queueing, explicit metadata precedence, and generated GA/GAV metadata
- fix Docker manifest deletion when the linked asset has no blob

## Verification

- `mvn -B -ntp -pl server -am -Dsurefire.failIfNoSpecifiedTests=false clean verify`
- all 22 reactor modules passed
- 941 server tests passed
- MySQL integration tests applied all 29 Flyway migrations
- GitHub Actions CI and CodeQL passed
- Codecov project and patch checks passed
- Go/Helm/Raw live compatibility was attempted earlier on this branch, but the configured local Nexus admin endpoint returned 401 during repository setup before protocol comparisons ran

## Coverage

- Codecov project coverage: 46.66% -> 56.70% (+10.04 percentage points)
- all modified and coverable lines are covered
- server JaCoCo line coverage: 69.56%; branch coverage: 50.96%
- latest worker, security, Maven, and npm target classes: 768/942 lines (81.53%)
- BlobGarbageCollectionWorker: 70/75 lines (93.33%)
- MetadataRebuildWorker: 63/66 lines (95.45%)
- RepositoryIndexRebuildWorker: 65/68 lines (95.59%)
- SecurityRateLimitFilter: 47/48 lines (97.92%)
- ManagementAuditFilter: 54/54 lines (100%)
- MavenMetadataService: 80/84 lines (95.24%)
- MavenHostedService: 78/105 lines (74.29%)
- NpmSearchService: 111/112 lines (99.11%)
- NpmHostedService: 200/330 lines (60.61%)
- Go runtime: 314/341 lines (92.08%)
- Helm runtime: 463/610 lines (75.90%)
- RawAssetWriter: 178/190 lines (93.68%)
- NpmProxyService: 175/238 lines (73.53%)
- PypiProxyService: 186/249 lines (74.70%)
- BrowseContentDeleteController: 157/207 lines (75.85%)
- RepositoryDataMigrationWorker: 194/327 lines (59.33%)
