### PR TITLE
chore: harden outbound proxy dependency and TLS coverage

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -37,6 +37,10 @@
       <artifactId>caffeine</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-devtools</artifactId>
       <optional>true</optional>
@@ -200,6 +204,12 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <version>${bouncycastle.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClient.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClient.java
@@ -24,6 +24,7 @@ import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -36,7 +37,7 @@ public class DockerRemoteRegistryClient {
 
   private final HttpRemoteFetcher fetcher;
   private final OutboundRequestPolicy outboundPolicy;
-  private final HttpClient tokenClient = HttpClient.newHttpClient();
+  private final HttpClient tokenClient;
   private final ProxiedHttpClientFactory proxyFactory;
   private final SharedCache tokenCache;
   private final boolean tokenCacheEnabled;
@@ -56,6 +57,26 @@ public class DockerRemoteRegistryClient {
       @Value("${kkrepo.docker.proxy.remote-token-cache.ttl-seconds:300}") long tokenCacheTtlSeconds,
       KkRepoMetrics metrics,
       ProxiedHttpClientFactory proxyFactory) {
+    this(
+        fetcher,
+        outboundPolicy,
+        tokenCache,
+        tokenCacheEnabled,
+        tokenCacheTtlSeconds,
+        metrics,
+        proxyFactory,
+        HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NEVER).build());
+  }
+
+  DockerRemoteRegistryClient(
+      HttpRemoteFetcher fetcher,
+      OutboundRequestPolicy outboundPolicy,
+      SharedCache tokenCache,
+      boolean tokenCacheEnabled,
+      long tokenCacheTtlSeconds,
+      KkRepoMetrics metrics,
+      ProxiedHttpClientFactory proxyFactory,
+      HttpClient tokenClient) {
     this.fetcher = fetcher;
     this.outboundPolicy = outboundPolicy;
     this.tokenCache = tokenCache;
@@ -63,6 +84,7 @@ public class DockerRemoteRegistryClient {
     this.tokenCacheTtl = tokenCacheTtlSeconds <= 0 ? Duration.ZERO : Duration.ofSeconds(tokenCacheTtlSeconds);
     this.metrics = metrics;
     this.proxyFactory = proxyFactory;
+    this.tokenClient = Objects.requireNonNull(tokenClient, "tokenClient");
   }
 
   public DockerRemoteRegistryClient(

--- a/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClient.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClient.java
@@ -98,20 +98,22 @@ public class DockerRemoteRegistryClient {
 
   public HttpRemoteFetcher.Result get(RepositoryRuntime runtime, String remotePath, String accept) throws IOException {
     String url = remoteUrl(runtime, remotePath);
-    HttpRemoteFetcher.Result result = fetch(url, runtime, null, accept);
-    if (result.status() == 401) {
+    RemoteFetch fetched = fetch(url, runtime, null, accept);
+    HttpRemoteFetcher.Result result = fetched.result();
+    if (result.status() == 401 && fetched.credentialsAllowed()) {
       String challenge = result.header("WWW-Authenticate");
       RemoteToken token = token(runtime, challenge).orElse(null);
-      result.close();
       if (token != null) {
-        result = fetch(url, runtime, token.value(), accept);
+        result.close();
+        fetched = fetch(fetched.effectiveUri().toString(), runtime, token.value(), accept);
+        result = fetched.result();
         if (result.status() == 401 && token.cached()) {
           evictToken(token.cacheKey());
           challenge = result.header("WWW-Authenticate");
           token = fetchToken(runtime, BearerChallenge.parse(challenge).orElse(null), true).orElse(null);
           if (token != null) {
             result.close();
-            result = fetch(url, runtime, token.value(), accept);
+            result = fetch(fetched.effectiveUri().toString(), runtime, token.value(), accept).result();
           }
         }
       }
@@ -119,12 +121,12 @@ public class DockerRemoteRegistryClient {
     return result;
   }
 
-  private HttpRemoteFetcher.Result fetch(
+  private RemoteFetch fetch(
       String url, RepositoryRuntime runtime, String bearerToken, String accept) throws IOException {
     return fetchWithHeaders(url, runtime, bearerToken, accept, 0, true);
   }
 
-  private HttpRemoteFetcher.Result fetchWithHeaders(
+  private RemoteFetch fetchWithHeaders(
       String url,
       RepositoryRuntime runtime,
       String bearerToken,
@@ -133,7 +135,7 @@ public class DockerRemoteRegistryClient {
     return fetchWithHeaders(url, runtime, bearerToken, accept, redirects, true);
   }
 
-  private HttpRemoteFetcher.Result fetchWithHeaders(
+  private RemoteFetch fetchWithHeaders(
       String url,
       RepositoryRuntime runtime,
       String bearerToken,
@@ -183,7 +185,10 @@ public class DockerRemoteRegistryClient {
       response.headers().map().forEach((k, v) -> {
         if (!v.isEmpty()) headers.put(k, v.get(0));
       });
-      return new HttpRemoteFetcher.Result(response.statusCode(), headers, response.body());
+      return new RemoteFetch(
+          new HttpRemoteFetcher.Result(response.statusCode(), headers, response.body()),
+          uri,
+          sendCredentials);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       IOException wrapped = new IOException("Interrupted fetching Docker remote " + url, e);
@@ -283,7 +288,7 @@ public class DockerRemoteRegistryClient {
   }
 
   /** Proxied counterpart of {@link #fetchWithHeaders} — same headers/redirect/metrics, via SOCKS/HTTP proxy. */
-  private HttpRemoteFetcher.Result proxiedFetchWithHeaders(
+  private RemoteFetch proxiedFetchWithHeaders(
       String url,
       RepositoryRuntime runtime,
       String bearerToken,
@@ -292,7 +297,7 @@ public class DockerRemoteRegistryClient {
     return proxiedFetchWithHeaders(url, runtime, bearerToken, accept, redirects, true);
   }
 
-  private HttpRemoteFetcher.Result proxiedFetchWithHeaders(
+  private RemoteFetch proxiedFetchWithHeaders(
       String url,
       RepositoryRuntime runtime,
       String bearerToken,
@@ -343,7 +348,10 @@ public class DockerRemoteRegistryClient {
             redirects + 1,
             forwardCredentials);
       }
-      return new HttpRemoteFetcher.Result(response.status(), response.headers(), releaseOnClose(response));
+      return new RemoteFetch(
+          new HttpRemoteFetcher.Result(response.status(), response.headers(), releaseOnClose(response)),
+          uri,
+          sendCredentials);
     } catch (IOException | RuntimeException e) {
       failure = e;
       if (response != null) {
@@ -612,6 +620,12 @@ public class DockerRemoteRegistryClient {
   }
 
   private record RemoteToken(String value, String cacheKey, boolean cached) {
+  }
+
+  private record RemoteFetch(
+      HttpRemoteFetcher.Result result,
+      URI effectiveUri,
+      boolean credentialsAllowed) {
   }
 
   private record BearerChallenge(String realm, String service, String scope) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClient.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClient.java
@@ -107,7 +107,7 @@ public class DockerRemoteRegistryClient {
         result.close();
         fetched = fetch(fetched.effectiveUri().toString(), runtime, token.value(), accept);
         result = fetched.result();
-        if (result.status() == 401 && token.cached()) {
+        if (result.status() == 401 && token.cached() && fetched.credentialsAllowed()) {
           evictToken(token.cacheKey());
           challenge = result.header("WWW-Authenticate");
           token = fetchToken(runtime, BearerChallenge.parse(challenge).orElse(null), true).orElse(null);

--- a/server/src/test/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClientTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClientTest.java
@@ -575,6 +575,82 @@ class DockerRemoteRegistryClientTest {
   }
 
   @Test
+  void cachedBearerTokenDoesNotHonorCrossOriginStorageChallenge() throws Exception {
+    try (TestRegistry registry = TestRegistry.start(); TestRegistry storage = TestRegistry.start()) {
+      AtomicInteger tokenCalls = new AtomicInteger();
+      AtomicInteger bearerCalls = new AtomicInteger();
+      List<String> storageAuthorizations = new ArrayList<>();
+      registry.server.createContext("/token", exchange -> {
+        tokenCalls.incrementAndGet();
+        byte[] body = "{\"token\":\"cached-remote-token\",\"expires_in\":3600}"
+            .getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, body.length);
+        exchange.getResponseBody().write(body);
+        exchange.close();
+      });
+      registry.server.createContext("/v2/library/alpine/manifests/latest", exchange -> {
+        String authorization = exchange.getRequestHeaders().getFirst("Authorization");
+        if (!"Bearer cached-remote-token".equals(authorization)) {
+          exchange.getResponseHeaders().add(
+              "WWW-Authenticate",
+              "Bearer realm=\"" + registry.baseUrl
+                  + "/token\",service=\"registry.local\",scope=\"repository:library/alpine:pull\"");
+          exchange.sendResponseHeaders(401, -1);
+        } else if (bearerCalls.incrementAndGet() == 1) {
+          byte[] body = "{}".getBytes(StandardCharsets.UTF_8);
+          exchange.getResponseHeaders().add("Content-Type", "application/json");
+          exchange.sendResponseHeaders(200, body.length);
+          exchange.getResponseBody().write(body);
+        } else {
+          exchange.getResponseHeaders().add("Location", storage.baseUrl + "/layers/abc");
+          exchange.sendResponseHeaders(307, -1);
+        }
+        exchange.close();
+      });
+      storage.server.createContext("/layers/abc", exchange -> {
+        storageAuthorizations.add(exchange.getRequestHeaders().getFirst("Authorization"));
+        exchange.getResponseHeaders().add(
+            "WWW-Authenticate",
+            "Bearer realm=\"" + storage.baseUrl + "/token\",service=\"storage.local\"");
+        exchange.sendResponseHeaders(401, -1);
+        exchange.close();
+      });
+      storage.server.createContext("/token", exchange -> {
+        tokenCalls.incrementAndGet();
+        byte[] body = "{\"token\":\"storage-token\"}".getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(200, body.length);
+        exchange.getResponseBody().write(body);
+        exchange.close();
+      });
+      DockerRemoteRegistryClient client = new DockerRemoteRegistryClient(
+          null,
+          OutboundRequestPolicy.allowPrivateForTests(),
+          new InMemorySharedCache(),
+          true,
+          300);
+      RepositoryRuntime runtime = runtime(registry.baseUrl, "robot", "secret");
+
+      try (HttpRemoteFetcher.Result result = client.get(
+          runtime,
+          "library/alpine/manifests/latest",
+          "application/json")) {
+        assertEquals(200, result.status());
+      }
+      try (HttpRemoteFetcher.Result result = client.get(
+          runtime,
+          "library/alpine/manifests/latest",
+          "application/json")) {
+        assertEquals(401, result.status());
+      }
+
+      assertEquals(Collections.singletonList(null), storageAuthorizations);
+      assertEquals(1, tokenCalls.get(),
+          "a cached Registry token must not let storage refresh credentials cross-origin");
+    }
+  }
+
+  @Test
   void remoteFetchRecordsDockerProxyRemoteMetrics() throws Exception {
     try (TestRegistry registry = TestRegistry.start()) {
       registry.server.createContext("/v2/library/alpine/manifests/latest", exchange -> {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClientTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClientTest.java
@@ -15,18 +15,43 @@ import com.github.klboke.kkrepo.server.proxy.ProxiedHttpClientFactory;
 import com.github.klboke.kkrepo.server.security.OutboundRequestPolicy;
 import com.github.klboke.kkrepo.server.support.FakeHttpProxyServer;
 import com.github.klboke.kkrepo.server.support.InMemorySharedCache;
+import com.sun.net.httpserver.HttpsConfigurator;
+import com.sun.net.httpserver.HttpsServer;
 import com.sun.net.httpserver.HttpServer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
+import java.math.BigInteger;
 import java.net.InetSocketAddress;
+import java.net.ProxySelector;
+import java.net.URI;
 import java.net.URLDecoder;
+import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.SecureRandom;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.junit.jupiter.api.Test;
 
 class DockerRemoteRegistryClientTest {
@@ -266,6 +291,84 @@ class DockerRemoteRegistryClientTest {
     assertTrue(DockerRemoteRegistryClient.sameOrigin(
         java.net.URI.create("https://registry.example.com/v2/a/b"),
         java.net.URI.create("https://registry.example.com:443/v2/a/b")));
+  }
+
+  @Test
+  void httpToHttpsUpgradePreservesBasicAndBearerCredentialsOverTls() throws Exception {
+    List<String> manifestAuthorizations = new ArrayList<>();
+    List<String> tokenAuthorizations = new ArrayList<>();
+    // Keep the Docker URLs on their real default ports so the redirect exercises the production
+    // 80-to-443 origin rule. This loopback router only maps those connections to an ephemeral TLS
+    // listener; the RepositoryRuntime itself has no outbound proxy, so the direct client path runs.
+    try (TestTlsRegistry registry = TestTlsRegistry.start();
+        FakeHttpProxyServer router = FakeHttpProxyServer.startTunneling(request -> {
+          URI target = URI.create(request.target());
+          String location = "https://localhost" + target.getRawPath()
+              + (target.getRawQuery() == null ? "" : "?" + target.getRawQuery());
+          return FakeHttpProxyServer.FakeResponse.status(307, Map.of("Location", location));
+        }, request -> new InetSocketAddress("127.0.0.1", registry.port()))) {
+      registry.server.createContext("/token", exchange -> {
+        tokenAuthorizations.add(exchange.getRequestHeaders().getFirst("Authorization"));
+        byte[] body = "{\"token\":\"tls-token\"}".getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.getResponseHeaders().add("Connection", "close");
+        exchange.sendResponseHeaders(200, body.length);
+        exchange.getResponseBody().write(body);
+        exchange.close();
+      });
+      registry.server.createContext("/v2/library/alpine/manifests/latest", exchange -> {
+        String authorization = exchange.getRequestHeaders().getFirst("Authorization");
+        manifestAuthorizations.add(authorization);
+        exchange.getResponseHeaders().add("Connection", "close");
+        if (!"Bearer tls-token".equals(authorization)) {
+          exchange.getResponseHeaders().add(
+              "WWW-Authenticate",
+              "Bearer realm=\"https://localhost/token\",service=\"registry.local\",scope=\"repository:library/alpine:pull\"");
+          exchange.sendResponseHeaders(401, -1);
+        } else {
+          byte[] body = "{}".getBytes(StandardCharsets.UTF_8);
+          exchange.getResponseHeaders().add("Content-Type", "application/json");
+          exchange.sendResponseHeaders(200, body.length);
+          exchange.getResponseBody().write(body);
+        }
+        exchange.close();
+      });
+      HttpClient tlsClient = HttpClient.newBuilder()
+          .followRedirects(HttpClient.Redirect.NEVER)
+          .proxy(ProxySelector.of(new InetSocketAddress("127.0.0.1", router.port())))
+          .sslContext(registry.clientSslContext)
+          .build();
+      DockerRemoteRegistryClient client = new DockerRemoteRegistryClient(
+          null,
+          OutboundRequestPolicy.allowPrivateForTests(),
+          null,
+          true,
+          300,
+          null,
+          null,
+          tlsClient);
+
+      try (HttpRemoteFetcher.Result result = client.get(
+          runtime("http://localhost", "robot", "secret"),
+          "library/alpine/manifests/latest",
+          "application/json")) {
+        assertEquals(200, result.status());
+      }
+
+      List<String> plainHttpAuthorizations = router.requests().stream()
+          .filter(request -> "GET".equals(request.method()))
+          .map(request -> request.header("Authorization"))
+          .toList();
+      assertEquals(List.of(basic("robot", "secret"), "Bearer tls-token"), plainHttpAuthorizations);
+      assertEquals(List.of(basic("robot", "secret"), "Bearer tls-token"), manifestAuthorizations);
+      assertEquals(List.of(basic("robot", "secret")), tokenAuthorizations);
+      List<FakeHttpProxyServer.RecordedRequest> connectRequests = router.requests().stream()
+          .filter(request -> "CONNECT".equals(request.method()))
+          .toList();
+      assertFalse(connectRequests.isEmpty());
+      assertTrue(connectRequests.stream()
+          .allMatch(request -> "localhost:443".equals(request.target())));
+    }
   }
 
   @Test
@@ -715,6 +818,78 @@ class DockerRemoteRegistryClientTest {
       HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
       server.start();
       return new TestRegistry(server);
+    }
+
+    @Override
+    public void close() {
+      server.stop(0);
+    }
+  }
+
+  private static final class TestTlsRegistry implements AutoCloseable {
+    private static final char[] KEY_PASSWORD = "test-password".toCharArray();
+
+    private final HttpsServer server;
+    private final SSLContext clientSslContext;
+
+    private TestTlsRegistry(HttpsServer server, SSLContext clientSslContext) {
+      this.server = server;
+      this.clientSslContext = clientSslContext;
+    }
+
+    static TestTlsRegistry start() throws Exception {
+      SecureRandom random = new SecureRandom();
+      KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+      keyPairGenerator.initialize(2048, random);
+      KeyPair keyPair = keyPairGenerator.generateKeyPair();
+
+      Instant now = Instant.now();
+      X500Name subject = new X500Name("CN=localhost");
+      JcaX509v3CertificateBuilder certificateBuilder = new JcaX509v3CertificateBuilder(
+          subject,
+          new BigInteger(128, random).setBit(127),
+          Date.from(now.minusSeconds(60)),
+          Date.from(now.plusSeconds(86400)),
+          subject,
+          keyPair.getPublic());
+      certificateBuilder.addExtension(
+          Extension.subjectAlternativeName,
+          false,
+          new GeneralNames(new GeneralName(GeneralName.dNSName, "localhost")));
+      ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
+          .build(keyPair.getPrivate());
+      X509Certificate certificate = new JcaX509CertificateConverter()
+          .getCertificate(certificateBuilder.build(signer));
+      certificate.verify(keyPair.getPublic());
+
+      KeyStore keyStore = KeyStore.getInstance("PKCS12");
+      keyStore.load(null, KEY_PASSWORD);
+      keyStore.setKeyEntry(
+          "server",
+          keyPair.getPrivate(),
+          KEY_PASSWORD,
+          new Certificate[] {certificate});
+      KeyManagerFactory keyManagers = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+      keyManagers.init(keyStore, KEY_PASSWORD);
+
+      SSLContext serverContext = SSLContext.getInstance("TLS");
+      serverContext.init(keyManagers.getKeyManagers(), null, random);
+      HttpsServer server = HttpsServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+      server.setHttpsConfigurator(new HttpsConfigurator(serverContext));
+      server.start();
+
+      KeyStore trustStore = KeyStore.getInstance("PKCS12");
+      trustStore.load(null, null);
+      trustStore.setCertificateEntry("server", certificate);
+      TrustManagerFactory trustManagers = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+      trustManagers.init(trustStore);
+      SSLContext clientContext = SSLContext.getInstance("TLS");
+      clientContext.init(null, trustManagers.getTrustManagers(), random);
+      return new TestTlsRegistry(server, clientContext);
+    }
+
+    int port() {
+      return server.getAddress().getPort();
     }
 
     @Override

--- a/server/src/test/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClientTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClientTest.java
@@ -359,7 +359,8 @@ class DockerRemoteRegistryClientTest {
           .filter(request -> "GET".equals(request.method()))
           .map(request -> request.header("Authorization"))
           .toList();
-      assertEquals(List.of(basic("robot", "secret"), "Bearer tls-token"), plainHttpAuthorizations);
+      assertEquals(List.of(basic("robot", "secret")), plainHttpAuthorizations,
+          "the bearer token must retry directly on the upgraded HTTPS URL");
       assertEquals(List.of(basic("robot", "secret"), "Bearer tls-token"), manifestAuthorizations);
       assertEquals(List.of(basic("robot", "secret")), tokenAuthorizations);
       List<FakeHttpProxyServer.RecordedRequest> connectRequests = router.requests().stream()
@@ -432,6 +433,46 @@ class DockerRemoteRegistryClientTest {
 
       assertEquals(List.of(basic("robot", "secret")), registryAuthorizations);
       assertEquals(Collections.singletonList(null), storageAuthorizations);
+    }
+  }
+
+  @Test
+  void crossOriginRedirectDoesNotHonorStorageBearerChallenge() throws Exception {
+    try (TestRegistry registry = TestRegistry.start(); TestRegistry storage = TestRegistry.start()) {
+      List<String> storageAuthorizations = new ArrayList<>();
+      AtomicInteger storageTokenCalls = new AtomicInteger();
+      registry.server.createContext("/v2/library/nginx/blobs/sha256:abc", exchange -> {
+        exchange.getResponseHeaders().add("Location", storage.baseUrl + "/layers/abc");
+        exchange.sendResponseHeaders(307, -1);
+        exchange.close();
+      });
+      storage.server.createContext("/layers/abc", exchange -> {
+        storageAuthorizations.add(exchange.getRequestHeaders().getFirst("Authorization"));
+        exchange.getResponseHeaders().add(
+            "WWW-Authenticate",
+            "Bearer realm=\"" + storage.baseUrl + "/token\",service=\"storage.local\"");
+        exchange.sendResponseHeaders(401, -1);
+        exchange.close();
+      });
+      storage.server.createContext("/token", exchange -> {
+        storageTokenCalls.incrementAndGet();
+        byte[] body = "{\"token\":\"storage-token\"}".getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(200, body.length);
+        exchange.getResponseBody().write(body);
+        exchange.close();
+      });
+      DockerRemoteRegistryClient client = client();
+
+      try (HttpRemoteFetcher.Result result = client.get(
+          runtime(registry.baseUrl, "robot", "secret"),
+          "library/nginx/blobs/sha256:abc",
+          "application/octet-stream")) {
+        assertEquals(401, result.status());
+      }
+
+      assertEquals(Collections.singletonList(null), storageAuthorizations);
+      assertEquals(0, storageTokenCalls.get(),
+          "a cross-origin storage challenge must not trigger a Registry credential exchange");
     }
   }
 

--- a/server/src/test/java/com/github/klboke/kkrepo/server/support/FakeHttpProxyServer.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/support/FakeHttpProxyServer.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
@@ -18,8 +19,10 @@ import java.util.concurrent.CopyOnWriteArrayList;
 /**
  * In-process fake HTTP proxy for tests. Records every request it receives (request line in
  * absolute or CONNECT form plus headers) and answers plain-HTTP requests through a
- * {@link Responder}. CONNECT requests get a canned "200 Connection established" and the tunnel is
- * then dropped, which is enough to assert that HTTPS targets are tunnelled via CONNECT.
+ * {@link Responder}. By default, CONNECT requests get a canned "200 Connection established" and
+ * the tunnel is then dropped, which is enough to assert that HTTPS targets use CONNECT. Tests that
+ * need a real TLS exchange can provide a {@link ConnectTargetResolver} to relay the tunnel to a
+ * loopback TLS server.
  */
 public final class FakeHttpProxyServer implements AutoCloseable {
 
@@ -51,13 +54,22 @@ public final class FakeHttpProxyServer implements AutoCloseable {
     FakeResponse respond(RecordedRequest request) throws IOException;
   }
 
+  @FunctionalInterface
+  public interface ConnectTargetResolver {
+    InetSocketAddress resolve(RecordedRequest request) throws IOException;
+  }
+
   private final ServerSocket serverSocket;
   private final Responder responder;
+  private final ConnectTargetResolver connectTargetResolver;
   private final List<RecordedRequest> requests = new CopyOnWriteArrayList<>();
   private volatile boolean running = true;
 
-  private FakeHttpProxyServer(Responder responder) throws IOException {
+  private FakeHttpProxyServer(
+      Responder responder,
+      ConnectTargetResolver connectTargetResolver) throws IOException {
     this.responder = responder;
+    this.connectTargetResolver = connectTargetResolver;
     this.serverSocket = new ServerSocket(0, 50, InetAddress.getByName("127.0.0.1"));
     Thread acceptor = new Thread(this::acceptLoop, "fake-http-proxy-accept");
     acceptor.setDaemon(true);
@@ -65,7 +77,13 @@ public final class FakeHttpProxyServer implements AutoCloseable {
   }
 
   public static FakeHttpProxyServer start(Responder responder) throws IOException {
-    return new FakeHttpProxyServer(responder);
+    return new FakeHttpProxyServer(responder, null);
+  }
+
+  public static FakeHttpProxyServer startTunneling(
+      Responder responder,
+      ConnectTargetResolver connectTargetResolver) throws IOException {
+    return new FakeHttpProxyServer(responder, connectTargetResolver);
   }
 
   public int port() {
@@ -109,6 +127,10 @@ public final class FakeHttpProxyServer implements AutoCloseable {
       requests.add(request);
       OutputStream out = socket.getOutputStream();
       if ("CONNECT".equalsIgnoreCase(request.method())) {
+        if (connectTargetResolver != null) {
+          tunnel(socket, in, out, connectTargetResolver.resolve(request));
+          return;
+        }
         out.write("HTTP/1.1 200 Connection established\r\n\r\n".getBytes(StandardCharsets.ISO_8859_1));
         out.flush();
         drainBriefly(in);
@@ -133,6 +155,53 @@ public final class FakeHttpProxyServer implements AutoCloseable {
       out.write(head.toString().getBytes(StandardCharsets.ISO_8859_1));
       out.write(body);
       out.flush();
+    } catch (IOException ignored) {
+    }
+  }
+
+  private static void tunnel(
+      Socket client,
+      InputStream clientIn,
+      OutputStream clientOut,
+      InetSocketAddress target) throws IOException {
+    try (Socket upstream = new Socket()) {
+      upstream.connect(target, 10000);
+      clientOut.write("HTTP/1.1 200 Connection established\r\n\r\n"
+          .getBytes(StandardCharsets.ISO_8859_1));
+      clientOut.flush();
+
+      Thread requestPipe = new Thread(
+          () -> transfer(clientIn, upstream),
+          "fake-http-proxy-client-to-upstream");
+      requestPipe.setDaemon(true);
+      requestPipe.start();
+      transfer(upstream.getInputStream(), clientOut);
+      try {
+        requestPipe.join(1000);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    } finally {
+      client.close();
+    }
+  }
+
+  private static void transfer(InputStream in, Socket target) {
+    try {
+      transfer(in, target.getOutputStream());
+      target.shutdownOutput();
+    } catch (IOException ignored) {
+    }
+  }
+
+  private static void transfer(InputStream in, OutputStream out) {
+    byte[] buffer = new byte[8192];
+    try {
+      int read;
+      while ((read = in.read(buffer)) >= 0) {
+        out.write(buffer, 0, read);
+        out.flush();
+      }
     } catch (IOException ignored) {
     }
   }


### PR DESCRIPTION
## Summary

- declare Apache HttpClient 5 as a direct `kkrepo-server` dependency while keeping its version managed by the Spring Boot BOM
- make the Docker remote HTTP client injectable for hermetic TLS testing
- extend the in-process HTTP proxy test support with an optional real CONNECT tunnel
- add a real TLS regression covering Docker Basic authentication, bearer-token exchange, and credential forwarding across a same-host HTTP-to-HTTPS upgrade
- retain the effective HTTPS URL after a Registry challenge so bearer retries never return to the clear-text HTTP hop
- ignore bearer challenges from cross-origin redirect targets where Registry credentials are no longer allowed, including cached-token refreshes

## Why

This follows up on the non-blocking recommendations from #134 and the security review on this PR. The server previously compiled through a transitive HttpClient 5 dependency from the Alibaba OSS SDK, and the Docker redirect coverage verified origin classification without completing a real TLS exchange. The first TLS regression also exposed that a newly issued bearer token was retried from the original HTTP URL before upgrading again.

This PR makes dependency ownership explicit, closes the end-to-end TLS coverage gap, and keeps bearer retries on the already validated HTTPS endpoint.

## Impact

Automatic redirects remain disabled so the manual redirect policy stays authoritative. After a credential-preserving HTTP-to-HTTPS upgrade, Docker bearer retries now start directly from the effective HTTPS URL. Cross-origin redirect targets still receive no Registry credentials and cannot initiate a Registry bearer-token exchange, including after a cached token is rejected.

The additional CONNECT relay and certificate generation are test-only.

## Validation

- `mvn -pl server -am -DskipTests clean compile`
- `mvn -pl server -am -DskipTests dependency:tree '-Dincludes=org.apache.httpcomponents.client5:httpclient5'`
- `mvn -pl server -am -Dtest=DockerRemoteRegistryClientTest,ProxiedHttpClientFactoryTest -Dsurefire.failIfNoSpecifiedTests=false test` — 39 tests, 0 failures/errors/skips
- `git diff --check`
