### PR TITLE
fix: recover concurrent PostgreSQL Docker manifest upserts

### DIFF
--- a/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/JdbcDockerRegistryDao.java
+++ b/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/JdbcDockerRegistryDao.java
@@ -149,38 +149,37 @@ public class JdbcDockerRegistryDao implements com.github.klboke.kkrepo.persisten
 
   @Transactional(propagation = Propagation.MANDATORY)
   public DockerManifestRecord upsertManifest(DockerManifestRecord record) {
-    try {
-      long id = insertManifest(record);
-      return findManifestById(id).orElseThrow();
-    } catch (DuplicateKeyException e) {
-      jdbcTemplate.update("""
-          UPDATE docker_manifest
-          SET media_type = ?, artifact_type = ?, subject_digest = ?, subject_digest_hash = ?,
-              asset_id = ?, size = ?, pushed_by = ?, pushed_by_ip = ?, deleted_at = NULL,
-              attributes_json = ?
-          WHERE repository_id = ?
-            AND image_name_hash = ?
-            AND digest_hash = ?
-          """,
-          record.mediaType(),
-          record.artifactType(),
-          record.subjectDigest(),
-          record.subjectDigestHash(),
-          record.assetId(),
-          record.size(),
-          record.pushedBy(),
-          record.pushedByIp(),
-          jsonColumns.parameter(record.attributes()),
-          record.repositoryId(),
-          record.imageNameHash(),
-          record.digestHash());
-      return findManifestByDigest(record.repositoryId(), record.imageName(), record.digest())
-          .orElseThrow(() -> new DuplicateKeyException("Docker manifest conflict was not visible", e));
+    OptionalLong inserted = tryInsertManifest(record);
+    if (inserted.isPresent()) {
+      return findManifestById(inserted.getAsLong()).orElseThrow();
     }
+    jdbcTemplate.update("""
+        UPDATE docker_manifest
+        SET media_type = ?, artifact_type = ?, subject_digest = ?, subject_digest_hash = ?,
+            asset_id = ?, size = ?, pushed_by = ?, pushed_by_ip = ?, deleted_at = NULL,
+            attributes_json = ?
+        WHERE repository_id = ?
+          AND image_name_hash = ?
+          AND digest_hash = ?
+        """,
+        record.mediaType(),
+        record.artifactType(),
+        record.subjectDigest(),
+        record.subjectDigestHash(),
+        record.assetId(),
+        record.size(),
+        record.pushedBy(),
+        record.pushedByIp(),
+        jsonColumns.parameter(record.attributes()),
+        record.repositoryId(),
+        record.imageNameHash(),
+        record.digestHash());
+    return findManifestByDigest(record.repositoryId(), record.imageName(), record.digest())
+        .orElseThrow(() -> new DuplicateKeyException("Docker manifest conflict was not visible"));
   }
 
-  private long insertManifest(DockerManifestRecord record) {
-    return JdbcInserts.insert(jdbcTemplate, """
+  private OptionalLong tryInsertManifest(DockerManifestRecord record) {
+    return JdbcInserts.tryInsert(jdbcTemplate, """
         INSERT INTO docker_manifest
           (repository_id, image_name, image_name_hash, digest_algorithm, digest, digest_hash,
            media_type, artifact_type, subject_digest, subject_digest_hash, asset_id, size,

--- a/persistence-postgresql/src/test/java/com/github/klboke/kkrepo/persistence/postgresql/DockerRegistryDaoPostgreSqlIntegrationTest.java
+++ b/persistence-postgresql/src/test/java/com/github/klboke/kkrepo/persistence/postgresql/DockerRegistryDaoPostgreSqlIntegrationTest.java
@@ -1,0 +1,174 @@
+package com.github.klboke.kkrepo.persistence.postgresql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.persistence.jdbc.api.AssetDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.DockerRegistryDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.model.AssetRecord;
+import com.github.klboke.kkrepo.persistence.jdbc.api.model.docker.DockerManifestRecord;
+import com.github.klboke.kkrepo.persistence.jdbc.api.model.docker.DockerManifestReferenceRecord;
+import com.github.klboke.kkrepo.persistence.jdbc.api.model.docker.DockerTagRecord;
+import com.github.klboke.kkrepo.persistence.jdbc.internal.JdbcAssetDao;
+import com.github.klboke.kkrepo.persistence.jdbc.internal.JdbcDockerRegistryDao;
+import com.github.klboke.kkrepo.persistence.jdbc.internal.support.HashColumns;
+import com.github.klboke.kkrepo.persistence.postgresql.support.PostgreSqlIntegrationTestSupport;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.Test;
+
+class DockerRegistryDaoPostgreSqlIntegrationTest extends PostgreSqlIntegrationTestSupport {
+  private static final int CONCURRENT_WRITERS = 20;
+  private static final String IMAGE_NAME = "acme/app";
+  private static final String MANIFEST_DIGEST = "sha256:" + "a".repeat(64);
+  private static final String REFERENCE_DIGEST = "sha256:" + "b".repeat(64);
+
+  @Test
+  void concurrentManifestUpsertsKeepTransactionTagAndReferencesConsistent() throws Exception {
+    long repositoryId = insertRepository("docker-proxy", "docker");
+    AssetDao assetDao = new JdbcAssetDao(jdbc(), jsonColumns());
+    long assetId = assetDao.insertAsset(asset(repositoryId));
+    CyclicBarrier start = new CyclicBarrier(CONCURRENT_WRITERS);
+    List<Callable<Long>> writers = new ArrayList<>();
+    for (int i = 0; i < CONCURRENT_WRITERS; i++) {
+      writers.add(writer(repositoryId, assetId, start, i));
+    }
+
+    List<Long> manifestIds = new ArrayList<>();
+    try (var executor = Executors.newFixedThreadPool(CONCURRENT_WRITERS)) {
+      for (var future : executor.invokeAll(writers)) {
+        manifestIds.add(future.get());
+      }
+    }
+
+    assertEquals(CONCURRENT_WRITERS, manifestIds.size());
+    assertEquals(1, manifestIds.stream().distinct().count());
+    assertEquals(1, jdbc().queryForObject("SELECT COUNT(*) FROM docker_manifest", Integer.class));
+
+    DockerRegistryDao dao = new JdbcDockerRegistryDao(jdbc(), jsonColumns());
+    DockerManifestRecord manifest = dao.findManifestByDigest(
+        repositoryId, IMAGE_NAME, MANIFEST_DIGEST).orElseThrow();
+    assertEquals(manifest.id(), dao.findManifestByTag(
+        repositoryId, IMAGE_NAME, "latest").orElseThrow().id());
+    assertEquals(List.of(REFERENCE_DIGEST), dao.listReferences(manifest.id()).stream()
+        .map(DockerManifestReferenceRecord::digest)
+        .toList());
+  }
+
+  private Callable<Long> writer(
+      long repositoryId, long assetId, CyclicBarrier start, int writerIndex) {
+    return () -> {
+      start.await();
+      DockerRegistryDao dao = new JdbcDockerRegistryDao(jdbc(), jsonColumns());
+      return inTransaction(() -> {
+        DockerManifestRecord manifest = dao.upsertManifest(
+            manifest(repositoryId, assetId, writerIndex));
+        dao.replaceManifestReferences(manifest.id(), List.of(reference(repositoryId, manifest)));
+        dao.upsertTag(tag(repositoryId, manifest));
+
+        // These statements must remain usable after the expected PostgreSQL unique-key conflict.
+        assertEquals(manifest.id(), dao.findManifestByDigest(
+            repositoryId, IMAGE_NAME, MANIFEST_DIGEST).orElseThrow().id());
+        assertTrue(dao.findManifestByTag(repositoryId, IMAGE_NAME, "latest").isPresent());
+        return manifest.id();
+      });
+    };
+  }
+
+  private long insertRepository(String name, String format) {
+    jdbc().update("""
+        INSERT INTO blob_store (name, type, attributes_json)
+        VALUES (?, 'S3', CAST('{}' AS jsonb))
+        """, name + "-store");
+    long blobStoreId = jdbc().queryForObject(
+        "SELECT id FROM blob_store WHERE name = ?", Long.class, name + "-store");
+    jdbc().update("""
+        INSERT INTO repository
+          (name, format, type, recipe_name, blob_store_id, attributes_json)
+        VALUES (?, ?, 'proxy', ?, ?, CAST('{}' AS jsonb))
+        """, name, format, format + "-proxy", blobStoreId);
+    return jdbc().queryForObject(
+        "SELECT id FROM repository WHERE name = ?", Long.class, name);
+  }
+
+  private static AssetRecord asset(long repositoryId) {
+    String path = "docker/manifests/" + IMAGE_NAME + "/" + MANIFEST_DIGEST;
+    return new AssetRecord(
+        null,
+        repositoryId,
+        null,
+        null,
+        RepositoryFormat.DOCKER,
+        path,
+        HashColumns.pathHash(path),
+        "manifest.json",
+        "MANIFEST",
+        "application/vnd.oci.image.manifest.v1+json",
+        10L,
+        null,
+        Instant.parse("2026-01-01T00:00:00Z"),
+        Map.of());
+  }
+
+  private static DockerManifestRecord manifest(
+      long repositoryId, long assetId, int writerIndex) {
+    return new DockerManifestRecord(
+        null,
+        repositoryId,
+        IMAGE_NAME,
+        JdbcDockerRegistryDao.hash(IMAGE_NAME),
+        "sha256",
+        MANIFEST_DIGEST,
+        JdbcDockerRegistryDao.hash(MANIFEST_DIGEST),
+        "application/vnd.oci.image.manifest.v1+json",
+        null,
+        null,
+        null,
+        assetId,
+        10,
+        "writer-" + writerIndex,
+        "127.0.0.1",
+        null,
+        Map.of("source", "concurrency-test"),
+        null,
+        null);
+  }
+
+  private static DockerManifestReferenceRecord reference(
+      long repositoryId, DockerManifestRecord manifest) {
+    return new DockerManifestReferenceRecord(
+        null,
+        manifest.id(),
+        repositoryId,
+        IMAGE_NAME,
+        REFERENCE_DIGEST,
+        JdbcDockerRegistryDao.hash(REFERENCE_DIGEST),
+        "MANIFEST",
+        "application/vnd.oci.image.manifest.v1+json",
+        123L,
+        Map.of("os", "linux", "architecture", "amd64"),
+        Map.of());
+  }
+
+  private static DockerTagRecord tag(long repositoryId, DockerManifestRecord manifest) {
+    return new DockerTagRecord(
+        null,
+        repositoryId,
+        IMAGE_NAME,
+        JdbcDockerRegistryDao.hash(IMAGE_NAME),
+        "latest",
+        JdbcDockerRegistryDao.hash("latest"),
+        manifest.id(),
+        MANIFEST_DIGEST,
+        "concurrency-test",
+        "127.0.0.1",
+        null,
+        null);
+  }
+}


### PR DESCRIPTION
## Summary

- route Docker manifest inserts through the existing savepoint-aware JDBC duplicate recovery path
- preserve the update-on-conflict behavior and MySQL transaction semantics
- add a PostgreSQL 12 regression test with 20 concurrent writers using independent DAO instances
- verify all writers converge on one manifest row while tag and manifest references remain consistent

## Root cause

`JdbcDockerRegistryDao.upsertManifest` caught `DuplicateKeyException` after a direct insert and then issued an update. PostgreSQL had already marked the transaction as aborted, so that update failed with SQL state `25P02`.

The insert now uses `JdbcInserts.tryInsert`, which rolls an expected PostgreSQL unique-key violation back to a savepoint before the update path continues. MySQL keeps its existing no-savepoint path.

## Validation

- `mvn -pl persistence-mysql,persistence-postgresql -am test`
  - MySQL: 51 tests passed against MySQL 8.0
  - PostgreSQL: 26 tests passed against PostgreSQL 12
  - JDBC/core: 27 tests passed
- `mvn -pl server -am -Dtest=DockerManifestStoreTest,DockerProxyServiceTest -Dsurefire.failIfNoSpecifiedTests=false test`
  - 17 Docker service tests passed

Closes #119