### PR TITLE
Deploy dev jar after merged main CI

### DIFF
--- a/.github/deploy/dev/docker-compose.yml
+++ b/.github/deploy/dev/docker-compose.yml
@@ -1,0 +1,64 @@
+name: kkrepo
+
+services:
+  postgresql:
+    image: postgres:17-alpine
+    container_name: kkrepo-postgresql
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      TZ: Asia/Shanghai
+    volumes:
+      - ${KKREPO_DEPLOY_BASE:-../../..}/data/postgresql:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 15s
+    restart: unless-stopped
+    mem_limit: 768m
+    cpus: 0.75
+    pids_limit: 256
+    logging:
+      driver: json-file
+      options:
+        max-size: 20m
+        max-file: "3"
+    networks:
+      kkrepo:
+        ipv4_address: 172.29.44.30
+
+  nginx:
+    image: nginx:stable-alpine
+    container_name: kkrepo-nginx
+    network_mode: host
+    volumes:
+      - ${KKREPO_DEPLOY_BASE:-../../..}/.github/deploy/dev/nginx/kkrepo.conf:/etc/nginx/conf.d/default.conf:ro
+      - ${KKREPO_DEPLOY_BASE:-../../..}/tls/kkrepo.cn_bundle.crt:/etc/nginx/tls/kkrepo.cn_bundle.crt:ro
+      - ${KKREPO_DEPLOY_BASE:-../../..}/tls/kkrepo.cn.key:/etc/nginx/tls/kkrepo.cn.key:ro
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1/nginx-health"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    mem_limit: 128m
+    cpus: 0.5
+    pids_limit: 128
+    security_opt:
+      - no-new-privileges:true
+    logging:
+      driver: json-file
+      options:
+        max-size: 20m
+        max-file: "3"
+
+networks:
+  kkrepo:
+    name: kkrepo-network
+    ipam:
+      config:
+        - subnet: 172.29.44.0/24

--- a/.github/deploy/dev/nginx/kkrepo.conf
+++ b/.github/deploy/dev/nginx/kkrepo.conf
@@ -1,0 +1,58 @@
+# Internal dev reverse proxy configuration.
+upstream kkrepo_app {
+    server 127.0.0.1:8080;
+    keepalive 32;
+}
+
+server {
+    listen 80 default_server;
+    server_name _;
+
+    location = /nginx-health {
+        access_log off;
+        default_type text/plain;
+        return 200 "ok\n";
+    }
+
+    location / {
+        return 301 https://kkrepo.cn$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl default_server;
+    http2 on;
+    server_name kkrepo.cn www.kkrepo.cn;
+
+    ssl_certificate /etc/nginx/tls/kkrepo.cn_bundle.crt;
+    ssl_certificate_key /etc/nginx/tls/kkrepo.cn.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 1d;
+    ssl_session_tickets off;
+
+    client_max_body_size 0;
+    client_body_timeout 600s;
+    send_timeout 600s;
+
+    location / {
+        proxy_pass http://kkrepo_app;
+        proxy_http_version 1.1;
+        proxy_request_buffering off;
+        proxy_buffering off;
+        proxy_connect_timeout 30s;
+        proxy_send_timeout 600s;
+        proxy_read_timeout 600s;
+        proxy_redirect http://kkrepo.cn/ https://kkrepo.cn/;
+        proxy_redirect http://www.kkrepo.cn/ https://www.kkrepo.cn/;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Port 443;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Authorization $http_authorization;
+        proxy_set_header Connection "";
+    }
+}

--- a/.github/deploy/dev/systemd/kkrepo.service
+++ b/.github/deploy/dev/systemd/kkrepo.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=kkRepo dev executable jar
+Wants=network-online.target
+After=network-online.target docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+User=kkrepo
+Group=kkrepo
+Environment=KKREPO_DEPLOY_ROOT=/opt/kkrepo/runtime
+ExecStartPre=/usr/bin/test -x /opt/kkrepo/bin/kkrepo-jar-deploy.sh
+ExecStart=/opt/kkrepo/bin/kkrepo-jar-deploy.sh start
+ExecStop=/opt/kkrepo/bin/kkrepo-jar-deploy.sh stop
+TimeoutStartSec=180
+TimeoutStopSec=60
+Restart=on-failure
+RestartSec=15
+
+[Install]
+WantedBy=multi-user.target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,3 +134,17 @@ jobs:
           docker compose -f docker-compose.compat-postgres.yml --profile kkrepo-postgresql config
       - uses: azure/setup-helm@v5
       - run: helm lint deploy/helm/kkrepo
+
+  dev-jar-deploy-contract:
+    name: dev-jar-deploy-contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Verify dev jar deployment scripts
+        run: |
+          bash -n scripts/deploy/kkrepo-jar-deploy.sh
+          bash -n scripts/ci/test-dev-jar-deploy.sh
+          scripts/ci/test-dev-jar-deploy.sh
+          test -f .github/deploy/dev/systemd/kkrepo.service
+          POSTGRES_DB=kkrepo POSTGRES_USER=kkrepo POSTGRES_PASSWORD=kkrepo \
+            docker compose -f .github/deploy/dev/docker-compose.yml config --quiet

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,131 @@
+name: Deploy Dev
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    branches:
+      - main
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: deploy-dev
+  cancel-in-progress: false
+
+jobs:
+  deploy-dev:
+    name: deploy-dev-jar
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: dev
+    steps:
+      - name: Confirm the main commit came from a merged pull request
+        id: source
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          deploy=false
+          for attempt in 1 2 3 4 5; do
+            deploy="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/pulls" \
+              --jq 'any(.[]; .merged_at != null and .base.ref == "main")')"
+            if [[ "$deploy" == "true" ]]; then
+              break
+            fi
+            sleep 3
+          done
+          echo "deploy=$deploy" >> "$GITHUB_OUTPUT"
+
+      - name: Check out merged revision
+        if: steps.source.outputs.deploy == 'true'
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
+
+      - name: Set up JDK 25
+        if: steps.source.outputs.deploy == 'true'
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: maven
+
+      - name: Build executable jar
+        if: steps.source.outputs.deploy == 'true'
+        id: build
+        run: |
+          mvn -B -ntp -pl server -am -DskipTests package spring-boot:repackage
+          project_version="$(mvn -q -N -DforceStdout help:evaluate -Dexpression=project.version)"
+          jar_file="server/target/kkrepo-server-${project_version}.jar"
+          manifest="$(unzip -p "$jar_file" META-INF/MANIFEST.MF)"
+          jar_listing="$(jar tf "$jar_file")"
+          [[ "$manifest" == *"Main-Class: org.springframework.boot.loader.launch.JarLauncher"* ]]
+          [[ "$manifest" == *"Start-Class: com.github.klboke.kkrepo.server.KkRepoApplication"* ]]
+          [[ "$jar_listing" == BOOT-INF/* || "$jar_listing" == *$'\n'BOOT-INF/* ]]
+          echo "jar_file=$jar_file" >> "$GITHUB_OUTPUT"
+
+      - name: Configure dev SSH
+        if: steps.source.outputs.deploy == 'true'
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.DEV_SSH_PRIVATE_KEY }}
+          SSH_KNOWN_HOSTS: ${{ secrets.DEV_SSH_KNOWN_HOSTS }}
+        run: |
+          install -d -m 0700 "$HOME/.ssh"
+          printf '%s\n' "$SSH_PRIVATE_KEY" > "$HOME/.ssh/dev"
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > "$HOME/.ssh/known_hosts"
+          chmod 0600 "$HOME/.ssh/dev" "$HOME/.ssh/known_hosts"
+
+      - name: Upload executable jar and deployment script
+        if: steps.source.outputs.deploy == 'true'
+        env:
+          SSH_HOST: ${{ secrets.DEV_SSH_HOST }}
+          SSH_PORT: ${{ secrets.DEV_SSH_PORT }}
+          SSH_USER: ${{ secrets.DEV_SSH_USER }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          JAR_FILE: ${{ steps.build.outputs.jar_file }}
+        run: |
+          remote_dir="/opt/kkrepo/staging/${HEAD_SHA}"
+          ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o StrictHostKeyChecking=yes \
+            -i "$HOME/.ssh/dev" -p "$SSH_PORT" "$SSH_USER@$SSH_HOST" \
+            "mkdir -p '$remote_dir'"
+          scp -q -o BatchMode=yes -o ConnectTimeout=15 -o StrictHostKeyChecking=yes \
+            -i "$HOME/.ssh/dev" -P "$SSH_PORT" \
+            "$JAR_FILE" "$SSH_USER@$SSH_HOST:$remote_dir/kkrepo.jar"
+          scp -q -o BatchMode=yes -o ConnectTimeout=15 -o StrictHostKeyChecking=yes \
+            -i "$HOME/.ssh/dev" -P "$SSH_PORT" \
+            scripts/deploy/kkrepo-jar-deploy.sh \
+            "$SSH_USER@$SSH_HOST:$remote_dir/kkrepo-jar-deploy.sh"
+
+      - name: Deploy and verify dev
+        if: steps.source.outputs.deploy == 'true'
+        env:
+          SSH_HOST: ${{ secrets.DEV_SSH_HOST }}
+          SSH_PORT: ${{ secrets.DEV_SSH_PORT }}
+          SSH_USER: ${{ secrets.DEV_SSH_USER }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          remote_dir="/opt/kkrepo/staging/${HEAD_SHA}"
+          ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o StrictHostKeyChecking=yes \
+            -i "$HOME/.ssh/dev" -p "$SSH_PORT" "$SSH_USER@$SSH_HOST" \
+            "install -m 0755 '$remote_dir/kkrepo-jar-deploy.sh' /opt/kkrepo/bin/kkrepo-jar-deploy.sh && \
+             KKREPO_DEPLOY_ROOT=/opt/kkrepo/runtime /opt/kkrepo/bin/kkrepo-jar-deploy.sh \
+               deploy '$remote_dir/kkrepo.jar' '$HEAD_SHA'"
+
+      - name: Remove remote staging files
+        if: always() && steps.source.outputs.deploy == 'true'
+        env:
+          SSH_HOST: ${{ secrets.DEV_SSH_HOST }}
+          SSH_PORT: ${{ secrets.DEV_SSH_PORT }}
+          SSH_USER: ${{ secrets.DEV_SSH_USER }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          ssh -q -o BatchMode=yes -o ConnectTimeout=15 -o StrictHostKeyChecking=yes \
+            -i "$HOME/.ssh/dev" -p "$SSH_PORT" "$SSH_USER@$SSH_HOST" \
+            "rm -rf '/opt/kkrepo/staging/${HEAD_SHA}'"

--- a/scripts/ci/test-dev-jar-deploy.sh
+++ b/scripts/ci/test-dev-jar-deploy.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEPLOY_SCRIPT="$ROOT/scripts/deploy/kkrepo-jar-deploy.sh"
+TEST_ROOT="$(mktemp -d)"
+FAKE_JAVA_HOME="$TEST_ROOT/fake-java-home"
+HEALTH_MARKER="$TEST_ROOT/healthy"
+
+cleanup() {
+  KKREPO_DEPLOY_ROOT="$TEST_ROOT/app" "$DEPLOY_SCRIPT" stop >/dev/null 2>&1 || true
+  rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+mkdir -p "$FAKE_JAVA_HOME/bin" "$TEST_ROOT/app/config"
+
+cat >"$FAKE_JAVA_HOME/bin/java" <<'FAKE_JAVA'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "-version" ]]; then
+  printf 'openjdk version "25.0.1"\n' >&2
+  exit 0
+fi
+
+jar_file=""
+previous=""
+for argument in "$@"; do
+  if [[ "$previous" == "-jar" ]]; then
+    jar_file="$argument"
+    break
+  fi
+  previous="$argument"
+done
+if [[ -z "$jar_file" ]]; then
+  exit 2
+fi
+if grep -q '^BROKEN$' "$jar_file"; then
+  exit 12
+fi
+
+remove_health_marker() {
+  rm -f "$KKREPO_TEST_HEALTH_MARKER"
+}
+trap 'remove_health_marker; exit 0' TERM INT
+trap remove_health_marker EXIT
+touch "$KKREPO_TEST_HEALTH_MARKER"
+while true; do
+  sleep 1
+done
+FAKE_JAVA
+
+cat >"$TEST_ROOT/fake-curl" <<'FAKE_CURL'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ -f "$KKREPO_TEST_HEALTH_MARKER" ]]
+FAKE_CURL
+
+chmod +x "$FAKE_JAVA_HOME/bin/java" "$TEST_ROOT/fake-curl"
+
+cat >"$TEST_ROOT/app/config/kkrepo.env" <<EOF
+JAVA_HOME='$FAKE_JAVA_HOME'
+KKREPO_HEALTH_URL='http://127.0.0.1:8081/actuator/health'
+KKREPO_STARTUP_TIMEOUT_SECONDS='3'
+KKREPO_STOP_TIMEOUT_SECONDS='2'
+KKREPO_KEEP_RELEASES='2'
+KKREPO_TEST_HEALTH_MARKER='$HEALTH_MARKER'
+KKREPO_CURL_BIN='$TEST_ROOT/fake-curl'
+EOF
+
+printf 'GOOD-1\n' >"$TEST_ROOT/good-1.jar"
+printf 'GOOD-2\n' >"$TEST_ROOT/good-2.jar"
+printf 'BROKEN\n' >"$TEST_ROOT/broken.jar"
+
+export KKREPO_DEPLOY_ROOT="$TEST_ROOT/app"
+
+"$DEPLOY_SCRIPT" deploy "$TEST_ROOT/good-1.jar" release-1
+"$DEPLOY_SCRIPT" status
+[[ "$(readlink -f "$TEST_ROOT/app/current")" == "$TEST_ROOT/app/releases/release-1" ]]
+
+"$DEPLOY_SCRIPT" deploy "$TEST_ROOT/good-2.jar" release-2
+"$DEPLOY_SCRIPT" status
+[[ "$(readlink -f "$TEST_ROOT/app/current")" == "$TEST_ROOT/app/releases/release-2" ]]
+
+if "$DEPLOY_SCRIPT" deploy "$TEST_ROOT/broken.jar" release-broken; then
+  printf 'broken release unexpectedly passed deployment\n' >&2
+  exit 1
+fi
+
+"$DEPLOY_SCRIPT" status
+[[ "$(readlink -f "$TEST_ROOT/app/current")" == "$TEST_ROOT/app/releases/release-2" ]]
+[[ ! -d "$TEST_ROOT/app/releases/release-broken" ]]
+
+"$DEPLOY_SCRIPT" stop
+if "$DEPLOY_SCRIPT" status; then
+  printf 'stopped service unexpectedly reported healthy\n' >&2
+  exit 1
+fi
+
+printf '[test] dev jar deployment contract passed\n'

--- a/scripts/deploy/kkrepo-jar-deploy.sh
+++ b/scripts/deploy/kkrepo-jar-deploy.sh
@@ -1,0 +1,398 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+DEPLOY_ROOT="${KKREPO_DEPLOY_ROOT:-/opt/kkrepo/runtime}"
+RELEASES_DIR="$DEPLOY_ROOT/releases"
+CURRENT_LINK="$DEPLOY_ROOT/current"
+CONFIG_DIR="$DEPLOY_ROOT/config"
+RUN_DIR="$DEPLOY_ROOT/run"
+LOG_DIR="$DEPLOY_ROOT/logs"
+ENV_FILE="${KKREPO_ENV_FILE:-$CONFIG_DIR/kkrepo.env}"
+PID_FILE="${KKREPO_PID_FILE:-$RUN_DIR/kkrepo.pid}"
+CONSOLE_LOG="${KKREPO_CONSOLE_LOG:-$LOG_DIR/console.log}"
+LOCK_DIR="$RUN_DIR/deploy.lock.d"
+CURRENT_JAR="$CURRENT_LINK/kkrepo.jar"
+
+RUNTIME_LOADED=false
+
+log() {
+  printf '[deploy] %s\n' "$*"
+}
+
+fail() {
+  printf '[deploy] ERROR: %s\n' "$*" >&2
+  return 1
+}
+
+ensure_layout() {
+  mkdir -p "$RELEASES_DIR" "$CONFIG_DIR" "$RUN_DIR" "$LOG_DIR"
+}
+
+load_runtime_environment() {
+  if [[ "$RUNTIME_LOADED" == "true" ]]; then
+    return
+  fi
+  if [[ ! -r "$ENV_FILE" ]]; then
+    fail "runtime environment file is missing or unreadable: $ENV_FILE"
+    return 1
+  fi
+
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+  RUNTIME_LOADED=true
+}
+
+pid_from_file() {
+  if [[ ! -f "$PID_FILE" ]]; then
+    return 1
+  fi
+  tr -dc '0-9' <"$PID_FILE"
+}
+
+is_running() {
+  local pid="${1:-}"
+  [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null
+}
+
+is_managed_process() {
+  local pid="${1:-}"
+  local command_line
+  if ! is_running "$pid"; then
+    return 1
+  fi
+  if [[ -r "/proc/$pid/cmdline" ]]; then
+    command_line="$(tr '\0' ' ' <"/proc/$pid/cmdline")"
+  else
+    command_line="$(ps -o command= -p "$pid" 2>/dev/null || true)"
+  fi
+  [[ "$command_line" == *" -jar $CURRENT_JAR"* ]]
+}
+
+java_binary() {
+  if [[ -n "${KKREPO_JAVA_BIN:-}" ]]; then
+    printf '%s\n' "$KKREPO_JAVA_BIN"
+  elif [[ -n "${JAVA_HOME:-}" ]]; then
+    printf '%s\n' "$JAVA_HOME/bin/java"
+  else
+    command -v java
+  fi
+}
+
+verify_java() {
+  local java_bin="$1"
+  local major
+  if [[ ! -x "$java_bin" ]]; then
+    fail "Java executable not found: $java_bin"
+    return 1
+  fi
+  major="$($java_bin -version 2>&1 | awk -F'[\".]' '/version/ {print $2; exit}')"
+  if [[ ! "$major" =~ ^[0-9]+$ ]] || (( major < 25 )); then
+    fail "Java 25 or newer is required (detected: ${major:-unknown})"
+    return 1
+  fi
+}
+
+health_url() {
+  printf '%s\n' "${KKREPO_HEALTH_URL:-http://127.0.0.1:8081/actuator/health}"
+}
+
+health_check() {
+  local curl_bin="${KKREPO_CURL_BIN:-curl}"
+  local pid
+  pid="$(pid_from_file 2>/dev/null || true)"
+  is_managed_process "$pid" || return 1
+  "$curl_bin" --fail --silent --max-time 5 "$(health_url)" >/dev/null
+}
+
+wait_for_health() {
+  local timeout="${KKREPO_STARTUP_TIMEOUT_SECONDS:-120}"
+  local elapsed=0
+  while (( elapsed < timeout )); do
+    if health_check; then
+      return 0
+    fi
+    if [[ -f "$PID_FILE" ]]; then
+      local pid
+      pid="$(pid_from_file 2>/dev/null || true)"
+      if [[ -n "$pid" ]] && ! is_running "$pid"; then
+        fail "process exited before becoming healthy"
+        return 1
+      fi
+    fi
+    sleep 1
+    ((elapsed += 1))
+  done
+  fail "health check did not pass within ${timeout}s: $(health_url)"
+}
+
+stop_service() {
+  local timeout="${KKREPO_STOP_TIMEOUT_SECONDS:-45}"
+  local pid
+  pid="$(pid_from_file 2>/dev/null || true)"
+  if [[ -z "$pid" ]]; then
+    rm -f "$PID_FILE"
+    log "service is already stopped"
+    return 0
+  fi
+  if ! is_running "$pid"; then
+    rm -f "$PID_FILE"
+    log "removed stale PID file"
+    return 0
+  fi
+  if ! is_managed_process "$pid"; then
+    fail "PID $pid does not belong to $CURRENT_JAR; refusing to stop it"
+    return 1
+  fi
+
+  log "stopping pid=$pid"
+  kill "$pid"
+  for ((elapsed = 0; elapsed < timeout; elapsed += 1)); do
+    if ! is_running "$pid"; then
+      rm -f "$PID_FILE"
+      log "service stopped"
+      return 0
+    fi
+    sleep 1
+  done
+
+  log "graceful stop timed out; sending KILL to pid=$pid"
+  kill -9 "$pid" 2>/dev/null || true
+  for _ in {1..10}; do
+    if ! is_running "$pid"; then
+      rm -f "$PID_FILE"
+      return 0
+    fi
+    sleep 0.2
+  done
+  fail "unable to stop pid=$pid"
+}
+
+start_service() {
+  local java_bin
+  local pid
+  local -a command=()
+  local -a parsed_java_args=()
+  local -a parsed_application_args=()
+
+  load_runtime_environment
+  if [[ ! -f "$CURRENT_JAR" ]]; then
+    fail "current executable jar is missing: $CURRENT_JAR"
+    return 1
+  fi
+
+  pid="$(pid_from_file 2>/dev/null || true)"
+  if is_managed_process "$pid"; then
+    log "service is already running, pid=$pid"
+    return 0
+  fi
+  if is_running "$pid"; then
+    fail "PID $pid is running but is not a managed kkRepo process"
+    return 1
+  fi
+  rm -f "$PID_FILE"
+
+  java_bin="$(java_binary)"
+  verify_java "$java_bin"
+  command=("$java_bin")
+  if [[ -n "${JAVA_OPTS:-}" ]]; then
+    # JAVA_OPTS is intentionally parsed as whitespace-separated JVM arguments.
+    read -r -a parsed_java_args <<<"$JAVA_OPTS"
+    command+=("${parsed_java_args[@]}")
+  fi
+  command+=(-jar "$CURRENT_JAR")
+  if [[ -n "${KKREPO_APPLICATION_ARGS:-}" ]]; then
+    read -r -a parsed_application_args <<<"$KKREPO_APPLICATION_ARGS"
+    command+=("${parsed_application_args[@]}")
+  fi
+
+  log "starting release=$(basename "$(readlink -f "$CURRENT_LINK")")"
+  (
+    cd "$DEPLOY_ROOT"
+    umask 027
+    nohup "${command[@]}" >>"$CONSOLE_LOG" 2>&1 </dev/null &
+    printf '%s\n' "$!" >"$PID_FILE.tmp"
+    mv -f "$PID_FILE.tmp" "$PID_FILE"
+  )
+  pid="$(pid_from_file)"
+  log "started pid=$pid"
+}
+
+switch_current() {
+  local release_dir="$1"
+  local temporary_link="$DEPLOY_ROOT/.current.$$.tmp"
+  ln -s "$release_dir" "$temporary_link"
+  if mv --help 2>&1 | grep -q -- '--no-target-directory'; then
+    mv -Tf "$temporary_link" "$CURRENT_LINK"
+  else
+    mv -fh "$temporary_link" "$CURRENT_LINK"
+  fi
+}
+
+acquire_deploy_lock() {
+  local owner=""
+  if mkdir "$LOCK_DIR" 2>/dev/null; then
+    printf '%s\n' "$$" >"$LOCK_DIR/pid"
+    return 0
+  fi
+
+  if [[ -f "$LOCK_DIR/pid" ]]; then
+    owner="$(tr -dc '0-9' <"$LOCK_DIR/pid")"
+  fi
+  if is_running "$owner"; then
+    fail "another deployment is already running, pid=$owner"
+    return 1
+  fi
+
+  log "removing stale deployment lock"
+  rm -rf -- "$LOCK_DIR"
+  if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+    fail "unable to acquire deployment lock"
+    return 1
+  fi
+  printf '%s\n' "$$" >"$LOCK_DIR/pid"
+}
+
+release_deploy_lock() {
+  rm -rf -- "$LOCK_DIR"
+}
+
+cleanup_old_releases() {
+  local keep="${KKREPO_KEEP_RELEASES:-5}"
+  local current_target
+  local index=0
+  local release_dir
+  current_target="$(readlink -f "$CURRENT_LINK")"
+
+  while IFS= read -r release_dir; do
+    release_dir="${release_dir%/}"
+    ((index += 1))
+    if (( index <= keep )) || [[ "$release_dir" == "$current_target" ]]; then
+      continue
+    fi
+    rm -rf -- "$release_dir"
+    log "removed old release $(basename "$release_dir")"
+  done < <(ls -1dt "$RELEASES_DIR"/*/ 2>/dev/null || true)
+}
+
+deploy_release() {
+  local staged_jar="${1:-}"
+  local release_id="${2:-}"
+  local release_dir
+  local previous_target=""
+  local failed=false
+
+  if [[ -z "$staged_jar" || -z "$release_id" ]]; then
+    fail "usage: $0 deploy <staged-jar> <release-id>"
+    return 2
+  fi
+  if [[ ! "$release_id" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    fail "release id contains unsupported characters: $release_id"
+    return 2
+  fi
+  if [[ ! -s "$staged_jar" ]]; then
+    fail "staged jar is missing or empty: $staged_jar"
+    return 1
+  fi
+
+  acquire_deploy_lock
+  trap release_deploy_lock EXIT
+
+  release_dir="$RELEASES_DIR/$release_id"
+  mkdir -p "$release_dir"
+  install -m 0644 "$staged_jar" "$release_dir/kkrepo.jar.tmp"
+  mv -f "$release_dir/kkrepo.jar.tmp" "$release_dir/kkrepo.jar"
+
+  if [[ -L "$CURRENT_LINK" ]]; then
+    previous_target="$(readlink -f "$CURRENT_LINK")"
+  fi
+  if [[ "$previous_target" == "$release_dir" ]] && health_check; then
+    log "release $release_id is already current and healthy"
+    release_deploy_lock
+    trap - EXIT
+    return 0
+  fi
+
+  if [[ -n "$previous_target" ]]; then
+    stop_service
+  fi
+  switch_current "$release_dir"
+
+  if ! start_service || ! wait_for_health; then
+    failed=true
+  fi
+
+  if [[ "$failed" == "false" ]]; then
+    log "release $release_id is healthy"
+    cleanup_old_releases
+    release_deploy_lock
+    trap - EXIT
+    return 0
+  fi
+
+  log "release $release_id failed; attempting rollback"
+  stop_service || true
+  if [[ -n "$previous_target" && -d "$previous_target" ]]; then
+    switch_current "$previous_target"
+    if start_service && wait_for_health; then
+      rm -rf -- "$release_dir"
+      log "rollback to $(basename "$previous_target") succeeded"
+    else
+      fail "rollback to $(basename "$previous_target") failed"
+      return 1
+    fi
+  else
+    rm -f "$CURRENT_LINK"
+    fail "no previous release is available for rollback"
+    return 1
+  fi
+  fail "release $release_id did not become healthy"
+}
+
+show_status() {
+  local pid
+  local release="none"
+  if [[ -L "$CURRENT_LINK" ]]; then
+    release="$(basename "$(readlink -f "$CURRENT_LINK")")"
+  fi
+  pid="$(pid_from_file 2>/dev/null || true)"
+  if ! is_managed_process "$pid"; then
+    printf '[status] stopped release=%s\n' "$release"
+    return 3
+  fi
+  if health_check; then
+    printf '[status] running pid=%s release=%s health=UP\n' "$pid" "$release"
+    return 0
+  fi
+  printf '[status] running pid=%s release=%s health=DOWN\n' "$pid" "$release"
+  return 1
+}
+
+ensure_layout
+load_runtime_environment
+
+case "${1:-status}" in
+  deploy)
+    deploy_release "${2:-}" "${3:-}"
+    ;;
+  start)
+    start_service
+    wait_for_health
+    ;;
+  stop)
+    stop_service
+    ;;
+  restart)
+    stop_service
+    start_service
+    wait_for_health
+    ;;
+  status)
+    show_status
+    ;;
+  *)
+    fail "usage: $0 {deploy <staged-jar> <release-id>|start|stop|restart|status}"
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary

- add a `Deploy Dev` workflow that runs only after a successful `CI` push on `main` associated with a merged pull request
- build and verify the Spring Boot executable jar, then deploy it to the dev host with health checks and automatic rollback
- keep PostgreSQL and Nginx in Docker while running the kkRepo application as a Java 25 jar
- keep dev-only Compose, Nginx, and systemd assets under `.github/deploy/dev`
- add a CI contract test for start, stop, successful upgrade, failed upgrade rollback, and Compose validation

## Why

The dev deployment previously ran the application in Docker and had no main-merge deployment workflow. This moves application lifecycle management to a tested jar deployment script while preserving the existing database and reverse proxy containers.

## Operational impact

- GitHub environment: `dev`
- application process: `/opt/kkrepo/bin/kkrepo-jar-deploy.sh`
- runtime releases: `/opt/kkrepo/runtime/releases`
- startup service: `kkrepo.service`
- deployment keeps five releases by default and rolls back when the new release does not become healthy

## Validation

- `scripts/ci/test-dev-jar-deploy.sh`
- `docker compose -f .github/deploy/dev/docker-compose.yml config --quiet`
- `mvn -B -ntp -pl server -am -DskipTests package spring-boot:repackage`
- verified executable jar manifest and `BOOT-INF` layout
- verified the dev host jar health, Nginx/PostgreSQL health, systemd enablement, and public HTTPS response
