### PR TITLE
fix: make Helm chart parsing concurrency-safe

### DIFF
--- a/protocol-helm/src/main/java/com/github/klboke/kkrepo/protocol/helm/HelmChartPackageParser.java
+++ b/protocol-helm/src/main/java/com/github/klboke/kkrepo/protocol/helm/HelmChartPackageParser.java
@@ -14,17 +14,21 @@ import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 public final class HelmChartPackageParser {
   private static final String CHART_YAML = "Chart.yaml";
-  private final Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
 
   public HelmChartMetadata parse(InputStream input) throws IOException {
     byte[] chartYaml = readChartYaml(input);
-    Object loaded = yaml.load(new ByteArrayInputStream(chartYaml));
+    Object loaded = newYaml().load(new ByteArrayInputStream(chartYaml));
     if (!(loaded instanceof Map<?, ?> map)) {
       throw new IllegalArgumentException("Chart.yaml is not a YAML mapping");
     }
     HelmChartMetadata metadata = HelmChartMetadata.fromYamlMap(castMap(map));
     metadata.requireNameAndVersion();
     return metadata;
+  }
+
+  private static Yaml newYaml() {
+    // Yaml retains mutable load state, while this parser is shared by singleton hosted services.
+    return new Yaml(new SafeConstructor(new LoaderOptions()));
   }
 
   private byte[] readChartYaml(InputStream input) throws IOException {

--- a/protocol-helm/src/test/java/com/github/klboke/kkrepo/protocol/helm/HelmProtocolTest.java
+++ b/protocol-helm/src/test/java/com/github/klboke/kkrepo/protocol/helm/HelmProtocolTest.java
@@ -9,14 +9,21 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPOutputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.junit.jupiter.api.Test;
 
 class HelmProtocolTest {
+  private static final int CONCURRENT_PARSE_COUNT = 32;
+
   @Test
   void parsesChartYamlFromPackage() throws Exception {
     HelmChartMetadata metadata = new HelmChartPackageParser()
@@ -45,6 +52,56 @@ class HelmProtocolTest {
         () -> new HelmChartPackageParser().parse(new ByteArrayInputStream(bytes)));
 
     assertEquals("Chart.yaml not found in Helm chart package", error.getMessage());
+  }
+
+  @Test
+  void rejectsChartYamlThatIsNotAMapping() throws Exception {
+    byte[] bytes = chartPackageWithEntry("demo/Chart.yaml", "- not-a-mapping\n");
+
+    IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+        () -> new HelmChartPackageParser().parse(new ByteArrayInputStream(bytes)));
+
+    assertEquals("Chart.yaml is not a YAML mapping", error.getMessage());
+  }
+
+  @Test
+  void concurrentlyParsesPackagesWithOneSharedParser() throws Exception {
+    HelmChartPackageParser parser = new HelmChartPackageParser();
+    List<byte[]> charts = new ArrayList<>();
+    for (int i = 0; i < CONCURRENT_PARSE_COUNT; i++) {
+      charts.add(chartPackage("demo-" + i, "1.2." + i));
+    }
+    CountDownLatch ready = new CountDownLatch(CONCURRENT_PARSE_COUNT);
+    CountDownLatch start = new CountDownLatch(1);
+
+    try (var executor = Executors.newFixedThreadPool(CONCURRENT_PARSE_COUNT)) {
+      List<Future<?>> parses = new ArrayList<>();
+      for (int worker = 0; worker < CONCURRENT_PARSE_COUNT; worker++) {
+        int workerIndex = worker;
+        parses.add(executor.submit(() -> {
+          ready.countDown();
+          if (!start.await(5, TimeUnit.SECONDS)) {
+            throw new AssertionError("Concurrent Helm parses did not start together");
+          }
+          for (int iteration = 0; iteration < 25; iteration++) {
+            int chartIndex = (workerIndex + iteration) % charts.size();
+            HelmChartMetadata metadata = parser.parse(
+                new ByteArrayInputStream(charts.get(chartIndex)));
+            assertEquals("demo-" + chartIndex, metadata.name());
+            assertEquals("1.2." + chartIndex, metadata.version());
+          }
+          return null;
+        }));
+      }
+      try {
+        assertTrue(ready.await(5, TimeUnit.SECONDS), "All Helm parser workers should be ready");
+      } finally {
+        start.countDown();
+      }
+      for (Future<?> parse : parses) {
+        parse.get(15, TimeUnit.SECONDS);
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

- create a fresh safe-constructor-backed SnakeYAML parser for each `Chart.yaml` parse
- keep `HelmChartPackageParser` safe to share from singleton hosted services without a JVM-local lock
- add a 32-worker regression test that runs 800 parses across multiple valid chart packages
- retain the existing missing-`Chart.yaml` validation and add coverage for non-mapping metadata

## Root cause

`HelmChartPackageParser` stored one mutable SnakeYAML `Yaml` instance in a field. The parser is reused by singleton Helm hosted services, so concurrent uploads could corrupt SnakeYAML scanner state and surface as HTTP 500 responses.

## Validation

- `mvn -pl protocol-helm test` — 18 tests passed
- `mvn -pl server -am -Dtest='HelmHostedServiceTest,HelmAssetWriterTest,HelmHostedServiceConcurrencyTest,ComponentUploadServiceTest,ComponentUploadErrorAdviceTest' -Dsurefire.failIfNoSpecifiedTests=false test` — 20 tests passed
- the live Nexus/kkRepo black-box tests compiled, but could not execute locally because the configured reference endpoints were unavailable (`ConnectException`)

Fixes #118