### PR TITLE
ci: limit Codecov statuses to pull requests

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    # Coverage is uploaded on main to keep the baseline current, but status
+    # checks should gate pull requests rather than post-merge commits.
+    project:
+      default:
+        only_pulls: true
+    patch:
+      default:
+        only_pulls: true


### PR DESCRIPTION
## What changed

- Add a root `codecov.yml` configuration.
- Keep Codecov project and patch status checks on pull requests only.
- Continue uploading coverage from `main` so the branch baseline remains current.

## Why

A documentation-only merge such as `338d391` can produce a failing `codecov/project` status on the resulting `main` commit when total coverage moves by a small amount due to report fluctuation. The PR checks were successful, but the post-merge commit status reported a `0.01%` project coverage drop.

This change removes the misleading post-merge status without making coverage informational on pull requests. PR coverage checks remain the gate for code changes.

## Validation

- Codecov configuration validator: passed
- Ruby YAML parse: passed
- `git diff --check`: passed
