### PR TITLE
fix: recover PostgreSQL asset insert conflicts within transactions

### DIFF
--- a/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/api/AssetDao.java
+++ b/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/api/AssetDao.java
@@ -24,6 +24,10 @@ public interface AssetDao {
 
   long insertAsset(AssetRecord record);
 
+  /**
+   * Attempts to insert an asset, returning empty when its natural path key already exists. The
+   * current transaction remains usable for callers to load and reuse the winning row.
+   */
   OptionalLong tryInsertAsset(AssetRecord record);
 
   Optional<AssetRecord> findAssetByPathHash(long repositoryId, byte[] pathHash);

--- a/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/JdbcAssetDao.java
+++ b/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/JdbcAssetDao.java
@@ -211,16 +211,12 @@ public class JdbcAssetDao implements com.github.klboke.kkrepo.persistence.jdbc.a
   }
 
   public OptionalLong tryInsertAsset(AssetRecord record) {
-    try {
-      return OptionalLong.of(JdbcInserts.insert(jdbcTemplate, """
-          INSERT INTO asset
-            (repository_id, component_id, asset_blob_id, format, path, path_hash,
-             name, kind, content_type, size, last_downloaded_at, last_updated_at, attributes_json)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-          """, ps -> setAssetInsertParameters(ps, record)));
-    } catch (DuplicateKeyException e) {
-      return OptionalLong.empty();
-    }
+    return JdbcInserts.tryInsert(jdbcTemplate, """
+        INSERT INTO asset
+          (repository_id, component_id, asset_blob_id, format, path, path_hash,
+           name, kind, content_type, size, last_downloaded_at, last_updated_at, attributes_json)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """, ps -> setAssetInsertParameters(ps, record));
   }
 
   public Optional<AssetRecord> findAssetByPathHash(long repositoryId, byte[] pathHash) {

--- a/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/support/JdbcDuplicateRecovery.java
+++ b/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/support/JdbcDuplicateRecovery.java
@@ -1,0 +1,20 @@
+package com.github.klboke.kkrepo.persistence.jdbc.internal.support;
+
+import java.sql.Connection;
+import java.sql.Savepoint;
+import java.sql.SQLException;
+
+/** Database-specific savepoint policy for duplicate-key recovery inside an open transaction. */
+final class JdbcDuplicateRecovery {
+  private JdbcDuplicateRecovery() {
+  }
+
+  static Savepoint createSavepointIfRequired(Connection connection) throws SQLException {
+    // PostgreSQL aborts the transaction after a constraint violation. MySQL keeps the transaction
+    // usable and can invalidate a JDBC savepoint while the portable update/insert path is running.
+    return !connection.getAutoCommit()
+        && "PostgreSQL".equalsIgnoreCase(connection.getMetaData().getDatabaseProductName())
+        ? connection.setSavepoint()
+        : null;
+  }
+}

--- a/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/support/JdbcInserts.java
+++ b/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/support/JdbcInserts.java
@@ -1,5 +1,14 @@
 package com.github.klboke.kkrepo.persistence.jdbc.internal.support;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Savepoint;
+import java.sql.SQLException;
+import java.util.OptionalLong;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.core.ConnectionCallback;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.PreparedStatementSetter;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
@@ -23,5 +32,51 @@ public final class JdbcInserts {
       throw new IllegalStateException("Insert did not return a generated key");
     }
     return key.longValue();
+  }
+
+  /**
+   * Attempts an insert that returns an identity key. A duplicate key is represented as an empty
+   * result while leaving an existing PostgreSQL transaction usable for a follow-up lookup.
+   */
+  public static OptionalLong tryInsert(
+      JdbcTemplate jdbcTemplate, String sql, PreparedStatementSetter setter) {
+    return jdbcTemplate.execute((ConnectionCallback<OptionalLong>) connection -> {
+      Savepoint savepoint = JdbcDuplicateRecovery.createSavepointIfRequired(connection);
+      try {
+        return OptionalLong.of(insert(connection, sql, setter));
+      } catch (SQLException insertFailure) {
+        if (savepoint != null) {
+          connection.rollback(savepoint);
+        }
+        DataAccessException translated = jdbcTemplate.getExceptionTranslator()
+            .translate("try insert", sql, insertFailure);
+        if (translated instanceof DuplicateKeyException) {
+          return OptionalLong.empty();
+        }
+        throw insertFailure;
+      } finally {
+        if (savepoint != null) {
+          connection.releaseSavepoint(savepoint);
+        }
+      }
+    });
+  }
+
+  private static long insert(
+      Connection connection, String sql, PreparedStatementSetter setter) throws SQLException {
+    try (PreparedStatement statement = connection.prepareStatement(sql, new String[]{"id"})) {
+      setter.setValues(statement);
+      statement.executeUpdate();
+      try (ResultSet keys = statement.getGeneratedKeys()) {
+        if (!keys.next()) {
+          throw new IllegalStateException("Insert did not return a generated key");
+        }
+        Number key = (Number) keys.getObject(1);
+        if (key == null) {
+          throw new IllegalStateException("Insert did not return a generated key");
+        }
+        return key.longValue();
+      }
+    }
   }
 }

--- a/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/support/JdbcUpserts.java
+++ b/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/support/JdbcUpserts.java
@@ -25,9 +25,7 @@ public final class JdbcUpserts {
       return;
     }
     jdbc.execute((ConnectionCallback<Void>) connection -> {
-      Savepoint savepoint = requiresDuplicateRecoverySavepoint(connection)
-          ? connection.setSavepoint()
-          : null;
+      Savepoint savepoint = JdbcDuplicateRecovery.createSavepointIfRequired(connection);
       try {
         executeUpdate(connection, insertSql, insertArguments);
       } catch (SQLException insertFailure) {
@@ -47,14 +45,6 @@ public final class JdbcUpserts {
       }
       return null;
     });
-  }
-
-  private static boolean requiresDuplicateRecoverySavepoint(Connection connection)
-      throws SQLException {
-    // PostgreSQL aborts the transaction after a constraint violation. MySQL keeps the transaction
-    // usable and can invalidate a JDBC savepoint while the portable update/insert path is running.
-    return !connection.getAutoCommit()
-        && "PostgreSQL".equalsIgnoreCase(connection.getMetaData().getDatabaseProductName());
   }
 
   private static int executeUpdate(Connection connection, String sql, Object[] arguments)

--- a/persistence-jdbc/src/test/java/com/github/klboke/kkrepo/persistence/jdbc/contract/PersistenceApiContract.java
+++ b/persistence-jdbc/src/test/java/com/github/klboke/kkrepo/persistence/jdbc/contract/PersistenceApiContract.java
@@ -8,11 +8,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.klboke.kkrepo.core.RepositoryFormat;
 import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.jdbc.api.PersistenceHashes;
 import com.github.klboke.kkrepo.persistence.jdbc.api.PersistenceStores;
 import com.github.klboke.kkrepo.persistence.jdbc.api.PubUploadSessionDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.RepositoryDataMigrationDao;
-import com.github.klboke.kkrepo.persistence.jdbc.api.SecurityAuditDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.RepositoryIndexRebuildDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.SecurityAuditDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.AssetBlobRecord;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.AssetRecord;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.BlobStoreRecord;
@@ -37,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
@@ -276,6 +278,31 @@ public abstract class PersistenceApiContract {
     List<Long> assetIds = invokeConcurrently(assetWrites, 5);
     assertEquals(1, new HashSet<>(assetIds).size());
     assertEquals(path, stores().assets().findAssetById(assetIds.getFirst()).orElseThrow().path());
+  }
+
+  @Test
+  void duplicateAssetInsertKeepsProtocolWriterTransactionUsable() throws Exception {
+    long blobStoreId = stores().blobStores().insert(blobStore("asset-conflict-store"));
+    long repositoryId = insertRepository(
+        "asset-conflict", RepositoryFormat.HELM, blobStoreId);
+    long blobId = stores().assets().insertBlob(
+        blob(blobStoreId, "helm/index.yaml", "helm-index-ref"));
+    String path = "index.yaml";
+    AssetRecord asset = new AssetRecord(
+        null, repositoryId, null, blobId, RepositoryFormat.HELM, path,
+        PersistenceHashes.pathHash(path),
+        path, "INDEX", "text/x-yaml", 42L, null,
+        Instant.parse("2026-07-13T10:00:00Z"), Map.of("generated", true));
+    CyclicBarrier transactionsReady = new CyclicBarrier(2);
+
+    List<Callable<AssetInsertResult>> writes = List.of(
+        () -> insertOrFindAssetInWriterTransaction(asset, transactionsReady),
+        () -> insertOrFindAssetInWriterTransaction(asset, transactionsReady));
+    List<AssetInsertResult> results = invokeConcurrently(writes, 2);
+
+    assertEquals(1, results.stream().filter(AssetInsertResult::inserted).count());
+    assertEquals(1, results.stream().map(AssetInsertResult::assetId).distinct().count());
+    assertEquals(path, stores().assets().findAssetByPath(repositoryId, path).orElseThrow().path());
   }
 
   @Test
@@ -658,6 +685,29 @@ public abstract class PersistenceApiContract {
       }
       return results;
     }
+  }
+
+  private AssetInsertResult insertOrFindAssetInWriterTransaction(
+      AssetRecord asset, CyclicBarrier transactionsReady) {
+    return inTransaction(() -> {
+      await(transactionsReady);
+      var inserted = stores().assets().tryInsertAsset(asset);
+      long assetId = inserted.isPresent()
+          ? inserted.getAsLong()
+          : stores().assets().findAssetByPath(asset.repositoryId(), asset.path()).orElseThrow().id();
+      return new AssetInsertResult(assetId, inserted.isPresent());
+    });
+  }
+
+  private static void await(CyclicBarrier barrier) {
+    try {
+      barrier.await();
+    } catch (Exception e) {
+      throw new AssertionError("Failed to coordinate duplicate asset insert race", e);
+    }
+  }
+
+  private record AssetInsertResult(long assetId, boolean inserted) {
   }
 
   private static ComponentRecord component(

--- a/persistence-jdbc/src/test/java/com/github/klboke/kkrepo/persistence/jdbc/internal/support/JdbcInsertsTest.java
+++ b/persistence-jdbc/src/test/java/com/github/klboke/kkrepo/persistence/jdbc/internal/support/JdbcInsertsTest.java
@@ -1,0 +1,139 @@
+package com.github.klboke.kkrepo.persistence.jdbc.internal.support;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.BadSqlGrammarException;
+import org.springframework.jdbc.UncategorizedSQLException;
+import org.springframework.jdbc.core.ConnectionCallback;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.SQLStateSQLExceptionTranslator;
+import org.springframework.jdbc.support.SQLExceptionTranslator;
+
+class JdbcInsertsTest {
+  private static final String SQL = "INSERT INTO sample (name) VALUES (?)";
+
+  @Test
+  void nonDuplicateSqlFailureIsNotTreatedAsAConflict() {
+    SQLException failure = new SQLException("invalid insert", "42000");
+    JdbcTemplate jdbc = new DirectConnectionJdbcTemplate(connectionThatThrows(failure));
+
+    assertThrows(BadSqlGrammarException.class,
+        () -> JdbcInserts.tryInsert(jdbc, SQL, statement -> {
+        }));
+  }
+
+  @Test
+  void missingGeneratedKeyFailsClearly() {
+    JdbcTemplate jdbc = new DirectConnectionJdbcTemplate(connectionWithGeneratedKey(false, null));
+
+    IllegalStateException failure = assertThrows(IllegalStateException.class,
+        () -> JdbcInserts.tryInsert(jdbc, SQL, statement -> {
+        }));
+
+    assertEquals("Insert did not return a generated key", failure.getMessage());
+  }
+
+  @Test
+  void nullGeneratedKeyFailsClearly() {
+    JdbcTemplate jdbc = new DirectConnectionJdbcTemplate(connectionWithGeneratedKey(true, null));
+
+    IllegalStateException failure = assertThrows(IllegalStateException.class,
+        () -> JdbcInserts.tryInsert(jdbc, SQL, statement -> {
+        }));
+
+    assertEquals("Insert did not return a generated key", failure.getMessage());
+  }
+
+  private static Connection connectionThatThrows(SQLException failure) {
+    return proxy(Connection.class, (ignored, method, arguments) -> switch (method.getName()) {
+      case "getAutoCommit" -> true;
+      case "prepareStatement" -> throw failure;
+      default -> defaultValue(method.getReturnType());
+    });
+  }
+
+  private static Connection connectionWithGeneratedKey(boolean present, Object key) {
+    ResultSet keys = proxy(ResultSet.class, (ignored, method, arguments) -> switch (method.getName()) {
+      case "next" -> present;
+      case "getObject" -> key;
+      default -> defaultValue(method.getReturnType());
+    });
+    PreparedStatement statement = proxy(
+        PreparedStatement.class,
+        (ignored, method, arguments) -> switch (method.getName()) {
+          case "executeUpdate" -> 1;
+          case "getGeneratedKeys" -> keys;
+          default -> defaultValue(method.getReturnType());
+        });
+    return proxy(Connection.class, (ignored, method, arguments) -> switch (method.getName()) {
+      case "getAutoCommit" -> true;
+      case "prepareStatement" -> statement;
+      default -> defaultValue(method.getReturnType());
+    });
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T proxy(Class<T> type, InvocationHandler handler) {
+    return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[]{type}, handler);
+  }
+
+  private static Object defaultValue(Class<?> type) {
+    if (!type.isPrimitive() || type == void.class) {
+      return null;
+    }
+    if (type == boolean.class) {
+      return false;
+    }
+    if (type == char.class) {
+      return '\0';
+    }
+    if (type == byte.class) {
+      return (byte) 0;
+    }
+    if (type == short.class) {
+      return (short) 0;
+    }
+    if (type == int.class) {
+      return 0;
+    }
+    if (type == long.class) {
+      return 0L;
+    }
+    if (type == float.class) {
+      return 0F;
+    }
+    return 0D;
+  }
+
+  private static final class DirectConnectionJdbcTemplate extends JdbcTemplate {
+    private final Connection connection;
+
+    private DirectConnectionJdbcTemplate(Connection connection) {
+      this.connection = connection;
+      setExceptionTranslator(new SQLStateSQLExceptionTranslator());
+    }
+
+    @Override
+    public <T> T execute(ConnectionCallback<T> action) throws DataAccessException {
+      try {
+        return action.doInConnection(connection);
+      } catch (SQLException failure) {
+        SQLExceptionTranslator translator = getExceptionTranslator();
+        DataAccessException translated = translator.translate("execute", SQL, failure);
+        if (translated != null) {
+          throw translated;
+        }
+        throw new UncategorizedSQLException("execute", SQL, failure);
+      }
+    }
+  }
+}

--- a/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/MySqlJdbcUpsertsTransactionTest.java
+++ b/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/MySqlJdbcUpsertsTransactionTest.java
@@ -1,7 +1,9 @@
 package com.github.klboke.kkrepo.persistence.mysql;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.github.klboke.kkrepo.persistence.jdbc.internal.support.JdbcInserts;
 import com.github.klboke.kkrepo.persistence.jdbc.internal.support.JdbcUpserts;
 import com.github.klboke.kkrepo.persistence.mysql.support.MySqlIntegrationTestSupport;
 import java.lang.reflect.InvocationTargetException;
@@ -30,6 +32,26 @@ class MySqlJdbcUpsertsTransactionTest extends MySqlIntegrationTestSupport {
         "SELECT default_language FROM ui_settings WHERE id = 1", String.class));
   }
 
+  @Test
+  void duplicateInsertInsideOuterTransactionDoesNotUsePostgreSqlSavepoint() {
+    JdbcTemplate noSavepointJdbc = new SavepointRejectingJdbcTemplate(jdbc().getDataSource());
+
+    inTransaction(() -> {
+      assertTrue(JdbcInserts.tryInsert(
+          noSavepointJdbc,
+          "INSERT INTO blob_store (name, type, attributes_json) "
+              + "VALUES (?, 'S3', JSON_OBJECT())",
+          statement -> statement.setString(1, "shared-store")).isPresent());
+      assertTrue(JdbcInserts.tryInsert(
+          noSavepointJdbc,
+          "INSERT INTO blob_store (name, type, attributes_json) "
+              + "VALUES (?, 'S3', JSON_OBJECT())",
+          statement -> statement.setString(1, "shared-store")).isEmpty());
+      assertEquals("S3", noSavepointJdbc.queryForObject(
+          "SELECT type FROM blob_store WHERE name = 'shared-store'", String.class));
+    });
+  }
+
   private static final class SavepointRejectingJdbcTemplate extends JdbcTemplate {
     private SavepointRejectingJdbcTemplate(DataSource dataSource) {
       super(dataSource);
@@ -43,7 +65,7 @@ class MySqlJdbcUpsertsTransactionTest extends MySqlIntegrationTestSupport {
             new Class<?>[]{Connection.class},
             (proxy, method, args) -> {
               if (method.getName().equals("setSavepoint")) {
-                throw new AssertionError("MySQL upserts must not create PostgreSQL savepoints");
+                throw new AssertionError("MySQL conflict handling must not create PostgreSQL savepoints");
               }
               try {
                 return method.invoke(connection, args);

--- a/server/src/test/java/com/github/klboke/kkrepo/server/helm/HelmHostedServiceConcurrencyTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/helm/HelmHostedServiceConcurrencyTest.java
@@ -1,0 +1,313 @@
+package com.github.klboke.kkrepo.server.helm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.core.BlobObjectMetadata;
+import com.github.klboke.kkrepo.core.BlobReference;
+import com.github.klboke.kkrepo.core.BlobStorage;
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.jdbc.api.BrowseNodeDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.ComponentDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.RepositoryIndexRebuildDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.model.AssetBlobRecord;
+import com.github.klboke.kkrepo.persistence.jdbc.api.model.AssetRecord;
+import com.github.klboke.kkrepo.persistence.jdbc.api.model.ComponentRecord;
+import com.github.klboke.kkrepo.server.cache.AssetMetadataCache;
+import com.github.klboke.kkrepo.server.cache.CachedAssetMetadata;
+import com.github.klboke.kkrepo.server.maven.BlobStorageRegistry;
+import com.github.klboke.kkrepo.server.maven.MavenResponse;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import com.github.klboke.kkrepo.server.support.InMemorySharedCache;
+import com.github.klboke.kkrepo.server.support.dao.AssetDaoAdapter;
+import com.github.klboke.kkrepo.server.support.dao.BrowseNodeDaoAdapter;
+import com.github.klboke.kkrepo.server.support.dao.ComponentDaoAdapter;
+import com.github.klboke.kkrepo.server.transaction.TransientTransactionRetry;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+class HelmHostedServiceConcurrencyTest {
+  @Test
+  void concurrentInitialIndexGenerationAndRebuildConvergeOnOneAsset() throws Exception {
+    RacingAssetDao assetDao = new RacingAssetDao();
+    RecordingTransactionManager transactions = new RecordingTransactionManager();
+    AssetMetadataCache cache = new AssetMetadataCache(new InMemorySharedCache(), false, 0, 0);
+    BlobStorage storage = new NoopBlobStorage();
+    HelmAssetWriter writer = new HelmAssetWriter(
+        assetDao,
+        new FixedComponentDao(),
+        new NoopBrowseNodeDao(),
+        cache,
+        new TransientTransactionRetry(transactions, 3, 0));
+    BlobStorageRegistry registry = mock(BlobStorageRegistry.class);
+    when(registry.forBlobStoreId(7L)).thenReturn(storage);
+    HelmAssetReader reader = mock(HelmAssetReader.class);
+    when(reader.serveSnapshot(any(CachedAssetMetadata.class), eq(true), eq("index.yaml")))
+        .thenReturn(MavenResponse.noBody(200));
+    HelmHostedService service = new HelmHostedService(
+        assetDao,
+        mock(RepositoryIndexRebuildDao.class),
+        registry,
+        writer,
+        reader,
+        cache);
+
+    try (var executor = Executors.newFixedThreadPool(2)) {
+      Future<MavenResponse> initialGet = executor.submit(
+          () -> service.get(runtime(), "index.yaml", true));
+      assetDao.awaitInitialIndexCheck();
+      Future<?> rebuild = executor.submit(() -> {
+        service.rebuildIndex(runtime(), storage, 7L, "system", null);
+        return null;
+      });
+
+      assertEquals(200, get(initialGet).status());
+      get(rebuild);
+    }
+
+    assertEquals(1, assetDao.assetCount());
+    assertEquals(2, assetDao.tryInsertCalls.get());
+    assertEquals(1, assetDao.updateAssetCalls.get());
+    assertEquals(1, assetDao.markDeletedCalls.get());
+    assertEquals(2, transactions.begun.get());
+    assertEquals(0, transactions.rolledBack.get());
+    assertEquals(2, transactions.committed.get());
+  }
+
+  private static <T> T get(Future<T> future) throws Exception {
+    try {
+      return future.get(10, TimeUnit.SECONDS);
+    } catch (ExecutionException e) {
+      if (e.getCause() instanceof Exception cause) {
+        throw cause;
+      }
+      throw e;
+    } catch (TimeoutException e) {
+      throw new AssertionError("Concurrent Helm index test timed out", e);
+    }
+  }
+
+  private static RepositoryRuntime runtime() {
+    return new RepositoryRuntime(
+        10L, "helm-hosted", RepositoryFormat.HELM, RepositoryType.HOSTED, "helm-hosted",
+        true, 7L, "ALLOW", null, null, true, null, 60, 60, true, null, List.of());
+  }
+
+  private static final class RacingAssetDao extends AssetDaoAdapter {
+    private final AtomicLong blobIds = new AtomicLong(900);
+    private final AtomicLong assetIds = new AtomicLong(100);
+    private final ConcurrentHashMap<Long, AssetBlobRecord> blobs = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, AssetRecord> assets = new ConcurrentHashMap<>();
+    private final CountDownLatch initialIndexCheck = new CountDownLatch(1);
+    private final CountDownLatch persistFinds = new CountDownLatch(2);
+    private final CountDownLatch insertAttempts = new CountDownLatch(2);
+    private final CountDownLatch successfulInsert = new CountDownLatch(1);
+    private final AtomicInteger findCalls = new AtomicInteger();
+    private final AtomicInteger tryInsertCalls = new AtomicInteger();
+    private final AtomicInteger updateAssetCalls = new AtomicInteger();
+    private final AtomicInteger markDeletedCalls = new AtomicInteger();
+
+    @Override
+    public Optional<AssetRecord> findAssetByPath(long repositoryId, String path) {
+      int call = findCalls.incrementAndGet();
+      if (call == 1) {
+        initialIndexCheck.countDown();
+        return Optional.empty();
+      }
+      if (call <= 3) {
+        persistFinds.countDown();
+        await(persistFinds, "Helm writers did not reach the initial asset lookup");
+        return Optional.empty();
+      }
+      return Optional.ofNullable(assets.get(key(repositoryId, path)));
+    }
+
+    @Override
+    public Optional<AssetBlobRecord> findReusableBlobBySha256(
+        long blobStoreId, String sha256, long size) {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<AssetBlobRecord> recoverDeletedBlobBySha256(
+        long blobStoreId, String sha256, long size) {
+      return Optional.empty();
+    }
+
+    @Override
+    public long insertBlob(AssetBlobRecord record) {
+      long id = blobIds.incrementAndGet();
+      blobs.put(id, record.withId(id));
+      return id;
+    }
+
+    @Override
+    public Optional<AssetBlobRecord> findBlobById(long blobId) {
+      return Optional.ofNullable(blobs.get(blobId));
+    }
+
+    @Override
+    public OptionalLong tryInsertAsset(AssetRecord record) {
+      int call = tryInsertCalls.incrementAndGet();
+      insertAttempts.countDown();
+      await(insertAttempts, "Helm writers did not race the asset insert");
+      if (call == 1) {
+        await(successfulInsert, "Concurrent Helm asset insert did not complete");
+        return OptionalLong.empty();
+      }
+      long id = assetIds.incrementAndGet();
+      assets.put(key(record.repositoryId(), record.path()), withId(record, id));
+      successfulInsert.countDown();
+      return OptionalLong.of(id);
+    }
+
+    @Override
+    public int updateAssetBlobBindingAndMetadata(
+        long assetId,
+        Long componentId,
+        long assetBlobId,
+        String kind,
+        String contentType,
+        long size,
+        Instant lastUpdatedAt,
+        Map<String, Object> attributes) {
+      updateAssetCalls.incrementAndGet();
+      assets.computeIfPresent(key(10L, "index.yaml"), (ignored, prior) -> new AssetRecord(
+          prior.id(), prior.repositoryId(), componentId, assetBlobId, prior.format(), prior.path(),
+          prior.pathHash(), prior.name(), kind, contentType, size, prior.lastDownloadedAt(),
+          lastUpdatedAt, attributes));
+      return 1;
+    }
+
+    @Override
+    public int markBlobDeletedIfUnreferenced(long blobId, String reason) {
+      markDeletedCalls.incrementAndGet();
+      return 1;
+    }
+
+    @Override
+    public List<HelmIndexRow> listHelmIndexRows(long repositoryId) {
+      return List.of();
+    }
+
+    void awaitInitialIndexCheck() {
+      await(initialIndexCheck, "Initial Helm index request did not check for index.yaml");
+    }
+
+    int assetCount() {
+      return assets.size();
+    }
+
+    private static String key(long repositoryId, String path) {
+      return repositoryId + ":" + path;
+    }
+
+    private static AssetRecord withId(AssetRecord record, long id) {
+      return new AssetRecord(
+          id, record.repositoryId(), record.componentId(), record.assetBlobId(), record.format(),
+          record.path(), record.pathHash(), record.name(), record.kind(), record.contentType(),
+          record.size(), record.lastDownloadedAt(), record.lastUpdatedAt(), record.attributes());
+    }
+
+    private static void await(CountDownLatch latch, String message) {
+      try {
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+          throw new AssertionError(message);
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new AssertionError(e);
+      }
+    }
+  }
+
+  private static final class FixedComponentDao extends ComponentDaoAdapter {
+    @Override
+    public long upsertReturningId(ComponentRecord record) {
+      return 501L;
+    }
+  }
+
+  private static final class NoopBrowseNodeDao extends BrowseNodeDaoAdapter {
+    @Override
+    public void upsertPathAncestors(
+        long repositoryId, String fullPath, Long assetId, Long componentId) {
+    }
+  }
+
+  private static final class NoopBlobStorage implements BlobStorage {
+    private final AtomicInteger puts = new AtomicInteger();
+
+    @Override
+    public BlobReference put(
+        String repository, String logicalPath, InputStream content, long size, String sha256) {
+      return new BlobReference(
+          "default", "helm-index/" + puts.incrementAndGet(), sha256, size);
+    }
+
+    @Override
+    public Optional<InputStream> get(BlobReference reference) {
+      return Optional.empty();
+    }
+
+    @Override
+    public boolean exists(BlobReference reference) {
+      return false;
+    }
+
+    @Override
+    public Optional<BlobObjectMetadata> stat(BlobReference reference) {
+      return Optional.empty();
+    }
+
+    @Override
+    public void delete(BlobReference reference) {
+    }
+  }
+
+  private static final class RecordingTransactionManager implements PlatformTransactionManager {
+    private final AtomicInteger begun = new AtomicInteger();
+    private final AtomicInteger committed = new AtomicInteger();
+    private final AtomicInteger rolledBack = new AtomicInteger();
+
+    @Override
+    public TransactionStatus getTransaction(TransactionDefinition definition)
+        throws TransactionException {
+      begun.incrementAndGet();
+      return new SimpleTransactionStatus();
+    }
+
+    @Override
+    public void commit(TransactionStatus status) throws TransactionException {
+      committed.incrementAndGet();
+    }
+
+    @Override
+    public void rollback(TransactionStatus status) throws TransactionException {
+      rolledBack.incrementAndGet();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- recover PostgreSQL duplicate asset inserts with a transaction savepoint before returning the shared `OptionalLong.empty()` conflict result
- keep the existing MySQL path savepoint-free while preserving its current transaction semantics
- document the backend-neutral `tryInsertAsset` contract used by protocol writers
- add a real database race regression plus a Helm initial `index.yaml` generation/rebuild concurrency regression
- cover non-duplicate SQL failures and missing/null generated-key defenses in the shared insert helper

## Root cause

`JdbcAssetDao.tryInsertAsset` translated a unique-key violation into an empty result, but PostgreSQL had already marked the surrounding protocol-writer transaction as aborted. The losing writer then tried to load the winning asset in that same transaction and received SQLSTATE `25P02`.

The shared insert helper now creates a savepoint only for PostgreSQL transactions. A duplicate-key failure rolls back to that savepoint before returning the existing conflict result, so every protocol writer can safely load or reuse the winning row. MySQL keeps its existing path because its transaction remains usable after the duplicate and its portable upsert path must not rely on JDBC savepoints.

The database unique key remains the cross-replica coordinator; no process-local state is introduced for correctness.

## Validation

- `mvn -pl server -am test`
  - server: 952 tests
  - MySQL persistence: 51 tests
  - PostgreSQL persistence: 25 tests
- `mvn -pl persistence-jdbc -am test`
- `mvn -pl persistence-postgresql -am -Dtest=PostgreSqlPersistenceApiContractTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl persistence-mysql -am -Dtest=MySqlPersistenceApiContractTest,MySqlJdbcUpsertsTransactionTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl server -am -Dtest=MavenAssetWriterConcurrencyTest,NpmAssetWriterConcurrencyTest,PypiAssetWriterConcurrencyTest,HelmHostedServiceConcurrencyTest -Dsurefire.failIfNoSpecifiedTests=false test`
- Codecov: all modified and coverable lines are covered by tests
- GitHub Actions `Client E2E compatibility (mysql)`: passed, including real Helm package/upload/repo update/pull
- GitHub Actions `Client E2E compatibility (postgresql)`: passed, including real Helm package/upload/repo update/pull

Fixes #114