### PR TITLE
Enforce add permission for new Docker manifests

### DIFF
--- a/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerAuthFilter.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerAuthFilter.java
@@ -23,6 +23,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpHeaders;
 import org.springframework.session.web.http.SessionRepositoryFilter;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Component
@@ -94,8 +95,7 @@ public class DockerAuthFilter extends OncePerRequestFilter {
       challenge(response, request, target, challengeActions);
       return;
     }
-    PermissionAction permission = permissionFor(
-        action, request.getMethod(), target.path(), runtime.get());
+    PermissionAction permission = permissionFor(action, target.path(), runtime.get(), request);
     if (permission != null && !accessDecisionService.decide(
         subject.get().permissionSubject(),
         new RepositoryPermission(
@@ -213,16 +213,37 @@ public class DockerAuthFilter extends OncePerRequestFilter {
   }
 
   private PermissionAction permissionFor(
-      String action, String method, DockerPath path, RepositoryRuntime runtime) {
+      String action, DockerPath path, RepositoryRuntime runtime, HttpServletRequest request) {
     if ("push".equals(action)) {
       if (path.kind() == DockerPath.Kind.MANIFEST) {
-        boolean exists = dockerRegistryDao.findManifestByReference(
-            runtime.id(), path.imageName(), path.reference()).isPresent();
-        return exists ? PermissionAction.EDIT : PermissionAction.ADD;
+        return allManifestReferencesExist(runtime, path, request)
+            ? PermissionAction.EDIT
+            : PermissionAction.ADD;
       }
       return PermissionAction.ADD;
     }
     return permissionFor(action);
+  }
+
+  private boolean allManifestReferencesExist(
+      RepositoryRuntime runtime, DockerPath path, HttpServletRequest request) {
+    if (dockerRegistryDao.findManifestByReference(
+        runtime.id(), path.imageName(), path.reference()).isEmpty()) {
+      return false;
+    }
+    String[] rawTags = request.getParameterValues("tag");
+    if (rawTags == null) {
+      return true;
+    }
+    for (String rawTag : rawTags) {
+      for (String tag : StringUtils.commaDelimitedListToStringArray(rawTag)) {
+        if (!tag.isBlank() && dockerRegistryDao.findManifestByReference(
+            runtime.id(), path.imageName(), tag).isEmpty()) {
+          return false;
+        }
+      }
+    }
+    return true;
   }
 
   private static String[] challengeActions(String action) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerAuthFilter.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerAuthFilter.java
@@ -4,6 +4,7 @@ import com.github.klboke.kkrepo.auth.AccessDecisionService;
 import com.github.klboke.kkrepo.auth.PermissionAction;
 import com.github.klboke.kkrepo.auth.RepositoryPermission;
 import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.persistence.jdbc.api.DockerRegistryDao;
 import com.github.klboke.kkrepo.protocol.docker.DockerConstants;
 import com.github.klboke.kkrepo.protocol.docker.DockerPath;
 import com.github.klboke.kkrepo.protocol.docker.DockerPathParser;
@@ -33,17 +34,20 @@ public class DockerAuthFilter extends OncePerRequestFilter {
   private final DockerAuthService authService;
   private final SecurityAuthenticationService authenticationService;
   private final AccessDecisionService accessDecisionService;
+  private final DockerRegistryDao dockerRegistryDao;
   private final DockerPathParser parser = new DockerPathParser();
 
   public DockerAuthFilter(
       RepositoryRuntimeRegistry registry,
       DockerAuthService authService,
       SecurityAuthenticationService authenticationService,
-      AccessDecisionService accessDecisionService) {
+      AccessDecisionService accessDecisionService,
+      DockerRegistryDao dockerRegistryDao) {
     this.registry = registry;
     this.authService = authService;
     this.authenticationService = authenticationService;
     this.accessDecisionService = accessDecisionService;
+    this.dockerRegistryDao = dockerRegistryDao;
   }
 
   @Override
@@ -90,7 +94,8 @@ public class DockerAuthFilter extends OncePerRequestFilter {
       challenge(response, request, target, challengeActions);
       return;
     }
-    PermissionAction permission = permissionFor(action, request.getMethod(), target.path());
+    PermissionAction permission = permissionFor(
+        action, request.getMethod(), target.path(), runtime.get());
     if (permission != null && !accessDecisionService.decide(
         subject.get().permissionSubject(),
         new RepositoryPermission(
@@ -207,11 +212,15 @@ public class DockerAuthFilter extends OncePerRequestFilter {
     };
   }
 
-  private static PermissionAction permissionFor(String action, String method, DockerPath path) {
+  private PermissionAction permissionFor(
+      String action, String method, DockerPath path, RepositoryRuntime runtime) {
     if ("push".equals(action)) {
-      return path.kind() == DockerPath.Kind.MANIFEST
-          ? PermissionAction.EDIT
-          : PermissionAction.ADD;
+      if (path.kind() == DockerPath.Kind.MANIFEST) {
+        boolean exists = dockerRegistryDao.findManifestByReference(
+            runtime.id(), path.imageName(), path.reference()).isPresent();
+        return exists ? PermissionAction.EDIT : PermissionAction.ADD;
+      }
+      return PermissionAction.ADD;
     }
     return permissionFor(action);
   }

--- a/server/src/test/java/com/github/klboke/kkrepo/server/docker/DockerAuthFilterTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/docker/DockerAuthFilterTest.java
@@ -305,6 +305,73 @@ class DockerAuthFilterTest {
   }
 
   @Test
+  void newQueryTagOnExistingManifestRequiresAddPermission() throws Exception {
+    RepositoryRuntime runtime = dockerProxy("docker-live-proxy");
+    when(registry.resolve("docker-live-proxy")).thenReturn(Optional.of(runtime));
+    when(dockerRegistryDao.findManifestByReference(65L, "library/alpine", "latest"))
+        .thenReturn(Optional.of(mock(DockerManifestRecord.class)));
+    when(authService.authenticateBearer(
+        "valid-token", "docker-live-proxy", "library/alpine", "push"))
+        .thenReturn(Optional.of(subject));
+    when(accessDecisionService.decide(
+        org.mockito.ArgumentMatchers.eq(permissionSubject), org.mockito.ArgumentMatchers.any()))
+        .thenReturn(AccessDecision.allow());
+    DockerAuthFilter filter = new DockerAuthFilter(
+        registry,
+        authService,
+        mock(SecurityAuthenticationService.class),
+        accessDecisionService,
+        dockerRegistryDao);
+    MockHttpServletRequest request =
+        new MockHttpServletRequest("PUT", "/v2/docker-live-proxy/library/alpine/manifests/latest");
+    request.addParameter("tag", "stable");
+    request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer valid-token");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    filter.doFilter(request, response, new MockFilterChain());
+
+    RepositoryPermission permission = capturedPermission();
+    assertEquals(PermissionAction.ADD, permission.action());
+    assertEquals("library/alpine", permission.pathPattern());
+  }
+
+  @Test
+  void existingQueryTagsOnExistingManifestRequireEditPermission() throws Exception {
+    RepositoryRuntime runtime = dockerProxy("docker-live-proxy");
+    when(registry.resolve("docker-live-proxy")).thenReturn(Optional.of(runtime));
+    DockerManifestRecord manifest = mock(DockerManifestRecord.class);
+    when(dockerRegistryDao.findManifestByReference(65L, "library/alpine", "latest"))
+        .thenReturn(Optional.of(manifest));
+    when(dockerRegistryDao.findManifestByReference(65L, "library/alpine", "stable"))
+        .thenReturn(Optional.of(manifest));
+    when(dockerRegistryDao.findManifestByReference(65L, "library/alpine", "1.0"))
+        .thenReturn(Optional.of(manifest));
+    when(authService.authenticateBearer(
+        "valid-token", "docker-live-proxy", "library/alpine", "push"))
+        .thenReturn(Optional.of(subject));
+    when(accessDecisionService.decide(
+        org.mockito.ArgumentMatchers.eq(permissionSubject), org.mockito.ArgumentMatchers.any()))
+        .thenReturn(AccessDecision.allow());
+    DockerAuthFilter filter = new DockerAuthFilter(
+        registry,
+        authService,
+        mock(SecurityAuthenticationService.class),
+        accessDecisionService,
+        dockerRegistryDao);
+    MockHttpServletRequest request =
+        new MockHttpServletRequest("PUT", "/v2/docker-live-proxy/library/alpine/manifests/latest");
+    request.addParameter("tag", "stable,1.0");
+    request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer valid-token");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    filter.doFilter(request, response, new MockFilterChain());
+
+    RepositoryPermission permission = capturedPermission();
+    assertEquals(PermissionAction.EDIT, permission.action());
+    assertEquals("library/alpine", permission.pathPattern());
+  }
+
+  @Test
   void catalogRequiresRepositoryAdminPermission() throws Exception {
     RepositoryRuntime runtime = dockerProxy("docker-live-proxy");
     when(registry.resolve("docker-live-proxy")).thenReturn(Optional.of(runtime));

--- a/server/src/test/java/com/github/klboke/kkrepo/server/docker/DockerAuthFilterTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/docker/DockerAuthFilterTest.java
@@ -14,6 +14,8 @@ import com.github.klboke.kkrepo.auth.PermissionSubject;
 import com.github.klboke.kkrepo.auth.RepositoryPermission;
 import com.github.klboke.kkrepo.core.RepositoryFormat;
 import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.jdbc.api.DockerRegistryDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.model.docker.DockerManifestRecord;
 import com.github.klboke.kkrepo.protocol.docker.DockerConstants;
 import com.github.klboke.kkrepo.protocol.docker.DockerErrorCode;
 import com.github.klboke.kkrepo.protocol.docker.DockerProtocolException;
@@ -39,6 +41,7 @@ class DockerAuthFilterTest {
   private DockerAuthService authService;
   private RepositoryRuntimeRegistry registry;
   private AccessDecisionService accessDecisionService;
+  private DockerRegistryDao dockerRegistryDao;
 
   @BeforeEach
   void setUp() {
@@ -53,6 +56,7 @@ class DockerAuthFilterTest {
     authService = mock(DockerAuthService.class);
     registry = mock(RepositoryRuntimeRegistry.class);
     accessDecisionService = mock(AccessDecisionService.class);
+    dockerRegistryDao = mock(DockerRegistryDao.class);
   }
 
   @Test
@@ -67,7 +71,8 @@ class DockerAuthFilterTest {
         registry,
         authService,
         authenticationService,
-        accessDecisionService);
+        accessDecisionService,
+        dockerRegistryDao);
     MockHttpServletRequest request = new MockHttpServletRequest("GET", "/v2/");
     request.setScheme("http");
     request.setServerName("127.0.0.1");
@@ -92,7 +97,8 @@ class DockerAuthFilterTest {
         registry,
         authService,
         mock(SecurityAuthenticationService.class),
-        accessDecisionService);
+        accessDecisionService,
+        dockerRegistryDao);
     MockHttpServletRequest request = new MockHttpServletRequest("GET", "/v2/");
     request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer base-token");
     MockHttpServletResponse response = new MockHttpServletResponse();
@@ -120,7 +126,7 @@ class DockerAuthFilterTest {
             + "service=\"127.0.0.1:18090\",scope=\"repository:docker-live-proxy/library/alpine:pull\"");
     SecurityAuthenticationService authenticationService = mock(SecurityAuthenticationService.class);
     DockerAuthFilter filter = new DockerAuthFilter(
-        registry, authService, authenticationService, accessDecisionService);
+        registry, authService, authenticationService, accessDecisionService, dockerRegistryDao);
     MockHttpServletRequest request =
         new MockHttpServletRequest("GET", "/v2/docker-live-proxy/library/alpine/manifests/latest");
     request.setScheme("http");
@@ -153,7 +159,7 @@ class DockerAuthFilterTest {
         .thenReturn("Bearer realm=\"http://127.0.0.1:18180/service/rest/v1/docker/token\","
             + "service=\"127.0.0.1:18180\",scope=\"repository:codex/alpine:pull\"");
     DockerAuthFilter filter = new DockerAuthFilter(
-        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService);
+        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService, dockerRegistryDao);
     MockHttpServletRequest request =
         new MockHttpServletRequest("GET", "/v2/codex/alpine/manifests/latest");
     request.setScheme("http");
@@ -181,7 +187,7 @@ class DockerAuthFilterTest {
     when(accessDecisionService.decide(org.mockito.ArgumentMatchers.eq(subject.permissionSubject()), org.mockito.ArgumentMatchers.any()))
         .thenReturn(AccessDecision.allow());
     DockerAuthFilter filter = new DockerAuthFilter(
-        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService);
+        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService, dockerRegistryDao);
     MockHttpServletRequest request =
         new MockHttpServletRequest("GET", "/v2/docker-live-proxy/library/alpine/manifests/latest");
     request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer valid-token");
@@ -206,7 +212,7 @@ class DockerAuthFilterTest {
         org.mockito.ArgumentMatchers.any()))
         .thenReturn(AccessDecision.allow());
     DockerAuthFilter filter = new DockerAuthFilter(
-        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService);
+        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService, dockerRegistryDao);
     MockHttpServletRequest request =
         new MockHttpServletRequest("POST", "/v2/docker-live-proxy/library/alpine/blobs/uploads/");
     request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer valid-token");
@@ -232,7 +238,7 @@ class DockerAuthFilterTest {
     when(accessDecisionService.decide(org.mockito.ArgumentMatchers.eq(permissionSubject), org.mockito.ArgumentMatchers.any()))
         .thenReturn(AccessDecision.allow());
     DockerAuthFilter filter = new DockerAuthFilter(
-        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService);
+        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService, dockerRegistryDao);
     MockHttpServletRequest request =
         new MockHttpServletRequest("POST", "/v2/docker-live-proxy/library/alpine/blobs/uploads/");
     request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer valid-token");
@@ -246,7 +252,7 @@ class DockerAuthFilterTest {
   }
 
   @Test
-  void manifestPutRequiresEditPermission() throws Exception {
+  void newManifestReferenceRequiresAddPermission() throws Exception {
     RepositoryRuntime runtime = dockerProxy("docker-live-proxy");
     when(registry.resolve("docker-live-proxy")).thenReturn(Optional.of(runtime));
     when(authService.authenticateBearer(
@@ -255,7 +261,37 @@ class DockerAuthFilterTest {
     when(accessDecisionService.decide(org.mockito.ArgumentMatchers.eq(permissionSubject), org.mockito.ArgumentMatchers.any()))
         .thenReturn(AccessDecision.allow());
     DockerAuthFilter filter = new DockerAuthFilter(
-        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService);
+        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService, dockerRegistryDao);
+    MockHttpServletRequest request =
+        new MockHttpServletRequest("PUT", "/v2/docker-live-proxy/library/alpine/manifests/latest");
+    request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer valid-token");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    filter.doFilter(request, response, new MockFilterChain());
+
+    RepositoryPermission permission = capturedPermission();
+    assertEquals(PermissionAction.ADD, permission.action());
+    assertEquals("library/alpine", permission.pathPattern());
+  }
+
+  @Test
+  void existingManifestReferenceRequiresEditPermission() throws Exception {
+    RepositoryRuntime runtime = dockerProxy("docker-live-proxy");
+    when(registry.resolve("docker-live-proxy")).thenReturn(Optional.of(runtime));
+    when(dockerRegistryDao.findManifestByReference(65L, "library/alpine", "latest"))
+        .thenReturn(Optional.of(mock(DockerManifestRecord.class)));
+    when(authService.authenticateBearer(
+        "valid-token", "docker-live-proxy", "library/alpine", "push"))
+        .thenReturn(Optional.of(subject));
+    when(accessDecisionService.decide(
+        org.mockito.ArgumentMatchers.eq(permissionSubject), org.mockito.ArgumentMatchers.any()))
+        .thenReturn(AccessDecision.allow());
+    DockerAuthFilter filter = new DockerAuthFilter(
+        registry,
+        authService,
+        mock(SecurityAuthenticationService.class),
+        accessDecisionService,
+        dockerRegistryDao);
     MockHttpServletRequest request =
         new MockHttpServletRequest("PUT", "/v2/docker-live-proxy/library/alpine/manifests/latest");
     request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer valid-token");
@@ -278,7 +314,7 @@ class DockerAuthFilterTest {
     when(accessDecisionService.decide(org.mockito.ArgumentMatchers.eq(permissionSubject), org.mockito.ArgumentMatchers.any()))
         .thenReturn(AccessDecision.allow());
     DockerAuthFilter filter = new DockerAuthFilter(
-        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService);
+        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService, dockerRegistryDao);
     MockHttpServletRequest request =
         new MockHttpServletRequest("GET", "/v2/docker-live-proxy/_catalog");
     request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer valid-token");
@@ -301,7 +337,7 @@ class DockerAuthFilterTest {
         .thenReturn("Bearer realm=\"http://127.0.0.1:18090/service/rest/v1/docker/token\","
             + "service=\"127.0.0.1:18090\",scope=\"registry:catalog:*\"");
     DockerAuthFilter filter = new DockerAuthFilter(
-        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService);
+        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService, dockerRegistryDao);
     MockHttpServletRequest request =
         new MockHttpServletRequest("GET", "/v2/docker-live-proxy/_catalog");
     request.setScheme("http");


### PR DESCRIPTION
## What changed

- Resolve the target Docker manifest reference before authorizing a push.
- Require `ADD` when a tag or digest reference is new, and `EDIT` when it already exists.
- Add regression coverage for both new and existing manifest references.

## Why

Manifest pushes previously always mapped to `EDIT`. That made creation and replacement share the same permission path even though the repository permission model distinguishes adding a new resource from editing an existing one.

## Impact

Users who only have edit permission can continue replacing existing manifest references, but cannot create new tags or digest references. Users with add permission can create new references as intended.

## Root cause

Authorization selected the permission solely from the Docker route kind and did not check whether the referenced manifest already existed.

## Validation

`mvn -pl server -am -Dtest=DockerAuthFilterTest -Dsurefire.failIfNoSpecifiedTests=false test`

Result: 13 tests passed; reactor build succeeded.
