### PR TITLE
Limit decompressed Helm chart metadata

### DIFF
--- a/protocol-helm/src/main/java/com/github/klboke/kkrepo/protocol/helm/HelmChartPackageParser.java
+++ b/protocol-helm/src/main/java/com/github/klboke/kkrepo/protocol/helm/HelmChartPackageParser.java
@@ -14,6 +14,7 @@ import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 public final class HelmChartPackageParser {
   private static final String CHART_YAML = "Chart.yaml";
+  private static final int MAX_CHART_YAML_BYTES = 1024 * 1024;
 
   public HelmChartMetadata parse(InputStream input) throws IOException {
     byte[] chartYaml = readChartYaml(input);
@@ -28,7 +29,10 @@ public final class HelmChartPackageParser {
 
   private static Yaml newYaml() {
     // Yaml retains mutable load state, while this parser is shared by singleton hosted services.
-    return new Yaml(new SafeConstructor(new LoaderOptions()));
+    LoaderOptions options = new LoaderOptions();
+    options.setCodePointLimit(MAX_CHART_YAML_BYTES);
+    options.setMaxAliasesForCollections(50);
+    return new Yaml(new SafeConstructor(options));
   }
 
   private byte[] readChartYaml(InputStream input) throws IOException {
@@ -56,11 +60,17 @@ public final class HelmChartPackageParser {
   }
 
   private static byte[] readCurrentEntry(TarArchiveInputStream tar) throws IOException {
-    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    ByteArrayOutputStream out = new ByteArrayOutputStream(8192);
     byte[] buffer = new byte[8192];
+    int total = 0;
     int n;
     while ((n = tar.read(buffer)) > 0) {
+      if (total > MAX_CHART_YAML_BYTES - n) {
+        throw new IllegalArgumentException(
+            CHART_YAML + " exceeds the " + MAX_CHART_YAML_BYTES + " byte limit");
+      }
       out.write(buffer, 0, n);
+      total += n;
     }
     return out.toByteArray();
   }

--- a/protocol-helm/src/test/java/com/github/klboke/kkrepo/protocol/helm/HelmProtocolTest.java
+++ b/protocol-helm/src/test/java/com/github/klboke/kkrepo/protocol/helm/HelmProtocolTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 class HelmProtocolTest {
   private static final int CONCURRENT_PARSE_COUNT = 32;
+  private static final int MAX_CHART_YAML_BYTES = 1024 * 1024;
 
   @Test
   void parsesChartYamlFromPackage() throws Exception {
@@ -62,6 +63,23 @@ class HelmProtocolTest {
         () -> new HelmChartPackageParser().parse(new ByteArrayInputStream(bytes)));
 
     assertEquals("Chart.yaml is not a YAML mapping", error.getMessage());
+  }
+
+  @Test
+  void rejectsChartYamlThatExceedsDecompressedSizeLimit() throws Exception {
+    String chartYaml = """
+        apiVersion: v2
+        name: demo
+        version: 1.2.3
+        #
+        """ + "x".repeat(MAX_CHART_YAML_BYTES);
+    byte[] bytes = chartPackageWithEntry("demo/Chart.yaml", chartYaml);
+    assertTrue(bytes.length < 16 * 1024, "Test package should remain highly compressed");
+
+    IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+        () -> new HelmChartPackageParser().parse(new ByteArrayInputStream(bytes)));
+
+    assertEquals("Chart.yaml exceeds the 1048576 byte limit", error.getMessage());
   }
 
   @Test


### PR DESCRIPTION
## What changed

- Cap decompressed `Chart.yaml` metadata at 1 MiB while streaming it from a Helm package.
- Apply the same code-point limit to SnakeYAML and retain a bounded alias setting.
- Add a regression test using a package that is small when compressed but expands beyond the metadata limit.

## Why

`Chart.yaml` was previously copied into an unbounded in-memory buffer before YAML parsing. A highly compressible metadata entry could therefore consume disproportionate heap during upload processing.

## Impact

Normal Helm chart metadata continues to parse unchanged. Packages whose decompressed `Chart.yaml` exceeds 1 MiB are rejected with a clear validation error before the full entry is buffered.

## Root cause

The archive reader streamed the complete entry into `ByteArrayOutputStream` without tracking decompressed bytes or coordinating the archive limit with the YAML parser limit.

## Validation

`mvn -pl protocol-helm -am -Dtest=HelmProtocolTest -Dsurefire.failIfNoSpecifiedTests=false test`

Result: 9 tests passed; reactor build succeeded.
