### PR TITLE
build: centralize Maven project version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+.flattened-pom.xml
 .idea/
 .vscode/
 *.iml

--- a/admin-ui/pom.xml
+++ b/admin-ui/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.klboke</groupId>
     <artifactId>kkrepo</artifactId>
-    <version>0.3.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>kkrepo-admin-ui</artifactId>

--- a/browse-ui/pom.xml
+++ b/browse-ui/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.klboke</groupId>
     <artifactId>kkrepo</artifactId>
-    <version>0.3.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>kkrepo-browse-ui</artifactId>

--- a/cache/pom.xml
+++ b/cache/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.klboke</groupId>
     <artifactId>kkrepo</artifactId>
-    <version>0.3.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>kkrepo-cache</artifactId>

--- a/compat-test/pom.xml
+++ b/compat-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.klboke</groupId>
     <artifactId>kkrepo</artifactId>
-    <version>0.3.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>kkrepo-compat-test</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.klboke</groupId>
     <artifactId>kkrepo</artifactId>
-    <version>0.3.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>kkrepo-core</artifactId>

--- a/migration-nexus/pom.xml
+++ b/migration-nexus/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.klboke</groupId>
     <artifactId>kkrepo</artifactId>
-    <version>0.3.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>kkrepo-migration-nexus</artifactId>

--- a/persistence-jdbc/pom.xml
+++ b/persistence-jdbc/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.klboke</groupId>
     <artifactId>kkrepo</artifactId>
-    <version>0.3.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>kkrepo-persistence-jdbc</artifactId>

--- a/persistence-mysql/pom.xml
+++ b/persistence-mysql/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.klboke</groupId>
     <artifactId>kkrepo</artifactId>
-    <version>0.3.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>kkrepo-persistence-mysql</artifactId>

--- a/persistence-postgresql/pom.xml
+++ b/persistence-postgresql/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.klboke</groupId>
     <artifactId>kkrepo</artifactId>
-    <version>0.3.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>kkrepo-persistence-postgresql</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.github.klboke</groupId>
   <artifactId>kkrepo</artifactId>
-  <version>0.3.0</version>
+  <version>${revision}</version>
   <packaging>pom</packaging>
 
   <name>kkRepo</name>
@@ -40,6 +40,7 @@
   </modules>
 
   <properties>
+    <revision>0.3.0</revision>
     <java.version>25</java.version>
     <spring.boot.version>4.1.0</spring.boot.version>
     <apollo.client.version>2.5.0</apollo.client.version>
@@ -51,6 +52,7 @@
     <commons.compress.version>1.28.0</commons.compress.version>
     <commons.lang3.version>3.20.0</commons.lang3.version>
     <jacoco.version>0.8.15</jacoco.version>
+    <flatten.maven.plugin.version>1.7.3</flatten.maven.plugin.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <kkrepo.dist.version>${project.version}</kkrepo.dist.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -262,6 +264,31 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>${flatten.maven.plugin.version}</version>
+        <configuration>
+          <flattenMode>resolveCiFriendliesOnly</flattenMode>
+          <updatePomFile>true</updatePomFile>
+        </configuration>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>flatten-clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>

--- a/protocol-cargo/pom.xml
+++ b/protocol-cargo/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.klboke</groupId>
     <artifactId>kkrepo</artifactId>
-    <version>0.3.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>kkrepo-protocol-cargo</artifactId>

--- a/protocol-composer/pom.xml
+++ b/protocol-composer/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.klboke</groupId>
     <artifactId>kkrepo</artifactId>
-    <version>0.3.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>kkrepo-protocol-composer</artifactId>

--- a/protocol-docker/pom.xml
+++ b/protocol-docker/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.klboke</groupId>
     <artifactId>kkrepo</artifactId>
-    <version>0.3.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>kkrepo-protocol-docker</artifactId>

--- a/protocol-go/pom.xml
+++ b/protocol-go/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.klboke</groupId>
     <artifactId>kkrepo</artifactId>
-    <version>0.3.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>kkrepo-protocol-go</artifactId>

--- a/protocol-helm/pom.xml
+++ b/protocol-helm/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.klboke</groupId>
     <artifactId>kkrepo</artifactId>
-    <version>0.3.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>kkrepo-protocol-helm</artifactId>

--- a/protocol-maven/pom.xml
+++ b/protocol-maven/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.klboke</groupId>
     <artifactId>kkrepo</artifactId>
-    <version>0.3.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>kkrepo-protocol-maven</artifactId>

--- a/protocol-npm/pom.xml
+++ b/protocol-npm/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.klboke</groupId>
     <artifactId>kkrepo</artifactId>
-    <version>0.3.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>kkrepo-protocol-npm</artifactId>

--- a/protocol-nuget/pom.xml
+++ b/protocol-nuget/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.klboke</groupId>
     <artifactId>kkrepo</artifactId>
-    <version>0.3.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>kkrepo-protocol-nuget</artifactId>

--- a/protocol-pub/pom.xml
+++ b/protocol-pub/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.klboke</groupId>
     <artifactId>kkrepo</artifactId>
-    <version>0.3.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>kkrepo-protocol-pub</artifactId>

--- a/protocol-pypi/pom.xml
+++ b/protocol-pypi/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.klboke</groupId>
     <artifactId>kkrepo</artifactId>
-    <version>0.3.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>kkrepo-protocol-pypi</artifactId>

--- a/protocol-rubygems/pom.xml
+++ b/protocol-rubygems/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.klboke</groupId>
     <artifactId>kkrepo</artifactId>
-    <version>0.3.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>kkrepo-protocol-rubygems</artifactId>

--- a/protocol-yum/pom.xml
+++ b/protocol-yum/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.klboke</groupId>
     <artifactId>kkrepo</artifactId>
-    <version>0.3.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>kkrepo-protocol-yum</artifactId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.klboke</groupId>
     <artifactId>kkrepo</artifactId>
-    <version>0.3.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>kkrepo-server</artifactId>

--- a/storage-file/pom.xml
+++ b/storage-file/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.klboke</groupId>
     <artifactId>kkrepo</artifactId>
-    <version>0.3.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>kkrepo-storage-file</artifactId>

--- a/storage-s3/pom.xml
+++ b/storage-s3/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.klboke</groupId>
     <artifactId>kkrepo</artifactId>
-    <version>0.3.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>kkrepo-storage-s3</artifactId>


### PR DESCRIPTION
## Summary

- define the reactor version once as `<revision>0.3.0</revision>` in the root POM
- use Maven's CI-friendly `${revision}` placeholder for the root project and all 24 child parent declarations
- add `flatten-maven-plugin` with `resolveCiFriendliesOnly` so installed and deployed POMs contain concrete versions
- ignore generated `.flattened-pom.xml` files

## Why

Releases previously required updating the root POM and every child module POM. After this change, the Maven project version is updated in one place while all reactor modules remain aligned. The root project still has a Maven version through `<version>${revision}</version>`; the default resolves to `0.3.0`, and release builds can override it with `-Drevision=<version>`.

## Impact

Future releases only need to change the root `<revision>` value, or pass `-Drevision` from CI. Existing `${project.version}` references for internal reactor dependencies remain unchanged.

## Verification

- `mvn -q -N -DforceStdout help:evaluate -Dexpression=project.version`
- `mvn -q -N -Drevision=0.4.0 -DforceStdout help:evaluate -Dexpression=project.version`
- `mvn -pl server -am -DskipTests package spring-boot:repackage`
- `mvn -pl server -am -DskipTests install`
- verified installed root and server POMs contain `0.3.0` and no `${revision}` token
- `mvn -pl server -am test` (all reactor modules passed; server module ran 951 tests with zero failures)
- `git diff --check`