### PR TITLE
Release kkRepo 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable public changes to kkrepo are documented in this file.
 
 This project follows a pragmatic early-stage release process. Until a stable `1.0.0` release is announced, minor versions may include behavior changes, but releases should call out migration impact, compatibility changes, and operational notes.
 
+## 0.5.0 - 2026-07-18
+
+### Added
+
+- Nexus-compatible Terraform module and provider repositories with hosted, proxy, and group recipes, official discovery endpoints, checksums and detached PGP signatures, archive validation, component upload, Browse/Search/Admin integration, metrics, and Nexus migration support. (#124)
+- Swift Package Registry v1 hosted, GitHub-backed proxy, and group repositories with immutable signed publication, manifests, range and cache behavior, identifier lookup, proxy pinning, Browse/Search/Admin integration, cleanup and rebuild workers, and Nexus migration support. (#128)
+- Per-repository outbound HTTP and SOCKS5 proxy settings for proxy repositories, including optional credentials, Admin UI configuration, isolated client state, redirect and SSRF controls, and support across shared remote fetch paths and Docker registry authentication flows. (#134, #136)
+- A main-merge development deployment workflow for the executable Java 25 jar with health verification, retained releases, and automatic rollback while PostgreSQL and Nginx remain containerized. (#121)
+
+### Changed
+
+- MySQL and PostgreSQL now include equivalent V30-V33 migrations for Terraform registry state and Swift release, manifest, proxy inventory, lease, cache, and group-binding state. (#124, #128)
+- Quickstart defaults, Dockerfile packaging, deployment documentation, and the Helm application version now use `0.5.0`.
+- Repository permission documentation now defines actions by protocol route and operation, including protocol-specific behavior for Cargo, Pub, Swift, Terraform, and Docker. (#132)
+- Pull requests remain gated by Codecov project and patch checks, while main-branch coverage uploads update the baseline without publishing misleading post-merge statuses. (#133)
+- Bouncy Castle OpenPGP support was updated to `bcpg-jdk18on` 1.84. (#126)
+
+### Fixed
+
+- PostgreSQL duplicate asset inserts and concurrent Docker manifest upserts now roll expected unique-key conflicts back to transaction savepoints before continuing, while preserving MySQL transaction behavior and database-backed cross-replica coordination. (#117, #122)
+- Helm chart parsing is safe under concurrent uploads, and decompressed `Chart.yaml` metadata is capped at 1 MiB before YAML parsing to prevent disproportionate heap use. (#120, #130)
+- Docker proxy redirects keep repository credentials on same-origin HTTP-to-HTTPS upgrades, drop them for cross-origin targets, and keep bearer-token retries on the validated HTTPS endpoint. (#136)
+
+### Compatibility And Validation
+
+- Terraform coverage includes official CLI 0.13 and current releases, Nexus 3.92 black-box behavior, hosted and proxy/group resolution, signing continuity, multi-replica coordination, and native proxy-cache migration. (#124)
+- Swift coverage includes Nexus 3.94 comparisons, SwiftPM 5.7, 5.10, and 6.x clients, platform-specific lanes, S3-compatible dual-replica resilience, backup/restore, and H2/PostgreSQL source migration. (#128)
+- HTTP and SOCKS5 outbound proxy behavior includes authenticated and anonymous isolation, timeout, redirect, TLS, Docker Basic and bearer exchange, and credential-forwarding regressions. (#134, #136)
+- Existing Maven, npm, PyPI, Go, Helm, Cargo/Rust, Dart/Pub, Composer/PHP, Docker/OCI, NuGet, RubyGems, Yum, and Raw compatibility paths remain covered by the reactor and live compatibility workflows.
+
+### Upgrade Notes
+
+- Existing `0.4.0` MySQL and PostgreSQL deployments can upgrade in place through Flyway V30-V33. Back up the database and blob store together before upgrading production deployments.
+- Terraform and Swift add shared relational coordination and metadata state while keeping artifact blobs behind the configured OSS/S3 storage abstraction. Do not run mixed application versions against a database after the new migrations are applied.
+- Validate Terraform signing and proxy/group resolution, Swift publication and migration policy, and any authenticated outbound proxy configuration in staging before enabling the new formats or network path in production.
+
 ## 0.4.0 - 2026-07-14
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:25-jre-jammy
 
 WORKDIR /app
 
-ARG JAR_FILE=server/target/kkrepo-server-0.4.0.jar
+ARG JAR_FILE=server/target/kkrepo-server-0.5.0.jar
 
 RUN groupadd --system kkrepo \
     && useradd --system --gid kkrepo --home-dir /app --shell /usr/sbin/nologin kkrepo

--- a/deploy/helm/kkrepo/Chart.yaml
+++ b/deploy/helm/kkrepo/Chart.yaml
@@ -3,5 +3,5 @@ name: kkrepo
 description: Multi-replica kkRepo artifact repository with an external MySQL or PostgreSQL database
 type: application
 version: 0.1.0
-appVersion: "0.4.0"
+appVersion: "0.5.0"
 kubeVersion: ">=1.27.0-0"

--- a/docker-compose.quickstart-postgresql.yml
+++ b/docker-compose.quickstart-postgresql.yml
@@ -25,7 +25,7 @@ services:
     command: ["sh", "-c", "mkdir -p /data/blobs && chown -R 999:999 /data"]
 
   kkrepo:
-    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.4.0}
+    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.5.0}
     depends_on:
       postgresql:
         condition: service_healthy

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -26,7 +26,7 @@ services:
     command: ["sh", "-c", "mkdir -p /data/blobs && chown -R 999:999 /data"]
 
   kkrepo:
-    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.4.0}
+    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.5.0}
     depends_on:
       mysql:
         condition: service_healthy

--- a/docs/en/build-deployment-guide.md
+++ b/docs/en/build-deployment-guide.md
@@ -45,7 +45,7 @@ bash quickstart.sh
 
 By default, it starts:
 
-- `ghcr.io/klboke/kkrepo:0.4.0`
+- `ghcr.io/klboke/kkrepo:0.5.0`
 - MySQL 8.0
 - Persistent MySQL and File blob storage volumes for local trials
 
@@ -137,7 +137,7 @@ Note: a normal `server` module jar does not contain a Spring Boot executable ent
 Pull the latest public release image:
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:0.4.0
+docker pull ghcr.io/klboke/kkrepo:0.5.0
 ```
 
 You can also use `latest` to follow the latest public release:

--- a/docs/zh/build-deployment-guide.md
+++ b/docs/zh/build-deployment-guide.md
@@ -45,7 +45,7 @@ bash quickstart.sh
 
 默认会启动：
 
-- `ghcr.io/klboke/kkrepo:0.4.0`
+- `ghcr.io/klboke/kkrepo:0.5.0`
 - MySQL 8.0
 - 用于本地试用的持久化 MySQL volume 和 File blob storage volume
 
@@ -137,7 +137,7 @@ server/target/kkrepo-server-<version>.jar
 拉取最新公开发行镜像：
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:0.4.0
+docker pull ghcr.io/klboke/kkrepo:0.5.0
 ```
 
 也可以使用 `latest` 跟随最新公开发行版本：

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
   </modules>
 
   <properties>
-    <revision>0.4.0</revision>
+    <revision>0.5.0</revision>
     <java.version>25</java.version>
     <spring.boot.version>4.1.0</spring.boot.version>
     <apollo.client.version>2.5.0</apollo.client.version>

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -211,7 +211,7 @@ if [[ -f .env ]]; then
   load_env_file_defaults .env
 fi
 
-: "${KKREPO_IMAGE_TAG:=0.4.0}"
+: "${KKREPO_IMAGE_TAG:=0.5.0}"
 : "${KKREPO_HTTP_PORT:=19090}"
 : "${KKREPO_MANAGEMENT_PORT:=19091}"
 : "${KKREPO_PROJECT_NAME:=kkrepo-quickstart}"


### PR DESCRIPTION
## Summary

- bump the Maven project, container, quickstart, Helm, and deployment-guide references from `0.4.0` to `0.5.0`
- add the `0.5.0` changelog for Terraform and Swift registries, per-repository outbound proxies, deployment improvements, and concurrency/security fixes
- document the MySQL/PostgreSQL V30–V33 upgrade path and mixed-version rollout considerations

## Release highlights

- Terraform hosted, proxy, and group repositories
- Swift Package Registry hosted, GitHub proxy, and group repositories
- per-repository HTTP/HTTPS and SOCKS5 outbound proxy support
- PostgreSQL asset/Docker manifest concurrency fixes
- Helm concurrency and decompression-limit hardening
- authenticated Docker blob redirects and outbound TLS regression coverage

## Validation

- `mvn -B -ntp -pl server -am -Dsurefire.failIfNoSpecifiedTests=false verify`
  - full reactor passed
  - server: 1,281 tests
  - MySQL persistence: 58 tests
  - PostgreSQL persistence: 32 tests
- `mvn -B -ntp -pl compat-test -am -Dtest=MavenMetadataMergeCompatibilityTest,MavenWritePolicyCompatibilityTest,NpmProtocolCompatibilityTest -Dsurefire.failIfNoSpecifiedTests=false verify`
  - 16 non-live compatibility tests passed
- both quickstart Compose files pass `docker compose config`
- `helm lint deploy/helm/kkrepo` passed
- `bash -n scripts/quickstart.sh` passed
- executable Spring Boot JAR verified after `spring-boot:repackage`
- `scripts/build-dist.sh` produced the `0.5.0` tar.gz and zip archives
- `scripts/build-docker-image.sh kkrepo:0.5.0-release-candidate` succeeded

## CI

The PR is intended to run the standard PR checks plus every opt-in suite:

- Docker/OCI conformance
- migration E2E
- client E2E
- live Nexus compatibility
