### PR TITLE
docs: add Swift Package Registry to repository roadmap

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -171,10 +171,11 @@ AI agent 和贡献者的开发说明见 [AGENTS.md](AGENTS.md)。
 3. Dart / Pub - 仓库能力已完成，包含 hosted/proxy/group、真实客户端 E2E、UI/API 上传、搜索和 Nexus 迁移能力（[设计说明](docs/zh/dev/dart-pub-repository-design.md)）
 4. Composer / PHP - hosted、proxy、group、UI/API 上传、搜索、真实客户端 E2E、强制 Nexus live 对比和显式选择的 Nexus proxy cache 迁移 E2E 已实现（[设计说明](docs/zh/dev/composer-php-repository-design.md)）
 5. ohpm / HarmonyOS - 规划中，覆盖 hosted、proxy、group、导入和管理端能力（[设计说明](docs/zh/dev/ohpm-repository-design.md)）
-6. APT / Debian
-7. Terraform Provider / Module Registry
-8. Conan
-9. Conda
+6. Swift Package Registry
+7. APT / Debian
+8. Terraform Provider / Module Registry
+9. Conan
+10. Conda
 
 用户和管理端 UI 已暴露的 token 类型包括协议专用 token（`NpmToken`、`CargoToken`、`PubToken`、`NuGetApiKey`、`RubyGemsApiKey`），以及面向 CI、脚本和自定义 HTTP 客户端的 `GenericToken`；`GenericToken` 适用于能够发送已配置 API-key header 或 bearer token 的调用方。
 

--- a/README.md
+++ b/README.md
@@ -171,10 +171,11 @@ Repository format roadmap:
 3. Dart / Pub - Repository support completed, including hosted/proxy/group, client E2E, UI/API upload, search, and Nexus migration ([Chinese design notes](docs/zh/dev/dart-pub-repository-design.md))
 4. Composer / PHP - Hosted, proxy, group, UI/API upload, search, real-client E2E, required Nexus live comparison, and explicitly selected Nexus proxy-cache migration E2E implemented ([Chinese design notes](docs/zh/dev/composer-php-repository-design.md))
 5. ohpm / HarmonyOS - Planned with hosted, proxy, group, import, and admin capabilities ([Chinese design notes](docs/zh/dev/ohpm-repository-design.md))
-6. APT / Debian
-7. Terraform Provider / Module Registry
-8. Conan
-9. Conda
+6. Swift Package Registry
+7. APT / Debian
+8. Terraform Provider / Module Registry
+9. Conan
+10. Conda
 
 Token types exposed in the user and admin UI include protocol-specific tokens (`NpmToken`, `CargoToken`, `PubToken`, `NuGetApiKey`, `RubyGemsApiKey`) plus `GenericToken` for CI, scripts, and custom HTTP clients that can send the configured API-key header or bearer token.
 


### PR DESCRIPTION
## Summary

- Add Swift Package Registry to the repository format roadmap.
- Keep the English and Chinese README roadmaps aligned.

## Validation

- [ ] `mvn -pl server -am test` (not applicable; documentation-only change)
- [ ] `mvn -pl compat-test -am -Dtest=MavenMetadataMergeCompatibilityTest,MavenWritePolicyCompatibilityTest,NpmProtocolCompatibilityTest -Dsurefire.failIfNoSpecifiedTests=false test` (not applicable; documentation-only change)
- [x] Live compatibility workflow is not applicable because this PR does not change protocol or admin API behavior.
- [x] Real client E2E is not applicable because this PR does not change package-client behavior.
- [x] Other: `git diff --check`

## Compatibility and design checklist

- [x] This PR does not change protocol behavior.
- [x] Compatibility tests are not required for this documentation-only change.
- [x] This PR does not touch state, cache, locking, session, background tasks, upload/delete, metadata, or permissions.
- [x] This PR does not touch migration behavior.

## Notes for reviewers

- The roadmap uses the official protocol name, Swift Package Registry.
