### PR TITLE
Fix CodeQL SSRF findings with DNS-pinned outbound requests

### DIFF
--- a/server/src/dist/conf/application.properties
+++ b/server/src/dist/conf/application.properties
@@ -138,7 +138,7 @@ kkrepo.catalog-cache.jdbc.initial-jitter-ms=100
 
 kkrepo.proxy.negative-cache.enabled=true
 kkrepo.proxy.negative-cache.ttl-minutes=5
-# Supported values are Java HttpClient versions such as HTTP_1_1 and HTTP_2.
+# DNS-pinned outbound connections currently use HTTP/1.1. HTTP_2 logs a downgrade warning.
 kkrepo.proxy.remote-http-version=HTTP_1_1
 kkrepo.proxy.search-timeout-seconds=30
 kkrepo.proxy.metadata-timeout-seconds=60

--- a/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClient.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClient.java
@@ -310,7 +310,9 @@ public class DockerRemoteRegistryClient {
     boolean recorded = false;
     ProxiedHttpClientFactory.ProxiedResponse response = null;
     try {
-      URI uri = outboundPolicy.validateHttpUri(url, "docker remote fetch");
+      OutboundRequestPolicy.ResolvedHttpTarget target =
+          outboundPolicy.resolveHttpTarget(url, "docker remote fetch");
+      URI uri = target.uri();
       Map<String, String> headers = new LinkedHashMap<>();
       headers.put("User-Agent", "kkrepo/0.1");
       headers.put("Accept", accept == null || accept.isBlank() ? "*/*" : accept);
@@ -323,7 +325,7 @@ public class DockerRemoteRegistryClient {
           runtime.name(),
           runtime.outboundProxy(),
           "GET",
-          uri,
+          target,
           headers,
           Duration.ofSeconds(180).toMillis());
       status = response.status();
@@ -376,7 +378,8 @@ public class DockerRemoteRegistryClient {
     Throwable failure = null;
     ProxiedHttpClientFactory.ProxiedResponse response = null;
     try {
-      URI uri = outboundPolicy.validateHttpUri(url, "docker token fetch");
+      OutboundRequestPolicy.ResolvedHttpTarget target =
+          outboundPolicy.resolveHttpTarget(url, "docker token fetch");
       Map<String, String> headers = new LinkedHashMap<>();
       headers.put("User-Agent", "kkrepo/0.1");
       basicAuthorization(runtime).ifPresent(value -> headers.put("Authorization", value));
@@ -384,7 +387,7 @@ public class DockerRemoteRegistryClient {
           runtime.name(),
           runtime.outboundProxy(),
           "GET",
-          uri,
+          target,
           headers,
           Duration.ofSeconds(30).toMillis());
       status = response.status();

--- a/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClient.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClient.java
@@ -13,9 +13,6 @@ import io.micrometer.core.instrument.Timer;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URLEncoder;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.security.MessageDigest;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -37,16 +34,11 @@ public class DockerRemoteRegistryClient {
 
   private final HttpRemoteFetcher fetcher;
   private final OutboundRequestPolicy outboundPolicy;
-  private final HttpClient tokenClient;
-  private final ProxiedHttpClientFactory proxyFactory;
+  private final ProxiedHttpClientFactory transportFactory;
   private final SharedCache tokenCache;
   private final boolean tokenCacheEnabled;
   private final Duration tokenCacheTtl;
   private final KkRepoMetrics metrics;
-
-  public DockerRemoteRegistryClient(HttpRemoteFetcher fetcher, OutboundRequestPolicy outboundPolicy) {
-    this(fetcher, outboundPolicy, null, true, 300, null, null);
-  }
 
   @Autowired
   public DockerRemoteRegistryClient(
@@ -56,44 +48,14 @@ public class DockerRemoteRegistryClient {
       @Value("${kkrepo.docker.proxy.remote-token-cache.enabled:true}") boolean tokenCacheEnabled,
       @Value("${kkrepo.docker.proxy.remote-token-cache.ttl-seconds:300}") long tokenCacheTtlSeconds,
       KkRepoMetrics metrics,
-      ProxiedHttpClientFactory proxyFactory) {
-    this(
-        fetcher,
-        outboundPolicy,
-        tokenCache,
-        tokenCacheEnabled,
-        tokenCacheTtlSeconds,
-        metrics,
-        proxyFactory,
-        HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NEVER).build());
-  }
-
-  DockerRemoteRegistryClient(
-      HttpRemoteFetcher fetcher,
-      OutboundRequestPolicy outboundPolicy,
-      SharedCache tokenCache,
-      boolean tokenCacheEnabled,
-      long tokenCacheTtlSeconds,
-      KkRepoMetrics metrics,
-      ProxiedHttpClientFactory proxyFactory,
-      HttpClient tokenClient) {
+      ProxiedHttpClientFactory transportFactory) {
     this.fetcher = fetcher;
     this.outboundPolicy = outboundPolicy;
     this.tokenCache = tokenCache;
     this.tokenCacheEnabled = tokenCacheEnabled;
     this.tokenCacheTtl = tokenCacheTtlSeconds <= 0 ? Duration.ZERO : Duration.ofSeconds(tokenCacheTtlSeconds);
     this.metrics = metrics;
-    this.proxyFactory = proxyFactory;
-    this.tokenClient = Objects.requireNonNull(tokenClient, "tokenClient");
-  }
-
-  public DockerRemoteRegistryClient(
-      HttpRemoteFetcher fetcher,
-      OutboundRequestPolicy outboundPolicy,
-      SharedCache tokenCache,
-      boolean tokenCacheEnabled,
-      long tokenCacheTtlSeconds) {
-    this(fetcher, outboundPolicy, tokenCache, tokenCacheEnabled, tokenCacheTtlSeconds, null, null);
+    this.transportFactory = Objects.requireNonNull(transportFactory, "transportFactory");
   }
 
   public HttpRemoteFetcher.Result get(RepositoryRuntime runtime, String remotePath, String accept) throws IOException {
@@ -123,85 +85,7 @@ public class DockerRemoteRegistryClient {
 
   private RemoteFetch fetch(
       String url, RepositoryRuntime runtime, String bearerToken, String accept) throws IOException {
-    return fetchWithHeaders(url, runtime, bearerToken, accept, 0, true);
-  }
-
-  private RemoteFetch fetchWithHeaders(
-      String url,
-      RepositoryRuntime runtime,
-      String bearerToken,
-      String accept,
-      int redirects) throws IOException {
-    return fetchWithHeaders(url, runtime, bearerToken, accept, redirects, true);
-  }
-
-  private RemoteFetch fetchWithHeaders(
-      String url,
-      RepositoryRuntime runtime,
-      String bearerToken,
-      String accept,
-      int redirects,
-      boolean sendCredentials) throws IOException {
-    if (proxyEnabled(runtime)) {
-      return proxiedFetchWithHeaders(url, runtime, bearerToken, accept, redirects, sendCredentials);
-    }
-    Timer.Sample sample = metrics == null ? null : metrics.startTimer();
-    int status = 0;
-    Throwable failure = null;
-    boolean recorded = false;
-    try {
-      URI uri = outboundPolicy.validateHttpUri(url, "docker remote fetch");
-      HttpRequest.Builder builder = HttpRequest.newBuilder(uri)
-          .timeout(Duration.ofSeconds(180))
-          .header("User-Agent", "kkrepo/0.1")
-          .header("Accept", accept == null || accept.isBlank() ? "*/*" : accept);
-      if (sendCredentials && bearerToken != null && !bearerToken.isBlank()) {
-        builder.header("Authorization", "Bearer " + bearerToken);
-      } else if (sendCredentials) {
-        basicAuthorization(runtime).ifPresent(value -> builder.header("Authorization", value));
-      }
-      HttpResponse<java.io.InputStream> response = tokenClient.send(
-          builder.GET().build(), HttpResponse.BodyHandlers.ofInputStream());
-      status = response.statusCode();
-      Optional<String> redirect = redirectLocation(response);
-      if (redirect.isPresent()) {
-        response.body().close();
-        if (redirects >= MAX_REDIRECTS) {
-          throw new IOException("Too many redirects fetching Docker remote " + url);
-        }
-        URI redirected = outboundPolicy.validateHttpUri(uri.resolve(redirect.get()), "docker remote redirect");
-        boolean forwardCredentials = sendCredentials && sameOrigin(uri, redirected);
-        recordRemote(runtime, "GET", url, status, null, sample);
-        recorded = true;
-        return fetchWithHeaders(
-            redirected.toString(),
-            runtime,
-            forwardCredentials ? bearerToken : null,
-            accept,
-            redirects + 1,
-            forwardCredentials);
-      }
-      Map<String, String> headers = new LinkedHashMap<>();
-      response.headers().map().forEach((k, v) -> {
-        if (!v.isEmpty()) headers.put(k, v.get(0));
-      });
-      return new RemoteFetch(
-          new HttpRemoteFetcher.Result(response.statusCode(), headers, response.body()),
-          uri,
-          sendCredentials);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      IOException wrapped = new IOException("Interrupted fetching Docker remote " + url, e);
-      failure = wrapped;
-      throw wrapped;
-    } catch (IOException | RuntimeException e) {
-      failure = e;
-      throw e;
-    } finally {
-      if (!recorded) {
-        recordRemote(runtime, "GET", url, status, failure, sample);
-      }
-    }
+    return pinnedFetchWithHeaders(url, runtime, bearerToken, accept, 0, true);
   }
 
   private Optional<RemoteToken> token(RepositoryRuntime runtime, String challenge) throws IOException {
@@ -230,48 +114,7 @@ public class DockerRemoteRegistryClient {
     String url = bearer.realm()
         + "?service=" + encode(bearer.service())
         + (bearer.scope() == null ? "" : "&scope=" + encode(bearer.scope()));
-    if (proxyEnabled(runtime)) {
-      return proxiedFetchToken(runtime, bearer, cacheable, url);
-    }
-    Timer.Sample sample = metrics == null ? null : metrics.startTimer();
-    int status = 0;
-    Throwable failure = null;
-    try {
-      URI uri = outboundPolicy.validateHttpUri(url, "docker token fetch");
-      HttpRequest.Builder builder = HttpRequest.newBuilder(uri)
-          .timeout(Duration.ofSeconds(30))
-          .header("User-Agent", "kkrepo/0.1");
-      basicAuthorization(runtime).ifPresent(value -> builder.header("Authorization", value));
-      HttpRequest request = builder.GET().build();
-      HttpResponse<String> response = tokenClient.send(request, HttpResponse.BodyHandlers.ofString());
-      status = response.statusCode();
-      if (response.statusCode() < 200 || response.statusCode() >= 300) {
-        return Optional.empty();
-      }
-      String body = response.body();
-      String token = extractJsonString(body, "token");
-      if (token == null) {
-        token = extractJsonString(body, "access_token");
-      }
-      if (token == null || token.isBlank()) {
-        return Optional.empty();
-      }
-      String cacheKey = tokenCacheKey(runtime, bearer);
-      if (cacheable && tokenCacheEnabled && !tokenCacheTtl.isZero() && tokenCache != null) {
-        tokenCache.putString(TOKEN_CACHE_NAMESPACE, cacheKey, token, tokenTtl(body));
-      }
-      return Optional.of(new RemoteToken(token, cacheKey, false));
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      IOException wrapped = new IOException("Interrupted fetching Docker remote token", e);
-      failure = wrapped;
-      throw wrapped;
-    } catch (IOException | RuntimeException e) {
-      failure = e;
-      throw e;
-    } finally {
-      recordRemote(runtime, "TOKEN", url, status, failure, sample);
-    }
+    return pinnedFetchToken(runtime, bearer, cacheable, url);
   }
 
   private void evictToken(String cacheKey) {
@@ -280,24 +123,8 @@ public class DockerRemoteRegistryClient {
     }
   }
 
-  private boolean proxyEnabled(RepositoryRuntime runtime) {
-    return proxyFactory != null
-        && runtime != null
-        && runtime.outboundProxy() != null
-        && runtime.outboundProxy().enabled();
-  }
-
-  /** Proxied counterpart of {@link #fetchWithHeaders} — same headers/redirect/metrics, via SOCKS/HTTP proxy. */
-  private RemoteFetch proxiedFetchWithHeaders(
-      String url,
-      RepositoryRuntime runtime,
-      String bearerToken,
-      String accept,
-      int redirects) throws IOException {
-    return proxiedFetchWithHeaders(url, runtime, bearerToken, accept, redirects, true);
-  }
-
-  private RemoteFetch proxiedFetchWithHeaders(
+  /** DNS-pinned Docker fetch, optionally routed through the repository's SOCKS/HTTP proxy. */
+  private RemoteFetch pinnedFetchWithHeaders(
       String url,
       RepositoryRuntime runtime,
       String bearerToken,
@@ -321,7 +148,7 @@ public class DockerRemoteRegistryClient {
       } else if (sendCredentials) {
         basicAuthorization(runtime).ifPresent(value -> headers.put("Authorization", value));
       }
-      response = proxyFactory.execute(
+      response = transportFactory.execute(
           runtime.name(),
           runtime.outboundProxy(),
           "GET",
@@ -338,11 +165,11 @@ public class DockerRemoteRegistryClient {
         if (redirects >= MAX_REDIRECTS) {
           throw new IOException("Too many redirects fetching Docker remote " + url);
         }
-        URI redirected = outboundPolicy.validateHttpUri(uri.resolve(location), "docker remote redirect");
+        URI redirected = uri.resolve(location);
         boolean forwardCredentials = sendCredentials && sameOrigin(uri, redirected);
         recordRemote(runtime, "GET", url, status, null, sample);
         recorded = true;
-        return proxiedFetchWithHeaders(
+        return pinnedFetchWithHeaders(
             redirected.toString(),
             runtime,
             forwardCredentials ? bearerToken : null,
@@ -367,8 +194,8 @@ public class DockerRemoteRegistryClient {
     }
   }
 
-  /** Proxied counterpart of {@link #fetchToken} for the Docker OAuth token exchange. */
-  private Optional<RemoteToken> proxiedFetchToken(
+  /** DNS-pinned Docker OAuth token exchange using the same optional outbound proxy. */
+  private Optional<RemoteToken> pinnedFetchToken(
       RepositoryRuntime runtime,
       BearerChallenge bearer,
       boolean cacheable,
@@ -383,7 +210,7 @@ public class DockerRemoteRegistryClient {
       Map<String, String> headers = new LinkedHashMap<>();
       headers.put("User-Agent", "kkrepo/0.1");
       basicAuthorization(runtime).ifPresent(value -> headers.put("Authorization", value));
-      response = proxyFactory.execute(
+      response = transportFactory.execute(
           runtime.name(),
           runtime.outboundProxy(),
           "GET",
@@ -504,14 +331,6 @@ public class DockerRemoteRegistryClient {
       return 443;
     }
     return -1;
-  }
-
-  private static Optional<String> redirectLocation(HttpResponse<?> response) {
-    int status = response.statusCode();
-    if (status == 301 || status == 302 || status == 303 || status == 307 || status == 308) {
-      return response.headers().firstValue("Location").filter(value -> !value.isBlank());
-    }
-    return Optional.empty();
   }
 
   private void recordRemote(

--- a/server/src/main/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcher.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcher.java
@@ -4,8 +4,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
@@ -15,7 +13,6 @@ import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import com.github.klboke.kkrepo.server.proxy.OutboundProxyConfig;
 import com.github.klboke.kkrepo.server.proxy.ProxiedHttpClientFactory;
@@ -30,9 +27,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
- * Outbound HTTP client used by the Maven proxy facet. Wraps {@link HttpClient} with the bits
- * we actually need: conditional GET, configurable timeouts, simple HEAD/GET API. Keeps Spring
- * out of the proxy logic so it can be tested standalone.
+ * Outbound HTTP client used by repository proxy facets. It validates and pins DNS answers before
+ * delegating GET/HEAD streaming to the shared Apache client factory.
  */
 @Component
 public class HttpRemoteFetcher {
@@ -47,7 +43,6 @@ public class HttpRemoteFetcher {
   private static final DateTimeFormatter RFC1123 =
       DateTimeFormatter.RFC_1123_DATE_TIME.withZone(ZoneOffset.UTC);
 
-  private final HttpClient client;
   private final ProxiedHttpClientFactory proxyFactory;
   private final OutboundRequestPolicy outboundPolicy;
   private final KkRepoMetrics metrics;
@@ -93,11 +88,11 @@ public class HttpRemoteFetcher {
     this.contentTimeout = Duration.ofSeconds(Math.max(1L, contentTimeoutSeconds));
     this.headTimeout = Duration.ofSeconds(Math.max(1L, headTimeoutSeconds));
     this.bodyReadRetryAttempts = Math.max(0, bodyReadRetryAttempts);
-    this.client = HttpClient.newBuilder()
-        .followRedirects(HttpClient.Redirect.NEVER)
-        .connectTimeout(Duration.ofSeconds(10))
-        .version(httpVersion(remoteHttpVersion))
-        .build();
+    if (httpVersion(remoteHttpVersion) == HttpClient.Version.HTTP_2) {
+      log.warn(
+          "kkrepo.proxy.remote-http-version=HTTP_2 is ignored because DNS-pinned outbound "
+              + "connections currently use Apache HttpClient 5 classic (HTTP/1.1)");
+    }
   }
 
   /** Issues a conditional GET (or HEAD) and returns the streaming body for the caller to drain. */
@@ -155,71 +150,18 @@ public class HttpRemoteFetcher {
   }
 
   private Result fetchInternal(Request req, int redirects) throws IOException {
-    if (proxyFactory != null && req.outboundProxy() != null && req.outboundProxy().enabled()) {
-      return fetchViaProxy(req, redirects);
+    if (proxyFactory == null) {
+      throw new IllegalStateException("Outbound HTTP client factory is required");
     }
-    var uri = req.validatedUri(outboundPolicy, "remote fetch");
-    HttpRequest.Builder b = HttpRequest.newBuilder()
-        .uri(uri)
-        .timeout(requestTimeout(req))
-        .header("Accept", "*/*")
-        .header("User-Agent", "kkrepo/0.1");
-    if (req.etag() != null && !req.etag().isBlank()) {
-      b.header("If-None-Match", "\"" + req.etag() + "\"");
-    }
-    if (req.lastModified() != null) {
-      b.header("If-Modified-Since", RFC1123.format(req.lastModified()));
-    }
-    if (req.authorizationHeader() != null && !req.authorizationHeader().isBlank()) {
-      b.header("Authorization", req.authorizationHeader());
-    }
-    HttpRequest request = req.headOnly()
-        ? b.method("HEAD", HttpRequest.BodyPublishers.noBody()).build()
-        : b.GET().build();
-    try {
-      HttpResponse<InputStream> response = client.send(request,
-          HttpResponse.BodyHandlers.ofInputStream());
-      Optional<String> redirect = redirectLocation(response);
-      if (redirect.isPresent()) {
-        response.body().close();
-        if (redirects >= MAX_REDIRECTS) {
-          throw new IOException("Too many redirects fetching " + req.url());
-        }
-        var redirected = outboundPolicy.validateHttpUri(uri.resolve(redirect.get()), "remote redirect");
-        String redirectAuthorization = req.authorizationHeaderForRedirect(uri, redirected);
-        String redirectTrustedHost = req.trustedHostForRedirect(uri, redirected);
-        return fetchInternal(new Request(
-            redirected.toString(),
-            req.etag(),
-            req.lastModified(),
-            req.timeout(),
-            req.timeoutProfile(),
-            req.headOnly(),
-            req.repository(),
-            req.format(),
-            redirectTrustedHost,
-            redirectAuthorization,
-            req.allowedUnsignedRedirectHosts(),
-            req.outboundProxy()), redirects + 1);
-      }
-      Map<String, String> headers = new LinkedHashMap<>();
-      response.headers().map().forEach((k, v) -> {
-        if (!v.isEmpty()) headers.put(k, v.get(0));
-      });
-      return new Result(response.statusCode(), headers, response.body());
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new IOException("Interrupted fetching " + req.url(), e);
-    }
+    return fetchInternal(req, redirects, req.resolvedTarget(outboundPolicy, "remote fetch"));
   }
 
-  /**
-   * Proxied fetch path using Apache HttpClient 5 (the JDK client cannot do SOCKS). Mirrors
-   * {@link #fetchInternal} semantics — same headers, redirects, trusted-host/auth re-derivation and
-   * Result shape — but tunnels the connection through the configured outbound proxy.
-   */
-  private Result fetchViaProxy(Request req, int redirects) throws IOException {
-    URI uri = req.validatedUri(outboundPolicy, "remote fetch");
+  private Result fetchInternal(
+      Request req,
+      int redirects,
+      OutboundRequestPolicy.ResolvedHttpTarget target)
+      throws IOException {
+    URI uri = target.uri();
     Map<String, String> headers = new LinkedHashMap<>();
     headers.put("Accept", "*/*");
     headers.put("User-Agent", "kkrepo/0.1");
@@ -239,19 +181,19 @@ public class HttpRemoteFetcher {
           req.repository(),
           req.outboundProxy(),
           req.headOnly() ? "HEAD" : "GET",
-          uri,
+          target,
           headers,
           timeout.toMillis());
-      String location = redirectLocationProxy(response);
+      String location = redirectLocation(response);
       if (location != null) {
         response.close();
         if (redirects >= MAX_REDIRECTS) {
           throw new IOException("Too many redirects fetching " + req.url());
         }
-        URI redirected = outboundPolicy.validateHttpUri(uri.resolve(location), "remote redirect");
+        URI redirected = uri.resolve(location);
         String redirectAuthorization = req.authorizationHeaderForRedirect(uri, redirected);
         String redirectTrustedHost = req.trustedHostForRedirect(uri, redirected);
-        return fetchViaProxy(new Request(
+        Request redirectedRequest = new Request(
             redirected.toString(),
             req.etag(),
             req.lastModified(),
@@ -263,7 +205,11 @@ public class HttpRemoteFetcher {
             redirectTrustedHost,
             redirectAuthorization,
             req.allowedUnsignedRedirectHosts(),
-            req.outboundProxy()), redirects + 1);
+            req.outboundProxy());
+        return fetchInternal(
+            redirectedRequest,
+            redirects + 1,
+            redirectedRequest.resolvedTarget(outboundPolicy, "remote redirect"));
       }
       return new Result(response.status(), response.headers(), releaseOnClose(response));
     } catch (IOException | RuntimeException e) {
@@ -293,7 +239,7 @@ public class HttpRemoteFetcher {
     };
   }
 
-  private static String redirectLocationProxy(ProxiedHttpClientFactory.ProxiedResponse response) {
+  private static String redirectLocation(ProxiedHttpClientFactory.ProxiedResponse response) {
     int status = response.status();
     if (status == 301 || status == 302 || status == 303 || status == 307 || status == 308) {
       String location = response.header("Location");
@@ -314,14 +260,6 @@ public class HttpRemoteFetcher {
       case METADATA -> metadataTimeout;
       case CONTENT, DEFAULT -> contentTimeout;
     };
-  }
-
-  private static Optional<String> redirectLocation(HttpResponse<?> response) {
-    int status = response.statusCode();
-    if (status == 301 || status == 302 || status == 303 || status == 307 || status == 308) {
-      return response.headers().firstValue("Location").filter(value -> !value.isBlank());
-    }
-    return Optional.empty();
   }
 
   private static String remoteHost(String url) {
@@ -492,12 +430,17 @@ public class HttpRemoteFetcher {
       return headOnly ? "HEAD" : "GET";
     }
 
-    java.net.URI validatedUri(OutboundRequestPolicy policy, String purpose) {
-      URI uri = policy.validateHttpUri(url, purpose);
-      if (trustedHost != null && !normalizeHost(uri.getHost()).equals(trustedHost)) {
+    OutboundRequestPolicy.ResolvedHttpTarget resolvedTarget(
+        OutboundRequestPolicy policy, String purpose) {
+      OutboundRequestPolicy.ResolvedHttpTarget target = policy.resolveHttpTarget(url, purpose);
+      if (trustedHost != null && !normalizeHost(target.uri().getHost()).equals(trustedHost)) {
         throw new SecurityValidationException(purpose + " URL host must remain " + trustedHost);
       }
-      return uri;
+      return target;
+    }
+
+    java.net.URI validatedUri(OutboundRequestPolicy policy, String purpose) {
+      return resolvedTarget(policy, purpose).uri();
     }
 
     String authorizationHeaderForRedirect(URI current, URI redirected) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/proxy/ProxiedHttpClientFactory.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/proxy/ProxiedHttpClientFactory.java
@@ -209,9 +209,10 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
       RequestConfig requestConfig)
       throws IOException {
     int port = effectivePort(uri);
+    String originalHost = endpointHost(uri);
     HttpHost pinnedTarget =
         new HttpHost(uri.getScheme(), address, address.getHostAddress(), port);
-    HttpHost originalTarget = new HttpHost(uri.getScheme(), uri.getHost(), port);
+    HttpHost originalTarget = new HttpHost(uri.getScheme(), originalHost, port);
     ClassicHttpRequest request =
         new BasicClassicHttpRequest("HEAD".equalsIgnoreCase(method) ? "HEAD" : "GET", requestPath(uri));
     if (headers != null) {
@@ -228,7 +229,7 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
         && URIScheme.HTTP.same(uri.getScheme());
     request.setScheme(uri.getScheme());
     request.setAuthority(new URIAuthority(
-        plainHttpProxy ? address.getHostAddress() : uri.getHost(), uri.getPort()));
+        plainHttpProxy ? address.getHostAddress() : originalHost, uri.getPort()));
     if (plainHttpProxy) {
       request.setHeader(HttpHeaders.HOST, hostHeader(uri));
     }
@@ -260,9 +261,19 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
     return URIScheme.HTTPS.same(uri.getScheme()) ? 443 : 80;
   }
 
-  private static String hostHeader(URI uri) {
+  static String endpointHost(URI uri) {
+    // URI.getHost() keeps IPv6 literal brackets, but Apache needs the bare address for TLS peer
+    // naming and request authority; its serializers add brackets back where URI syntax requires.
     String host = uri.getHost();
-    if (host.indexOf(':') >= 0 && !(host.startsWith("[") && host.endsWith("]"))) {
+    if (host != null && host.startsWith("[") && host.endsWith("]")) {
+      return host.substring(1, host.length() - 1);
+    }
+    return host;
+  }
+
+  private static String hostHeader(URI uri) {
+    String host = endpointHost(uri);
+    if (host.indexOf(':') >= 0) {
       host = "[" + host + "]";
     }
     return uri.getPort() >= 0 ? host + ":" + uri.getPort() : host;

--- a/server/src/main/java/com/github/klboke/kkrepo/server/proxy/ProxiedHttpClientFactory.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/proxy/ProxiedHttpClientFactory.java
@@ -3,18 +3,19 @@ package com.github.klboke.kkrepo.server.proxy;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.klboke.kkrepo.server.security.OutboundRequestPolicy.ResolvedHttpTarget;
 import jakarta.annotation.PreDestroy;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
-import org.apache.hc.client5.http.classic.methods.HttpGet;
-import org.apache.hc.client5.http.classic.methods.HttpHead;
 import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
@@ -24,17 +25,23 @@ import org.apache.hc.client5.http.impl.io.DefaultHttpClientConnectionOperator;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.io.DetachedSocketFactory;
 import org.apache.hc.client5.http.io.HttpClientConnectionOperator;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.client5.http.routing.HttpRoutePlanner;
 import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
 import org.apache.hc.client5.http.ssl.TlsSocketStrategy;
-import org.apache.hc.core5.http.Header;
-import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.ProtocolException;
 import org.apache.hc.core5.http.URIScheme;
 import org.apache.hc.core5.http.config.Lookup;
 import org.apache.hc.core5.http.config.RegistryBuilder;
-import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
+import org.apache.hc.core5.net.NamedEndpoint;
+import org.apache.hc.core5.net.URIAuthority;
 import org.apache.hc.core5.util.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,7 +49,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
- * Builds and caches outbound HTTP clients that tunnel upstream repository traffic through a
+ * Builds outbound HTTP clients for upstream repository traffic, optionally tunnelling through a
  * per-repository configured proxy (HTTP CONNECT or SOCKS).
  *
  * <p>HTTP proxies use Apache HttpClient 5's native CONNECT support with a per-client
@@ -69,8 +76,11 @@ import org.springframework.stereotype.Component;
 @Component
 public class ProxiedHttpClientFactory implements AutoCloseable {
   private static final Logger log = LoggerFactory.getLogger(ProxiedHttpClientFactory.class);
+  private static final String ORIGINAL_TARGET_CONTEXT =
+      ProxiedHttpClientFactory.class.getName() + ".originalTarget";
 
   private final Cache<String, CloseableHttpClient> cache;
+  private final CloseableHttpClient directClient;
   private final Duration idleTtl;
   private final Duration connectTimeout;
 
@@ -84,6 +94,7 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
         .removalListener((String key, CloseableHttpClient client, RemovalCause cause) ->
             closeQuietly(client))
         .build();
+    this.directClient = buildDirect();
   }
 
   /**
@@ -127,6 +138,7 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
   public void close() {
     cache.invalidateAll();
     cache.cleanUp();
+    closeQuietly(directClient);
   }
 
   private static void closeQuietly(CloseableHttpClient client) {
@@ -141,26 +153,67 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
   }
 
   /**
-   * Executes a GET/HEAD through the proxy and returns the live response. The caller must
+   * Executes a GET/HEAD against an already validated and DNS-resolved target. The caller must
    * {@link ProxiedResponse#close()} it after draining the body so the connection returns to the pool.
-   * {@code owner} is the repository identity (name) used to key the pooled client.
+   * When {@code config} is enabled, {@code owner} keys the proxy client; otherwise the shared direct
+   * client is used.
+   *
+   * <p>The actual socket or HTTP CONNECT destination is one of the policy-approved IP addresses.
+   * The original host remains the HTTP Host / TLS SNI and certificate-verification name. This binds
+   * address validation to connection establishment and prevents a second DNS lookup from changing
+   * the destination after validation.
    *
    * <p>The connect timeout is configured once per cached client on its connection manager
    * ({@code kkrepo.outbound-proxy.connect-timeout-ms}), because HttpClient 5.4+ removed per-request
    * connect timeouts ({@code RequestConfig.setConnectTimeout} is deprecated). The response timeout
    * stays per-request in {@link RequestConfig}.
    */
-  @SuppressWarnings("resource") // the cached client is shared; it is closed by the cache, not per request
+  @SuppressWarnings("resource") // the shared client is closed by this factory, not per request
   public ProxiedResponse execute(
       String owner,
       OutboundProxyConfig config,
       String method,
-      URI uri,
+      ResolvedHttpTarget target,
       Map<String, String> headers,
       long responseTimeoutMillis)
       throws IOException {
-    CloseableHttpClient client = clientFor(owner, config);
-    ClassicHttpRequest request = "HEAD".equalsIgnoreCase(method) ? new HttpHead(uri) : new HttpGet(uri);
+    if (target == null) {
+      throw new IllegalArgumentException("resolved outbound target is required");
+    }
+    CloseableHttpClient client = config != null && config.enabled()
+        ? clientFor(owner, config)
+        : directClient;
+    RequestConfig requestConfig = RequestConfig.custom()
+        .setResponseTimeout(Timeout.ofMilliseconds(Math.max(1L, responseTimeoutMillis)))
+        .build();
+    IOException failure = null;
+    for (InetAddress address : target.addresses()) {
+      try {
+        return executeAtAddress(
+            client, config, method, target.uri(), address, headers, requestConfig);
+      } catch (IOException e) {
+        failure = e;
+      }
+    }
+    throw failure != null ? failure : new IOException("resolved outbound target has no addresses");
+  }
+
+  @SuppressWarnings("resource") // the client is pooled and closed by this factory, not per request
+  private ProxiedResponse executeAtAddress(
+      CloseableHttpClient client,
+      OutboundProxyConfig config,
+      String method,
+      URI uri,
+      InetAddress address,
+      Map<String, String> headers,
+      RequestConfig requestConfig)
+      throws IOException {
+    int port = effectivePort(uri);
+    HttpHost pinnedTarget =
+        new HttpHost(uri.getScheme(), address, address.getHostAddress(), port);
+    HttpHost originalTarget = new HttpHost(uri.getScheme(), uri.getHost(), port);
+    ClassicHttpRequest request =
+        new BasicClassicHttpRequest("HEAD".equalsIgnoreCase(method) ? "HEAD" : "GET", requestPath(uri));
     if (headers != null) {
       headers.forEach((name, value) -> {
         if (name != null && value != null) {
@@ -168,19 +221,51 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
         }
       });
     }
-    RequestConfig requestConfig = RequestConfig.custom()
-        .setResponseTimeout(Timeout.ofMilliseconds(Math.max(1L, responseTimeoutMillis)))
-        .build();
+
+    boolean plainHttpProxy = config != null
+        && config.enabled()
+        && config.type() == OutboundProxyConfig.Type.HTTP
+        && URIScheme.HTTP.same(uri.getScheme());
+    request.setScheme(uri.getScheme());
+    request.setAuthority(new URIAuthority(
+        plainHttpProxy ? address.getHostAddress() : uri.getHost(), uri.getPort()));
+    if (plainHttpProxy) {
+      request.setHeader(HttpHeaders.HOST, hostHeader(uri));
+    }
+
     HttpClientContext context = HttpClientContext.create();
     context.setRequestConfig(requestConfig);
-    // executeOpen (unlike the deprecated execute overloads) returns a live, caller-closed response,
-    // which is what the streaming callers (releaseOnClose) require.
-    ClassicHttpResponse response = client.executeOpen(null, request, context);
+    context.setAttribute(ORIGINAL_TARGET_CONTEXT, originalTarget);
+    // executeOpen returns a live, caller-closed response required by streaming callers.
+    ClassicHttpResponse response = client.executeOpen(pinnedTarget, request, context);
     Map<String, String> responseHeaders = new LinkedHashMap<>();
     for (Header header : response.getHeaders()) {
       responseHeaders.putIfAbsent(header.getName(), header.getValue());
     }
     return new ProxiedResponse(response, responseHeaders);
+  }
+
+  private static String requestPath(URI uri) {
+    String path = uri.getRawPath();
+    if (path == null || path.isEmpty()) {
+      path = "/";
+    }
+    return uri.getRawQuery() == null ? path : path + "?" + uri.getRawQuery();
+  }
+
+  private static int effectivePort(URI uri) {
+    if (uri.getPort() >= 0) {
+      return uri.getPort();
+    }
+    return URIScheme.HTTPS.same(uri.getScheme()) ? 443 : 80;
+  }
+
+  private static String hostHeader(URI uri) {
+    String host = uri.getHost();
+    if (host.indexOf(':') >= 0 && !(host.startsWith("[") && host.endsWith("]"))) {
+      host = "[" + host + "]";
+    }
+    return uri.getPort() >= 0 ? host + ":" + uri.getPort() : host;
   }
 
   private CloseableHttpClient build(OutboundProxyConfig config) {
@@ -190,13 +275,25 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
     return buildHttp(config);
   }
 
+  private CloseableHttpClient buildDirect() {
+    PoolingHttpClientConnectionManager connectionManager =
+        new PoolingHttpClientConnectionManager();
+    configureConnectionManager(connectionManager);
+    return HttpClients.custom()
+        .setConnectionManager(connectionManager)
+        .setRoutePlanner(new PinnedRoutePlanner(null))
+        .disableContentCompression()
+        .disableRedirectHandling()
+        .build();
+  }
+
   private CloseableHttpClient buildHttp(OutboundProxyConfig config) {
     HttpHost proxy = new HttpHost(URIScheme.HTTP.getId(), config.host(), config.port());
     PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
-    connectionManager.setDefaultConnectionConfig(defaultConnectionConfig());
+    configureConnectionManager(connectionManager);
     var builder = HttpClients.custom()
         .setConnectionManager(connectionManager)
-        .setProxy(proxy)
+        .setRoutePlanner(new PinnedRoutePlanner(proxy))
         .disableContentCompression()
         .disableRedirectHandling();
     if (config.authenticated()) {
@@ -231,13 +328,12 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
         new DefaultHttpClientConnectionOperator(socketFactory, null, null, tlsStrategies);
     PoolingHttpClientConnectionManager connectionManager =
         new PoolingHttpClientConnectionManager(operator, null, null, null, null);
-    connectionManager.setMaxTotal(50);
-    connectionManager.setDefaultMaxPerRoute(20);
-    connectionManager.setDefaultConnectionConfig(defaultConnectionConfig());
+    configureConnectionManager(connectionManager);
     log.info("Configured outbound SOCKS proxy {}:{} for upstream repository fetches",
         config.host(), config.port());
     return HttpClients.custom()
         .setConnectionManager(connectionManager)
+        .setRoutePlanner(new PinnedRoutePlanner(null))
         .disableContentCompression()
         .disableRedirectHandling()
         .build();
@@ -253,12 +349,42 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
         .build();
   }
 
+  private void configureConnectionManager(PoolingHttpClientConnectionManager connectionManager) {
+    connectionManager.setMaxTotal(50);
+    connectionManager.setDefaultMaxPerRoute(20);
+    connectionManager.setDefaultConnectionConfig(defaultConnectionConfig());
+  }
+
   /**
    * A username-only proxy config is valid ({@link OutboundProxyConfig#authenticated()} only requires
    * a username), so a null/blank password must be treated as an empty secret rather than dereferenced.
    */
   private static char[] passwordChars(String password) {
     return password != null ? password.toCharArray() : new char[0];
+  }
+
+  private static final class PinnedRoutePlanner implements HttpRoutePlanner {
+    private final HttpHost proxy;
+
+    private PinnedRoutePlanner(HttpHost proxy) {
+      this.proxy = proxy;
+    }
+
+    @Override
+    public HttpRoute determineRoute(
+        HttpHost target, org.apache.hc.core5.http.protocol.HttpContext context)
+        throws ProtocolException {
+      if (target == null || target.getAddress() == null) {
+        throw new ProtocolException("Resolved target address is required");
+      }
+      Object original = context.getAttribute(ORIGINAL_TARGET_CONTEXT);
+      NamedEndpoint originalTarget =
+          original instanceof NamedEndpoint endpoint ? endpoint : target;
+      boolean secure = URIScheme.HTTPS.same(target.getSchemeName());
+      return proxy == null
+          ? new HttpRoute(target, originalTarget, null, secure)
+          : new HttpRoute(target, originalTarget, null, proxy, secure);
+    }
   }
 
   // --- SOCKS5 username/password authentication -------------------------------------------------

--- a/server/src/main/java/com/github/klboke/kkrepo/server/proxy/ProxiedHttpClientFactory.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/proxy/ProxiedHttpClientFactory.java
@@ -39,6 +39,7 @@ import org.apache.hc.core5.http.ProtocolException;
 import org.apache.hc.core5.http.URIScheme;
 import org.apache.hc.core5.http.config.Lookup;
 import org.apache.hc.core5.http.config.RegistryBuilder;
+import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
 import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
 import org.apache.hc.core5.net.NamedEndpoint;
 import org.apache.hc.core5.net.URIAuthority;
@@ -177,6 +178,24 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
       Map<String, String> headers,
       long responseTimeoutMillis)
       throws IOException {
+    return execute(owner, config, method, target, headers, null, responseTimeoutMillis);
+  }
+
+  /**
+   * Executes an HTTP request with an optional repeatable body against an already validated and
+   * DNS-resolved target. Non-idempotent requests are not retried against another approved address
+   * after an I/O failure, because doing so could submit the same operation twice.
+   */
+  @SuppressWarnings("resource") // the shared client is closed by this factory, not per request
+  public ProxiedResponse execute(
+      String owner,
+      OutboundProxyConfig config,
+      String method,
+      ResolvedHttpTarget target,
+      Map<String, String> headers,
+      byte[] body,
+      long responseTimeoutMillis)
+      throws IOException {
     if (target == null) {
       throw new IllegalArgumentException("resolved outbound target is required");
     }
@@ -186,13 +205,19 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
     RequestConfig requestConfig = RequestConfig.custom()
         .setResponseTimeout(Timeout.ofMilliseconds(Math.max(1L, responseTimeoutMillis)))
         .build();
+    String requestMethod = method == null || method.isBlank() ? "GET" : method;
+    boolean retryable =
+        "GET".equalsIgnoreCase(requestMethod) || "HEAD".equalsIgnoreCase(requestMethod);
     IOException failure = null;
     for (InetAddress address : target.addresses()) {
       try {
         return executeAtAddress(
-            client, config, method, target.uri(), address, headers, requestConfig);
+            client, config, requestMethod, target.uri(), address, headers, body, requestConfig);
       } catch (IOException e) {
         failure = e;
+        if (!retryable) {
+          throw e;
+        }
       }
     }
     throw failure != null ? failure : new IOException("resolved outbound target has no addresses");
@@ -206,6 +231,7 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
       URI uri,
       InetAddress address,
       Map<String, String> headers,
+      byte[] body,
       RequestConfig requestConfig)
       throws IOException {
     int port = effectivePort(uri);
@@ -213,8 +239,10 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
     HttpHost pinnedTarget =
         new HttpHost(uri.getScheme(), address, address.getHostAddress(), port);
     HttpHost originalTarget = new HttpHost(uri.getScheme(), originalHost, port);
-    ClassicHttpRequest request =
-        new BasicClassicHttpRequest("HEAD".equalsIgnoreCase(method) ? "HEAD" : "GET", requestPath(uri));
+    ClassicHttpRequest request = new BasicClassicHttpRequest(method, requestPath(uri));
+    if (body != null) {
+      request.setEntity(new ByteArrayEntity(body, null));
+    }
     if (headers != null) {
       headers.forEach((name, value) -> {
         if (name != null && value != null) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/proxy/ProxiedHttpClientFactory.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/proxy/ProxiedHttpClientFactory.java
@@ -241,6 +241,8 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
     HttpHost originalTarget = new HttpHost(uri.getScheme(), originalHost, port);
     ClassicHttpRequest request = new BasicClassicHttpRequest(method, requestPath(uri));
     if (body != null) {
+      // This entity is sent to the validated upstream target; it is never rendered in a web response.
+      // codeql[java/xss]
       request.setEntity(new ByteArrayEntity(body, null));
     }
     if (headers != null) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/proxy/ProxiedHttpClientFactory.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/proxy/ProxiedHttpClientFactory.java
@@ -39,8 +39,7 @@ import org.apache.hc.core5.http.ProtocolException;
 import org.apache.hc.core5.http.URIScheme;
 import org.apache.hc.core5.http.config.Lookup;
 import org.apache.hc.core5.http.config.RegistryBuilder;
-import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
-import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
+import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 import org.apache.hc.core5.net.NamedEndpoint;
 import org.apache.hc.core5.net.URIAuthority;
 import org.apache.hc.core5.util.Timeout;
@@ -239,12 +238,12 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
     HttpHost pinnedTarget =
         new HttpHost(uri.getScheme(), address, address.getHostAddress(), port);
     HttpHost originalTarget = new HttpHost(uri.getScheme(), originalHost, port);
-    ClassicHttpRequest request = new BasicClassicHttpRequest(method, requestPath(uri));
+    ClassicRequestBuilder requestBuilder =
+        ClassicRequestBuilder.create(method).setPath(requestPath(uri));
     if (body != null) {
-      // This entity is sent to the validated upstream target; it is never rendered in a web response.
-      // codeql[java/xss]
-      request.setEntity(new ByteArrayEntity(body, null));
+      requestBuilder.setEntity(body, null);
     }
+    ClassicHttpRequest request = requestBuilder.build();
     if (headers != null) {
       headers.forEach((name, value) -> {
         if (name != null && value != null) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/proxy/Socks5TunnelSocket.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/proxy/Socks5TunnelSocket.java
@@ -142,7 +142,9 @@ final class Socks5TunnelSocket extends Socket {
     out.write(0x00);
     InetAddress resolved = target.getAddress();
     String hostString = target.getHostString();
-    if (resolved != null && hostString.equals(resolved.getHostAddress())) {
+    if (resolved != null) {
+      // A resolved socket address is a policy-approved connection capability. Always serialize its
+      // IP bytes so the SOCKS proxy cannot perform a second, potentially rebound DNS lookup.
       byte[] address = resolved.getAddress();
       out.write(address.length == 4 ? 0x01 : 0x04);
       out.write(address);

--- a/server/src/main/java/com/github/klboke/kkrepo/server/security/OidcLoginController.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/security/OidcLoginController.java
@@ -4,15 +4,14 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.klboke.kkrepo.cache.SharedCache;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.SecurityRealmRecord;
+import com.github.klboke.kkrepo.server.proxy.ProxiedHttpClientFactory;
+import com.github.klboke.kkrepo.server.proxy.ProxiedHttpClientFactory.ProxiedResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URLEncoder;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.Base64;
@@ -41,11 +40,12 @@ public class OidcLoginController {
   private static final String DEFAULT_SCOPES = "openid profile email";
   private static final String DEFAULT_RETURN_TO = "/browse/#browse/welcome";
   private static final String DISCOVERY_CACHE_NAMESPACE = "oidc-discovery";
+  private static final long OIDC_HTTP_TIMEOUT_MILLIS = 30_000L;
 
   private final SecurityAuthenticationService authenticationService;
   private final ObjectMapper objectMapper;
-  private final HttpClient httpClient;
   private final OutboundRequestPolicy outboundPolicy;
+  private final ProxiedHttpClientFactory transportFactory;
   private final String externalBaseUrl;
   private final SharedCache sharedCache;
   private final SecureRandom secureRandom = new SecureRandom();
@@ -55,25 +55,16 @@ public class OidcLoginController {
       SecurityAuthenticationService authenticationService,
       ObjectMapper objectMapper,
       OutboundRequestPolicy outboundPolicy,
+      ProxiedHttpClientFactory transportFactory,
       SharedCache sharedCache,
       @Value("${kkrepo.security.external-base-url:}") String externalBaseUrl) {
     this.authenticationService = authenticationService;
     this.objectMapper = objectMapper;
     this.outboundPolicy = outboundPolicy;
+    this.transportFactory = java.util.Objects.requireNonNull(
+        transportFactory, "transportFactory");
     this.sharedCache = sharedCache;
     this.externalBaseUrl = asString(externalBaseUrl);
-    this.httpClient = HttpClient.newHttpClient();
-  }
-
-  public OidcLoginController(
-      SecurityAuthenticationService authenticationService,
-      ObjectMapper objectMapper) {
-    this(
-        authenticationService,
-        objectMapper,
-        OutboundRequestPolicy.allowPrivateForTests(),
-        null,
-        "");
   }
 
   @GetMapping("/login/options")
@@ -130,7 +121,7 @@ public class OidcLoginController {
     params.put("redirect_uri", redirectUri);
     params.put("scope", defaultString(stringConfig(config, "scopes", "scope"), DEFAULT_SCOPES));
     params.put("state", state);
-    OidcEndpoint authorizationEndpoint = endpoint(
+    OidcEndpoint authorizationEndpoint = browserEndpoint(
         config,
         "OIDC authorization endpoint",
         "authorizationEndpoint",
@@ -199,7 +190,7 @@ public class OidcLoginController {
       String code,
       String redirectUri) {
     String clientId = required(config, "clientId", "audience");
-    OidcEndpoint tokenEndpoint = endpoint(
+    OutboundRequestPolicy.ResolvedHttpTarget tokenEndpoint = resolvedEndpoint(
         config,
         "OIDC token endpoint",
         "tokenEndpoint",
@@ -214,45 +205,59 @@ public class OidcLoginController {
     if (clientSecret != null) {
       body.put("client_secret", clientSecret);
     }
-    HttpRequest tokenRequest = HttpRequest.newBuilder(tokenEndpoint.uri())
-        .header("Content-Type", MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-        .POST(HttpRequest.BodyPublishers.ofString(form(body)))
-        .build();
-    try {
-      HttpResponse<String> tokenResponse = httpClient.send(tokenRequest, HttpResponse.BodyHandlers.ofString());
-      if (tokenResponse.statusCode() < 200 || tokenResponse.statusCode() >= 300) {
-        throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "OIDC token endpoint returned " + tokenResponse.statusCode());
+    try (ProxiedResponse tokenResponse = transportFactory.execute(
+        "security:oidc-token",
+        null,
+        "POST",
+        tokenEndpoint,
+        Map.of("Content-Type", MediaType.APPLICATION_FORM_URLENCODED_VALUE),
+        form(body).getBytes(StandardCharsets.UTF_8),
+        OIDC_HTTP_TIMEOUT_MILLIS)) {
+      if (tokenResponse.status() < 200 || tokenResponse.status() >= 300) {
+        throw new ResponseStatusException(
+            HttpStatus.UNAUTHORIZED,
+            "OIDC token endpoint returned " + tokenResponse.status());
       }
       return objectMapper.readValue(tokenResponse.body(), JSON_MAP);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "OIDC token exchange was interrupted", e);
     } catch (IOException e) {
       throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "OIDC token exchange failed", e);
     }
   }
 
-  private OidcEndpoint endpoint(Map<String, Object> config, String purpose, String... keys) {
+  private OidcEndpoint browserEndpoint(
+      Map<String, Object> config, String purpose, String... keys) {
+    URI uri = outboundPolicy.validateHttpUri(endpointUrl(config, keys), purpose);
+    validateEndpointFragment(uri, purpose);
+    return new OidcEndpoint(uri, uri.getHost());
+  }
+
+  private OutboundRequestPolicy.ResolvedHttpTarget resolvedEndpoint(
+      Map<String, Object> config, String purpose, String... keys) {
+    OutboundRequestPolicy.ResolvedHttpTarget target =
+        outboundPolicy.resolveHttpTarget(endpointUrl(config, keys), purpose);
+    validateEndpointFragment(target.uri(), purpose);
+    return target;
+  }
+
+  private String endpointUrl(Map<String, Object> config, String... keys) {
     String direct = stringConfig(config, keys);
     if (direct != null) {
-      return validatedEndpoint(direct, purpose);
+      return direct;
     }
     Map<String, Object> discovery = discovery(config);
     for (String key : keys) {
       String discovered = asString(discovery.get(key));
       if (discovered != null) {
-        return validatedEndpoint(discovered, purpose);
+        return discovered;
       }
     }
     throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "OIDC endpoint is not configured: " + String.join("/", keys));
   }
 
-  private OidcEndpoint validatedEndpoint(String rawUrl, String purpose) {
-    URI uri = outboundPolicy.validateHttpUri(rawUrl, purpose);
+  private void validateEndpointFragment(URI uri, String purpose) {
     if (uri.getRawFragment() != null) {
       throw new SecurityValidationException(purpose + " URL must not include a fragment");
     }
-    return new OidcEndpoint(uri, uri.getHost());
   }
 
   private Map<String, Object> discovery(Map<String, Object> config) {
@@ -269,12 +274,19 @@ public class OidcLoginController {
         return document;
       }
     }
-    try {
-      HttpResponse<String> response = httpClient.send(
-          HttpRequest.newBuilder(outboundPolicy.validateHttpUri(uri, "OIDC discovery")).GET().build(),
-          HttpResponse.BodyHandlers.ofString());
-      if (response.statusCode() < 200 || response.statusCode() >= 300) {
-        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "OIDC discovery endpoint returned " + response.statusCode());
+    OutboundRequestPolicy.ResolvedHttpTarget target =
+        outboundPolicy.resolveHttpTarget(uri, "OIDC discovery");
+    try (ProxiedResponse response = transportFactory.execute(
+        "security:oidc-discovery",
+        null,
+        "GET",
+        target,
+        Map.of(),
+        OIDC_HTTP_TIMEOUT_MILLIS)) {
+      if (response.status() < 200 || response.status() >= 300) {
+        throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST,
+            "OIDC discovery endpoint returned " + response.status());
       }
       Map<String, Object> document = objectMapper.readValue(response.body(), JSON_MAP);
       validateDiscoveryDocument(config, document);
@@ -282,9 +294,6 @@ public class OidcLoginController {
         sharedCache.putJson(DISCOVERY_CACHE_NAMESPACE, uri, document, java.time.Duration.ofSeconds(300));
       }
       return document;
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "OIDC discovery was interrupted", e);
     } catch (IOException e) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "OIDC discovery failed", e);
     }

--- a/server/src/main/java/com/github/klboke/kkrepo/server/security/OutboundRequestPolicy.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/security/OutboundRequestPolicy.java
@@ -7,7 +7,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,22 +20,29 @@ import org.springframework.stereotype.Component;
 public class OutboundRequestPolicy {
   private final boolean allowPrivateAddresses;
   private final Set<String> allowedHosts;
+  private final HostResolver hostResolver;
 
   @Autowired
   public OutboundRequestPolicy(
       @Value("${kkrepo.security.outbound.allow-private-addresses:false}") boolean allowPrivateAddresses,
       @Value("${kkrepo.security.outbound.allowed-hosts:}") String allowedHosts) {
-    this.allowPrivateAddresses = allowPrivateAddresses;
-    this.allowedHosts = parseHosts(allowedHosts);
+    this(allowPrivateAddresses, parseHosts(allowedHosts), InetAddress::getAllByName);
   }
 
-  private OutboundRequestPolicy(boolean allowPrivateAddresses, Set<String> allowedHosts) {
+  OutboundRequestPolicy(
+      boolean allowPrivateAddresses, String allowedHosts, HostResolver hostResolver) {
+    this(allowPrivateAddresses, parseHosts(allowedHosts), hostResolver);
+  }
+
+  private OutboundRequestPolicy(
+      boolean allowPrivateAddresses, Set<String> allowedHosts, HostResolver hostResolver) {
     this.allowPrivateAddresses = allowPrivateAddresses;
     this.allowedHosts = allowedHosts;
+    this.hostResolver = Objects.requireNonNull(hostResolver, "hostResolver");
   }
 
   public static OutboundRequestPolicy allowPrivateForTests() {
-    return new OutboundRequestPolicy(true, Set.of());
+    return new OutboundRequestPolicy(true, Set.of(), InetAddress::getAllByName);
   }
 
   public URI validateHttpUri(String rawUrl, String purpose) {
@@ -48,6 +57,60 @@ public class OutboundRequestPolicy {
   }
 
   public URI validateHttpUri(URI uri, String purpose) {
+    String host = validatedHost(uri, purpose);
+    if (allowedHosts.contains(normalizeHost(host))) {
+      return uri;
+    }
+    return resolveHttpTarget(uri, purpose).uri();
+  }
+
+  /**
+   * Validates an outbound HTTP URL and captures the exact DNS answers approved by the policy.
+   * Callers must connect to one of {@link ResolvedHttpTarget#addresses()} instead of resolving the
+   * host name again; otherwise a DNS change between validation and connect can bypass the address
+   * checks.
+   */
+  public ResolvedHttpTarget resolveHttpTarget(String rawUrl, String purpose) {
+    if (rawUrl == null || rawUrl.isBlank()) {
+      throw new SecurityValidationException(purpose + " URL is required");
+    }
+    try {
+      return resolveHttpTarget(new URI(rawUrl), purpose);
+    } catch (URISyntaxException e) {
+      throw new SecurityValidationException(purpose + " URL is not valid: " + e.getMessage(), e);
+    }
+  }
+
+  public ResolvedHttpTarget resolveHttpTarget(URI uri, String purpose) {
+    String host = validatedHost(uri, purpose);
+    InetAddress[] addresses;
+    try {
+      addresses = hostResolver.resolve(host);
+    } catch (UnknownHostException e) {
+      throw new SecurityValidationException(purpose + " URL host cannot be resolved: " + host, e);
+    }
+    if (addresses == null || addresses.length == 0) {
+      throw new SecurityValidationException(purpose + " URL host cannot be resolved: " + host);
+    }
+    for (InetAddress address : addresses) {
+      if (address == null) {
+        throw new SecurityValidationException(purpose + " URL host cannot be resolved: " + host);
+      }
+    }
+    boolean addressChecksRequired =
+        !allowPrivateAddresses && !allowedHosts.contains(normalizeHost(host));
+    if (addressChecksRequired) {
+      for (InetAddress address : addresses) {
+        if (blockedAddress(address)) {
+          throw new SecurityValidationException(
+              purpose + " URL resolves to a private or local address: " + host + " -> " + address.getHostAddress());
+        }
+      }
+    }
+    return new ResolvedHttpTarget(uri, Arrays.asList(addresses));
+  }
+
+  private String validatedHost(URI uri, String purpose) {
     if (uri == null) {
       throw new SecurityValidationException(purpose + " URL is required");
     }
@@ -62,32 +125,10 @@ public class OutboundRequestPolicy {
     if (host == null || host.isBlank()) {
       throw new SecurityValidationException(purpose + " URL must have a host");
     }
-    validateHost(host, purpose);
-    return uri;
-  }
-
-  private void validateHost(String host, String purpose) {
-    String normalized = normalizeHost(host);
-    if (allowedHosts.contains(normalized)) {
-      return;
+    if (uri.getPort() == 0 || uri.getPort() > 65535) {
+      throw new SecurityValidationException(purpose + " URL has an invalid port");
     }
-    InetAddress[] addresses;
-    try {
-      addresses = InetAddress.getAllByName(host);
-    } catch (UnknownHostException e) {
-      throw new SecurityValidationException(purpose + " URL host cannot be resolved: " + host, e);
-    }
-    if (addresses.length == 0) {
-      throw new SecurityValidationException(purpose + " URL host cannot be resolved: " + host);
-    }
-    if (!allowPrivateAddresses) {
-      for (InetAddress address : addresses) {
-        if (blockedAddress(address)) {
-          throw new SecurityValidationException(
-              purpose + " URL resolves to a private or local address: " + host + " -> " + address.getHostAddress());
-        }
-      }
-    }
+    return host;
   }
 
   private boolean blockedAddress(InetAddress address) {
@@ -134,5 +175,29 @@ public class OutboundRequestPolicy {
       value = value.substring(1, value.length() - 1);
     }
     return value;
+  }
+
+  @FunctionalInterface
+  interface HostResolver {
+    InetAddress[] resolve(String host) throws UnknownHostException;
+  }
+
+  /** Policy-issued connection capability; only this class can create a validated instance. */
+  public static final class ResolvedHttpTarget {
+    private final URI uri;
+    private final List<InetAddress> addresses;
+
+    private ResolvedHttpTarget(URI uri, List<InetAddress> addresses) {
+      this.uri = uri;
+      this.addresses = List.copyOf(addresses);
+    }
+
+    public URI uri() {
+      return uri;
+    }
+
+    public List<InetAddress> addresses() {
+      return addresses;
+    }
   }
 }

--- a/server/src/main/java/com/github/klboke/kkrepo/server/security/OutboundRequestPolicy.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/security/OutboundRequestPolicy.java
@@ -45,6 +45,11 @@ public class OutboundRequestPolicy {
     return new OutboundRequestPolicy(true, Set.of(), InetAddress::getAllByName);
   }
 
+  /**
+   * Validates a URL for configuration storage or a client-side redirect only. Server-side HTTP
+   * callers must use {@link #resolveHttpTarget(String, String)} and connect through the pinned
+   * transport so the approved DNS answers cannot be discarded before connection establishment.
+   */
   public URI validateHttpUri(String rawUrl, String purpose) {
     if (rawUrl == null || rawUrl.isBlank()) {
       throw new SecurityValidationException(purpose + " URL is required");
@@ -56,6 +61,7 @@ public class OutboundRequestPolicy {
     }
   }
 
+  /** See {@link #validateHttpUri(String, String)}. */
   public URI validateHttpUri(URI uri, String purpose) {
     String host = validatedHost(uri, purpose);
     if (allowedHosts.contains(normalizeHost(host))) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/security/SecurityAuthenticationService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/security/SecurityAuthenticationService.java
@@ -9,13 +9,12 @@ import com.github.klboke.kkrepo.persistence.jdbc.api.model.ApiKeyRecord;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.SecurityAnonymousConfigRecord;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.SecurityRealmRecord;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.SecurityUserRecord;
+import com.github.klboke.kkrepo.server.proxy.ProxiedHttpClientFactory;
+import com.github.klboke.kkrepo.server.proxy.ProxiedHttpClientFactory.ProxiedResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import java.io.Serializable;
 import java.math.BigInteger;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.Signature;
@@ -61,14 +60,15 @@ public class SecurityAuthenticationService {
   private static final String STATUS_ACTIVE = "ACTIVE";
   private static final String STATUS_CHANGE_PASSWORD = "CHANGEPASSWORD";
   private static final String JWKS_CACHE_NAMESPACE = "oidc-jwks";
+  private static final long OIDC_HTTP_TIMEOUT_MILLIS = 30_000L;
   private static final TypeReference<Map<String, Object>> JSON_MAP = new TypeReference<>() {
   };
 
   private final SecurityDao securityDao;
   private final String tokenHeader;
   private final ObjectMapper objectMapper;
-  private final HttpClient httpClient;
   private final OutboundRequestPolicy outboundPolicy;
+  private final ProxiedHttpClientFactory transportFactory;
   private final String defaultAuthenticatedRoleId;
   private final SharedCache sharedCache;
   private final ApiKeyAuthCache apiKeyAuthCache;
@@ -83,6 +83,7 @@ public class SecurityAuthenticationService {
       @Value("${kkrepo.security.default-authenticated-role-id:nx-anonymous}") String defaultAuthenticatedRoleId,
       SharedCache sharedCache,
       OutboundRequestPolicy outboundPolicy,
+      ProxiedHttpClientFactory transportFactory,
       ApiKeyAuthCache apiKeyAuthCache,
       BasicAuthCache basicAuthCache,
       SecurityCatalogCache securityCatalogCache) {
@@ -92,25 +93,23 @@ public class SecurityAuthenticationService {
     this.defaultAuthenticatedRoleId = optionalText(defaultAuthenticatedRoleId);
     this.sharedCache = sharedCache;
     this.outboundPolicy = outboundPolicy;
+    this.transportFactory = java.util.Objects.requireNonNull(
+        transportFactory, "transportFactory");
     this.apiKeyAuthCache = apiKeyAuthCache;
     this.basicAuthCache = basicAuthCache;
     this.securityCatalogCache = securityCatalogCache;
-    this.httpClient = HttpClient.newHttpClient();
   }
 
   public SecurityAuthenticationService(
       SecurityDao securityDao,
       ObjectMapper objectMapper,
       @Value("${kkrepo.security.token-header:X-Nexus-Plus-Token}") String tokenHeader) {
-    this(securityDao, objectMapper, tokenHeader, DEFAULT_AUTHENTICATED_ROLE_ID);
-  }
-
-  public SecurityAuthenticationService(
-      SecurityDao securityDao,
-      ObjectMapper objectMapper,
-      String tokenHeader,
-      String defaultAuthenticatedRoleId) {
-    this(securityDao, objectMapper, tokenHeader, defaultAuthenticatedRoleId, null);
+    this(
+        securityDao,
+        objectMapper,
+        tokenHeader,
+        DEFAULT_AUTHENTICATED_ROLE_ID,
+        null);
   }
 
   SecurityAuthenticationService(
@@ -125,10 +124,10 @@ public class SecurityAuthenticationService {
     this.defaultAuthenticatedRoleId = optionalText(defaultAuthenticatedRoleId);
     this.sharedCache = null;
     this.outboundPolicy = OutboundRequestPolicy.allowPrivateForTests();
+    this.transportFactory = null;
     this.apiKeyAuthCache = null;
     this.basicAuthCache = null;
     this.securityCatalogCache = securityCatalogCache;
-    this.httpClient = HttpClient.newHttpClient();
   }
 
   @Transactional
@@ -813,13 +812,20 @@ public class SecurityAuthenticationService {
         ? null
         : sharedCache.getJson(JWKS_CACHE_NAMESPACE, jwksUri, JSON_MAP).orElse(null);
     if (jwks == null) {
-      HttpRequest request = HttpRequest.newBuilder(
-          outboundPolicy.validateHttpUri(jwksUri, "OIDC JWKS")).GET().build();
-      HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-      if (response.statusCode() < 200 || response.statusCode() >= 300) {
-        throw new SecurityValidationException("JWKS endpoint returned " + response.statusCode());
+      OutboundRequestPolicy.ResolvedHttpTarget target =
+          outboundPolicy.resolveHttpTarget(jwksUri, "OIDC JWKS");
+      try (ProxiedResponse response = transportFactory.execute(
+          "security:oidc-jwks",
+          null,
+          "GET",
+          target,
+          Map.of(),
+          OIDC_HTTP_TIMEOUT_MILLIS)) {
+        if (response.status() < 200 || response.status() >= 300) {
+          throw new SecurityValidationException("JWKS endpoint returned " + response.status());
+        }
+        jwks = objectMapper.readValue(response.body(), JSON_MAP);
       }
-      jwks = objectMapper.readValue(response.body(), JSON_MAP);
       if (sharedCache != null) {
         sharedCache.putJson(JWKS_CACHE_NAMESPACE, jwksUri, jwks, java.time.Duration.ofSeconds(cacheSeconds));
       }

--- a/server/src/main/java/com/github/klboke/kkrepo/server/terraform/TerraformService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/terraform/TerraformService.java
@@ -13,6 +13,7 @@ import com.github.klboke.kkrepo.server.maven.MavenExceptions;
 import com.github.klboke.kkrepo.server.maven.MavenResponse;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
+import com.github.klboke.kkrepo.server.maven.RemoteUrlBuilder;
 import com.github.klboke.kkrepo.server.raw.RawProxyService;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -903,7 +904,7 @@ public class TerraformService {
         ? path.rawPath().substring(0, path.rawPath().length() - ".json".length())
         : path.rawPath();
     String suffix = canonicalPath.substring(prefix.length());
-    return ensureSlash(service) + suffix;
+    return RemoteUrlBuilder.repositoryPathString(service, suffix);
   }
 
   private String discovery(RepositoryRuntime runtime, String key) {

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -76,6 +76,8 @@ kkrepo.cache.basic-auth.ttl-seconds=${KKREPO_CACHE_BASIC_AUTH_TTL_SECONDS:120}
 kkrepo.cache.basic-auth.missing-ttl-seconds=${KKREPO_CACHE_BASIC_AUTH_MISSING_TTL_SECONDS:5}
 kkrepo.proxy.negative-cache.enabled=${KKREPO_PROXY_NEGATIVE_CACHE_ENABLED:${KKREPO_MAVEN_PROXY_NEGATIVE_CACHE_ENABLED:true}}
 kkrepo.proxy.negative-cache.ttl-minutes=${KKREPO_PROXY_NEGATIVE_CACHE_TTL_MINUTES:${KKREPO_MAVEN_PROXY_NEGATIVE_CACHE_TTL_MINUTES:5}}
+# DNS-pinned outbound connections currently use HTTP/1.1.
+# HTTP_2 is accepted but downgraded with a warning.
 kkrepo.proxy.remote-http-version=${KKREPO_PROXY_REMOTE_HTTP_VERSION:HTTP_1_1}
 kkrepo.proxy.search-timeout-seconds=${KKREPO_PROXY_SEARCH_TIMEOUT_SECONDS:${KKREPO_NPM_PROXY_SEARCH_TIMEOUT_SECONDS:30}}
 kkrepo.proxy.metadata-timeout-seconds=${KKREPO_PROXY_METADATA_TIMEOUT_SECONDS:${KKREPO_MAVEN_PROXY_GET_TIMEOUT_SECONDS:60}}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClientTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClientTest.java
@@ -4,6 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.github.klboke.kkrepo.core.RepositoryFormat;
 import com.github.klboke.kkrepo.core.RepositoryType;
@@ -15,46 +23,32 @@ import com.github.klboke.kkrepo.server.proxy.ProxiedHttpClientFactory;
 import com.github.klboke.kkrepo.server.security.OutboundRequestPolicy;
 import com.github.klboke.kkrepo.server.support.FakeHttpProxyServer;
 import com.github.klboke.kkrepo.server.support.InMemorySharedCache;
-import com.sun.net.httpserver.HttpsConfigurator;
-import com.sun.net.httpserver.HttpsServer;
 import com.sun.net.httpserver.HttpServer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.math.BigInteger;
 import java.net.InetSocketAddress;
-import java.net.ProxySelector;
 import java.net.URI;
 import java.net.URLDecoder;
-import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.KeyStore;
-import java.security.SecureRandom;
-import java.security.cert.Certificate;
-import java.security.cert.X509Certificate;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManagerFactory;
-import org.bouncycastle.asn1.x500.X500Name;
-import org.bouncycastle.asn1.x509.Extension;
-import org.bouncycastle.asn1.x509.GeneralName;
-import org.bouncycastle.asn1.x509.GeneralNames;
-import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
-import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
-import org.bouncycastle.operator.ContentSigner;
-import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 class DockerRemoteRegistryClientTest {
+  private final ProxiedHttpClientFactory directFactory =
+      new ProxiedHttpClientFactory(60000, 10000);
+
+  @AfterEach
+  void closeDirectFactory() {
+    directFactory.close();
+  }
+
   @Test
   void remoteFetchUsesConfiguredBasicCredentials() throws Exception {
     try (TestRegistry registry = TestRegistry.start()) {
@@ -294,82 +288,62 @@ class DockerRemoteRegistryClientTest {
   }
 
   @Test
-  void httpToHttpsUpgradePreservesBasicAndBearerCredentialsOverTls() throws Exception {
-    List<String> manifestAuthorizations = new ArrayList<>();
-    List<String> tokenAuthorizations = new ArrayList<>();
-    // Keep the Docker URLs on their real default ports so the redirect exercises the production
-    // 80-to-443 origin rule. This loopback router only maps those connections to an ephemeral TLS
-    // listener; the RepositoryRuntime itself has no outbound proxy, so the direct client path runs.
-    try (TestTlsRegistry registry = TestTlsRegistry.start();
-        FakeHttpProxyServer router = FakeHttpProxyServer.startTunneling(request -> {
-          URI target = URI.create(request.target());
-          String location = "https://localhost" + target.getRawPath()
-              + (target.getRawQuery() == null ? "" : "?" + target.getRawQuery());
-          return FakeHttpProxyServer.FakeResponse.status(307, Map.of("Location", location));
-        }, request -> new InetSocketAddress("127.0.0.1", registry.port()))) {
-      registry.server.createContext("/token", exchange -> {
-        tokenAuthorizations.add(exchange.getRequestHeaders().getFirst("Authorization"));
-        byte[] body = "{\"token\":\"tls-token\"}".getBytes(StandardCharsets.UTF_8);
-        exchange.getResponseHeaders().add("Content-Type", "application/json");
-        exchange.getResponseHeaders().add("Connection", "close");
-        exchange.sendResponseHeaders(200, body.length);
-        exchange.getResponseBody().write(body);
-        exchange.close();
-      });
-      registry.server.createContext("/v2/library/alpine/manifests/latest", exchange -> {
-        String authorization = exchange.getRequestHeaders().getFirst("Authorization");
-        manifestAuthorizations.add(authorization);
-        exchange.getResponseHeaders().add("Connection", "close");
-        if (!"Bearer tls-token".equals(authorization)) {
-          exchange.getResponseHeaders().add(
+  void directHttpToHttpsUpgradeUsesPinnedTransportAndPreservesCredentials() throws Exception {
+    ProxiedHttpClientFactory transport = mock(ProxiedHttpClientFactory.class);
+    List<TransportCall> calls = new ArrayList<>();
+    when(transport.execute(
+        anyString(),
+        nullable(OutboundProxyConfig.class),
+        eq("GET"),
+        any(OutboundRequestPolicy.ResolvedHttpTarget.class),
+        anyMap(),
+        anyLong())).thenAnswer(invocation -> {
+          OutboundProxyConfig proxy = invocation.getArgument(1);
+          OutboundRequestPolicy.ResolvedHttpTarget target = invocation.getArgument(3);
+          Map<String, String> headers = Map.copyOf(invocation.getArgument(4));
+          URI uri = target.uri();
+          calls.add(new TransportCall(uri, proxy, headers));
+          if ("http".equals(uri.getScheme())) {
+            return response(307, Map.of(
+                "Location", "https://localhost" + uri.getRawPath()), "");
+          }
+          if ("/token".equals(uri.getPath())) {
+            return response(200, Map.of(), "{\"token\":\"tls-token\"}");
+          }
+          if ("Bearer tls-token".equals(headers.get("Authorization"))) {
+            return response(200, Map.of("Content-Type", "application/json"), "{}");
+          }
+          return response(401, Map.of(
               "WWW-Authenticate",
-              "Bearer realm=\"https://localhost/token\",service=\"registry.local\",scope=\"repository:library/alpine:pull\"");
-          exchange.sendResponseHeaders(401, -1);
-        } else {
-          byte[] body = "{}".getBytes(StandardCharsets.UTF_8);
-          exchange.getResponseHeaders().add("Content-Type", "application/json");
-          exchange.sendResponseHeaders(200, body.length);
-          exchange.getResponseBody().write(body);
-        }
-        exchange.close();
-      });
-      HttpClient tlsClient = HttpClient.newBuilder()
-          .followRedirects(HttpClient.Redirect.NEVER)
-          .proxy(ProxySelector.of(new InetSocketAddress("127.0.0.1", router.port())))
-          .sslContext(registry.clientSslContext)
-          .build();
-      DockerRemoteRegistryClient client = new DockerRemoteRegistryClient(
-          null,
-          OutboundRequestPolicy.allowPrivateForTests(),
-          null,
-          true,
-          300,
-          null,
-          null,
-          tlsClient);
+              "Bearer realm=\"https://localhost/token\",service=\"registry.local\","
+                  + "scope=\"repository:library/alpine:pull\""), "");
+        });
+    DockerRemoteRegistryClient client = new DockerRemoteRegistryClient(
+        null,
+        OutboundRequestPolicy.allowPrivateForTests(),
+        null,
+        true,
+        300,
+        null,
+        transport);
 
-      try (HttpRemoteFetcher.Result result = client.get(
-          runtime("http://localhost", "robot", "secret"),
-          "library/alpine/manifests/latest",
-          "application/json")) {
-        assertEquals(200, result.status());
-      }
-
-      List<String> plainHttpAuthorizations = router.requests().stream()
-          .filter(request -> "GET".equals(request.method()))
-          .map(request -> request.header("Authorization"))
-          .toList();
-      assertEquals(List.of(basic("robot", "secret")), plainHttpAuthorizations,
-          "the bearer token must retry directly on the upgraded HTTPS URL");
-      assertEquals(List.of(basic("robot", "secret"), "Bearer tls-token"), manifestAuthorizations);
-      assertEquals(List.of(basic("robot", "secret")), tokenAuthorizations);
-      List<FakeHttpProxyServer.RecordedRequest> connectRequests = router.requests().stream()
-          .filter(request -> "CONNECT".equals(request.method()))
-          .toList();
-      assertFalse(connectRequests.isEmpty());
-      assertTrue(connectRequests.stream()
-          .allMatch(request -> "localhost:443".equals(request.target())));
+    try (HttpRemoteFetcher.Result result = client.get(
+        runtime("http://localhost", "robot", "secret"),
+        "library/alpine/manifests/latest",
+        "application/json")) {
+      assertEquals(200, result.status());
     }
+
+    assertEquals(List.of("http", "https", "https", "https"),
+        calls.stream().map(call -> call.uri().getScheme()).toList());
+    assertEquals(List.of(
+            basic("robot", "secret"),
+            basic("robot", "secret"),
+            basic("robot", "secret"),
+            "Bearer tls-token"),
+        calls.stream().map(call -> call.headers().get("Authorization")).toList());
+    assertTrue(calls.stream().allMatch(call -> call.proxy() == null),
+        "a repository without an outbound proxy must still use the DNS-pinned transport");
   }
 
   @Test
@@ -556,7 +530,9 @@ class DockerRemoteRegistryClientTest {
           OutboundRequestPolicy.allowPrivateForTests(),
           new InMemorySharedCache(),
           true,
-          300);
+          300,
+          null,
+          directFactory);
       RepositoryRuntime runtime = runtime(registry.baseUrl, null, null);
 
       for (int i = 0; i < 2; i++) {
@@ -628,7 +604,9 @@ class DockerRemoteRegistryClientTest {
           OutboundRequestPolicy.allowPrivateForTests(),
           new InMemorySharedCache(),
           true,
-          300);
+          300,
+          null,
+          directFactory);
       RepositoryRuntime runtime = runtime(registry.baseUrl, "robot", "secret");
 
       try (HttpRemoteFetcher.Result result = client.get(
@@ -668,7 +646,7 @@ class DockerRemoteRegistryClientTest {
           true,
           300,
           new KkRepoMetrics(meterRegistry),
-          null);
+          directFactory);
 
       try (HttpRemoteFetcher.Result result = client.get(
           runtime(registry.baseUrl, null, null),
@@ -894,8 +872,9 @@ class DockerRemoteRegistryClientTest {
         outboundProxy);
   }
 
-  private static DockerRemoteRegistryClient client() {
-    return new DockerRemoteRegistryClient(null, OutboundRequestPolicy.allowPrivateForTests());
+  private DockerRemoteRegistryClient client() {
+    return new DockerRemoteRegistryClient(
+        null, OutboundRequestPolicy.allowPrivateForTests(), null, true, 300, null, directFactory);
   }
 
   private static RepositoryRuntime runtime(String remoteUrl, String username, String password) {
@@ -929,6 +908,29 @@ class DockerRemoteRegistryClientTest {
         .encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
   }
 
+  private static ProxiedHttpClientFactory.ProxiedResponse response(
+      int status, Map<String, String> headers, String body) throws IOException {
+    ProxiedHttpClientFactory.ProxiedResponse response =
+        mock(ProxiedHttpClientFactory.ProxiedResponse.class);
+    when(response.status()).thenReturn(status);
+    when(response.headers()).thenReturn(headers);
+    when(response.header(anyString())).thenAnswer(invocation -> {
+      String name = invocation.getArgument(0);
+      return headers.entrySet().stream()
+          .filter(entry -> entry.getKey().equalsIgnoreCase(name))
+          .map(Map.Entry::getValue)
+          .findFirst()
+          .orElse(null);
+    });
+    when(response.body()).thenAnswer(ignored ->
+        new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
+    return response;
+  }
+
+  private record TransportCall(
+      URI uri, OutboundProxyConfig proxy, Map<String, String> headers) {
+  }
+
   private static final class TestRegistry implements AutoCloseable {
     private final HttpServer server;
     private final String baseUrl;
@@ -942,78 +944,6 @@ class DockerRemoteRegistryClientTest {
       HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
       server.start();
       return new TestRegistry(server);
-    }
-
-    @Override
-    public void close() {
-      server.stop(0);
-    }
-  }
-
-  private static final class TestTlsRegistry implements AutoCloseable {
-    private static final char[] KEY_PASSWORD = "test-password".toCharArray();
-
-    private final HttpsServer server;
-    private final SSLContext clientSslContext;
-
-    private TestTlsRegistry(HttpsServer server, SSLContext clientSslContext) {
-      this.server = server;
-      this.clientSslContext = clientSslContext;
-    }
-
-    static TestTlsRegistry start() throws Exception {
-      SecureRandom random = new SecureRandom();
-      KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
-      keyPairGenerator.initialize(2048, random);
-      KeyPair keyPair = keyPairGenerator.generateKeyPair();
-
-      Instant now = Instant.now();
-      X500Name subject = new X500Name("CN=localhost");
-      JcaX509v3CertificateBuilder certificateBuilder = new JcaX509v3CertificateBuilder(
-          subject,
-          new BigInteger(128, random).setBit(127),
-          Date.from(now.minusSeconds(60)),
-          Date.from(now.plusSeconds(86400)),
-          subject,
-          keyPair.getPublic());
-      certificateBuilder.addExtension(
-          Extension.subjectAlternativeName,
-          false,
-          new GeneralNames(new GeneralName(GeneralName.dNSName, "localhost")));
-      ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
-          .build(keyPair.getPrivate());
-      X509Certificate certificate = new JcaX509CertificateConverter()
-          .getCertificate(certificateBuilder.build(signer));
-      certificate.verify(keyPair.getPublic());
-
-      KeyStore keyStore = KeyStore.getInstance("PKCS12");
-      keyStore.load(null, KEY_PASSWORD);
-      keyStore.setKeyEntry(
-          "server",
-          keyPair.getPrivate(),
-          KEY_PASSWORD,
-          new Certificate[] {certificate});
-      KeyManagerFactory keyManagers = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-      keyManagers.init(keyStore, KEY_PASSWORD);
-
-      SSLContext serverContext = SSLContext.getInstance("TLS");
-      serverContext.init(keyManagers.getKeyManagers(), null, random);
-      HttpsServer server = HttpsServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
-      server.setHttpsConfigurator(new HttpsConfigurator(serverContext));
-      server.start();
-
-      KeyStore trustStore = KeyStore.getInstance("PKCS12");
-      trustStore.load(null, null);
-      trustStore.setCertificateEntry("server", certificate);
-      TrustManagerFactory trustManagers = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-      trustManagers.init(trustStore);
-      SSLContext clientContext = SSLContext.getInstance("TLS");
-      clientContext.init(null, trustManagers.getTrustManagers(), random);
-      return new TestTlsRegistry(server, clientContext);
-    }
-
-    int port() {
-      return server.getAddress().getPort();
     }
 
     @Override

--- a/server/src/test/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClientTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClientTest.java
@@ -707,8 +707,12 @@ class DockerRemoteRegistryClientTest {
 
       assertEquals(1, proxy.requests().size());
       FakeHttpProxyServer.RecordedRequest recorded = proxy.requests().get(0);
-      assertEquals("http://localhost/v2/library/alpine/manifests/latest",
-          recorded.target());
+      URI routed = URI.create(recorded.target());
+      java.net.InetAddress routedAddress = java.net.InetAddress.getByName(routed.getHost());
+      assertTrue(java.util.Arrays.stream(java.net.InetAddress.getAllByName("localhost"))
+          .anyMatch(routedAddress::equals));
+      assertEquals("/v2/library/alpine/manifests/latest", routed.getRawPath());
+      assertEquals("localhost", recorded.header("Host"));
       assertEquals(basic("robot", "secret"), recorded.header("Authorization"));
       assertEquals("application/vnd.docker.distribution.manifest.v2+json", recorded.header("Accept"));
     }
@@ -739,7 +743,9 @@ class DockerRemoteRegistryClientTest {
 
       assertEquals(2, proxy.requests().size());
       assertEquals(basic("robot", "secret"), proxy.requests().get(0).header("Authorization"));
-      assertEquals("http://127.0.0.1/layers/abc", proxy.requests().get(1).target());
+      URI redirected = URI.create(proxy.requests().get(1).target());
+      assertEquals("127.0.0.1", redirected.getHost());
+      assertEquals("/layers/abc", redirected.getRawPath());
       assertNull(proxy.requests().get(1).header("Authorization"),
           "registry credentials must not leak to the cross-origin storage URL");
     }
@@ -776,7 +782,8 @@ class DockerRemoteRegistryClientTest {
   void proxiedBearerTokenFlowFetchesTokenThroughProxy() throws Exception {
     AtomicInteger manifestCalls = new AtomicInteger();
     try (FakeHttpProxyServer proxy = FakeHttpProxyServer.start(request -> {
-          if (request.target().startsWith("http://127.0.0.1/token")) {
+          URI target = URI.create(request.target());
+          if ("127.0.0.1".equals(target.getHost()) && "/token".equals(target.getPath())) {
             return FakeHttpProxyServer.FakeResponse.bytes(200,
                 Map.of("Content-Type", "application/json"),
                 "{\"token\":\"proxied-remote-token\"}".getBytes(StandardCharsets.UTF_8));
@@ -803,7 +810,7 @@ class DockerRemoteRegistryClientTest {
       }
 
       FakeHttpProxyServer.RecordedRequest tokenRequest = proxy.requests().stream()
-          .filter(request -> request.target().startsWith("http://127.0.0.1/token"))
+          .filter(request -> "/token".equals(URI.create(request.target()).getPath()))
           .findFirst()
           .orElseThrow();
       assertEquals(basic("robot", "secret"), tokenRequest.header("Authorization"));

--- a/server/src/test/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcherProxyTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcherProxyTest.java
@@ -3,6 +3,7 @@ package com.github.klboke.kkrepo.server.maven;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.klboke.kkrepo.server.proxy.OutboundProxyConfig;
 import com.github.klboke.kkrepo.server.proxy.ProxiedHttpClientFactory;
@@ -53,7 +54,8 @@ class HttpRemoteFetcherProxyTest {
       assertEquals(1, proxy.requests().size());
       FakeHttpProxyServer.RecordedRequest recorded = proxy.requests().get(0);
       assertEquals("GET", recorded.method());
-      assertEquals("http://localhost/com/acme/lib/1.0/lib-1.0.pom", recorded.target());
+      assertPinnedLocalhostTarget(recorded, "/com/acme/lib/1.0/lib-1.0.pom");
+      assertEquals("localhost", recorded.header("Host"));
       assertEquals("\"abc123\"", recorded.header("If-None-Match"));
       assertEquals(
           DateTimeFormatter.RFC_1123_DATE_TIME.withZone(ZoneOffset.UTC).format(lastModified),
@@ -95,7 +97,9 @@ class HttpRemoteFetcherProxyTest {
 
       assertEquals(2, proxy.requests().size());
       assertEquals("Basic cm9ib3Q6c2VjcmV0", proxy.requests().get(0).header("Authorization"));
-      assertEquals("http://127.0.0.1/files/lib-1.0.jar", proxy.requests().get(1).target());
+      URI redirectedTarget = URI.create(proxy.requests().get(1).target());
+      assertEquals("127.0.0.1", redirectedTarget.getHost());
+      assertEquals("/files/lib-1.0.jar", redirectedTarget.getRawPath());
       assertNull(proxy.requests().get(1).header("Authorization"),
           "credentials must not leak to the cross-origin redirect target");
     }
@@ -131,7 +135,7 @@ class HttpRemoteFetcherProxyTest {
       }
 
       assertEquals(2, proxy.requests().size());
-      assertEquals("http://localhost/moved/lib-1.0.jar", proxy.requests().get(1).target());
+      assertPinnedLocalhostTarget(proxy.requests().get(1), "/moved/lib-1.0.jar");
       assertEquals("Basic cm9ib3Q6c2VjcmV0", proxy.requests().get(1).header("Authorization"));
     }
   }
@@ -217,5 +221,15 @@ class HttpRemoteFetcherProxyTest {
 
   private static OutboundProxyConfig proxyConfig(int port, String username, String password) {
     return new OutboundProxyConfig(OutboundProxyConfig.Type.HTTP, "127.0.0.1", port, username, password);
+  }
+
+  private static void assertPinnedLocalhostTarget(
+      FakeHttpProxyServer.RecordedRequest recorded, String expectedPath)
+      throws Exception {
+    URI routed = URI.create(recorded.target());
+    java.net.InetAddress routedAddress = java.net.InetAddress.getByName(routed.getHost());
+    assertTrue(java.util.Arrays.stream(java.net.InetAddress.getAllByName("localhost"))
+        .anyMatch(routedAddress::equals));
+    assertEquals(expectedPath, routed.getRawPath());
   }
 }

--- a/server/src/test/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcherTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcherTest.java
@@ -38,7 +38,7 @@ class HttpRemoteFetcherTest {
   }
 
   @Test
-  void httpVersionAllowsHttp2OptIn() {
+  void httpVersionRecognizesHttp2ForDowngradeWarning() {
     assertEquals(HttpClient.Version.HTTP_2, HttpRemoteFetcher.httpVersion("HTTP_2"));
     assertEquals(HttpClient.Version.HTTP_2, HttpRemoteFetcher.httpVersion("http2"));
     assertEquals(HttpClient.Version.HTTP_2, HttpRemoteFetcher.httpVersion("2"));
@@ -88,10 +88,10 @@ class HttpRemoteFetcherTest {
 
   @Test
   void requestWithoutTrustedHostDoesNotPinOutboundHost() {
-    HttpRemoteFetcher.Request request = HttpRemoteFetcher.Request.get("https://repo.example.com/artifact.jar");
+    HttpRemoteFetcher.Request request = HttpRemoteFetcher.Request.get("https://localhost/artifact.jar");
 
-    assertEquals("repo.example.com",
-        request.validatedUri(new OutboundRequestPolicy(false, "repo.example.com"), "remote fetch").getHost());
+    assertEquals("localhost",
+        request.validatedUri(new OutboundRequestPolicy(false, "localhost"), "remote fetch").getHost());
   }
 
   @Test
@@ -108,15 +108,15 @@ class HttpRemoteFetcherTest {
         "RELEASE",
         "STRICT",
         true,
-        "https://repo.example.com/maven2",
+        "https://localhost/maven2",
         1440,
         1440,
         List.of());
     HttpRemoteFetcher.Request trusted = HttpRemoteFetcher.Request
-        .get("https://repo.example.com/maven2/com/example/app.jar")
+        .get("https://localhost/maven2/com/example/app.jar")
         .withRepository(runtime);
     HttpRemoteFetcher.Request tampered = new HttpRemoteFetcher.Request(
-        "https://evil.example.com/maven2/com/example/app.jar",
+        "https://127.0.0.1/maven2/com/example/app.jar",
         trusted.etag(),
         trusted.lastModified(),
         trusted.timeout(),
@@ -126,12 +126,12 @@ class HttpRemoteFetcherTest {
         trusted.format(),
         trusted.trustedHost());
 
-    OutboundRequestPolicy policy = new OutboundRequestPolicy(false, "repo.example.com,evil.example.com");
-    assertEquals("repo.example.com", trusted.validatedUri(policy, "remote fetch").getHost());
+    OutboundRequestPolicy policy = new OutboundRequestPolicy(false, "localhost,127.0.0.1");
+    assertEquals("localhost", trusted.validatedUri(policy, "remote fetch").getHost());
     SecurityValidationException error = assertThrows(
         SecurityValidationException.class,
         () -> tampered.validatedUri(policy, "remote fetch"));
-    assertEquals("remote fetch URL host must remain repo.example.com", error.getMessage());
+    assertEquals("remote fetch URL host must remain localhost", error.getMessage());
   }
 
   @Test

--- a/server/src/test/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcherTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcherTest.java
@@ -42,6 +42,24 @@ class HttpRemoteFetcherTest {
     assertEquals(HttpClient.Version.HTTP_2, HttpRemoteFetcher.httpVersion("HTTP_2"));
     assertEquals(HttpClient.Version.HTTP_2, HttpRemoteFetcher.httpVersion("http2"));
     assertEquals(HttpClient.Version.HTTP_2, HttpRemoteFetcher.httpVersion("2"));
+
+    HttpRemoteFetcher fetcher = new HttpRemoteFetcher(
+        null, null, null, "HTTP_2", 11, 22, 33, 7, 1);
+    assertEquals(
+        Duration.ofSeconds(33),
+        fetcher.requestTimeout(HttpRemoteFetcher.Request.get("https://repo.example/artifact.jar")));
+  }
+
+  @Test
+  void convenienceConstructorCannotExecuteWithoutPinnedTransportFactory() {
+    HttpRemoteFetcher fetcher =
+        new HttpRemoteFetcher(OutboundRequestPolicy.allowPrivateForTests());
+
+    IllegalStateException error = assertThrows(
+        IllegalStateException.class,
+        () -> fetcher.fetch(HttpRemoteFetcher.Request.get("http://localhost/artifact.jar")));
+
+    assertEquals("Outbound HTTP client factory is required", error.getMessage());
   }
 
   @Test

--- a/server/src/test/java/com/github/klboke/kkrepo/server/proxy/ProxiedHttpClientFactoryTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/proxy/ProxiedHttpClientFactoryTest.java
@@ -35,6 +35,17 @@ import org.junit.jupiter.api.Test;
 class ProxiedHttpClientFactoryTest {
 
   @Test
+  void ipv6LiteralUsesUnbracketedApacheEndpointHost() {
+    URI uri = URI.create("https://[2001:db8::1]/artifact");
+
+    String endpointHost = ProxiedHttpClientFactory.endpointHost(uri);
+
+    assertEquals("2001:db8::1", endpointHost);
+    assertEquals("2001:db8::1", new HttpHost(uri.getScheme(), endpointHost, 443).getHostName(),
+        "TLS peer name must not include URI-only IPv6 brackets");
+  }
+
+  @Test
   void executeRejectsMissingResolvedTargetCapability() throws Exception {
     try (ProxiedHttpClientFactory factory = new ProxiedHttpClientFactory(60000, 10000)) {
       IllegalArgumentException error = assertThrows(

--- a/server/src/test/java/com/github/klboke/kkrepo/server/proxy/ProxiedHttpClientFactoryTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/proxy/ProxiedHttpClientFactoryTest.java
@@ -9,6 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.github.klboke.kkrepo.server.security.OutboundRequestPolicy;
+import com.github.klboke.kkrepo.server.security.OutboundRequestPolicy.ResolvedHttpTarget;
 import com.github.klboke.kkrepo.server.support.FakeHttpProxyServer;
 import java.io.IOException;
 import java.io.InputStream;
@@ -23,8 +25,9 @@ import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
 import org.junit.jupiter.api.Test;
 
 class ProxiedHttpClientFactoryTest {
@@ -80,7 +83,7 @@ class ProxiedHttpClientFactoryTest {
           OutboundProxyConfig.Type.SOCKS, "127.0.0.1", staller.getLocalPort(), null, null);
       long startNanos = System.nanoTime();
       assertThrows(IOException.class, () ->
-          factory.execute("repo-a", config, "GET", java.net.URI.create("http://localhost/"),
+          factory.execute("repo-a", config, "GET", target("http://localhost/"),
               java.util.Map.of(), 60000));
       long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
       // The connect timeout is 500 ms; the greeting read must time out near it. The upper bound
@@ -128,7 +131,7 @@ class ProxiedHttpClientFactoryTest {
           OutboundProxyConfig.Type.SOCKS, "127.0.0.1", dripper.getLocalPort(), null, null);
       long startNanos = System.nanoTime();
       assertThrows(IOException.class, () ->
-          factory.execute("repo-a", config, "GET", java.net.URI.create("http://localhost/"),
+          factory.execute("repo-a", config, "GET", target("http://localhost/"),
               java.util.Map.of(), 60000));
       long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
       assertTrue(elapsedMillis >= 400,
@@ -202,11 +205,15 @@ class ProxiedHttpClientFactoryTest {
         // "localhost" resolves locally; the tunnel to it succeeds at the SOCKS layer and the server
         // then closes, so the HTTP exchange itself fails — only the handshake matters here.
         assertThrows(IOException.class, () ->
-            factory.execute("repo-a", config, "GET", java.net.URI.create("http://localhost/"),
+            factory.execute("repo-a", config, "GET", target("http://localhost/"),
                 java.util.Map.of(), 5000));
       }
       assertTrue(server.awaitHandshake(), "SOCKS server never saw an authentication attempt");
       assertOnlyCredentials(server, "alice", "s3cret");
+      assertTrue(!server.targetAddressTypes().isEmpty(), "SOCKS server never saw CONNECT");
+      assertTrue(server.targetAddressTypes().stream().allMatch(type -> type != 0x03),
+          "SOCKS CONNECT must use a policy-approved IP, not ask the proxy to resolve a domain: "
+              + server.targetAddressTypes());
     } finally {
       server.stop();
     }
@@ -228,10 +235,10 @@ class ProxiedHttpClientFactoryTest {
       try (CloseableHttpClient ignored = factory.clientFor("repo-one", configOne);
           CloseableHttpClient ignored2 = factory.clientFor("repo-two", configTwo)) {
         assertThrows(IOException.class, () ->
-            factory.execute("repo-one", configOne, "GET", java.net.URI.create("http://localhost/"),
+            factory.execute("repo-one", configOne, "GET", target("http://localhost/"),
                 java.util.Map.of(), 5000));
         assertThrows(IOException.class, () ->
-            factory.execute("repo-two", configTwo, "GET", java.net.URI.create("http://localhost/"),
+            factory.execute("repo-two", configTwo, "GET", target("http://localhost/"),
                 java.util.Map.of(), 5000));
       }
       assertTrue(first.awaitHandshake());
@@ -263,10 +270,10 @@ class ProxiedHttpClientFactoryTest {
           CloseableHttpClient clientB = factory.clientFor("repo-bob", bob)) {
         assertNotSame(clientA, clientB);
         assertThrows(IOException.class, () ->
-            factory.execute("repo-alice", alice, "GET", java.net.URI.create("http://localhost/"),
+            factory.execute("repo-alice", alice, "GET", target("http://localhost/"),
                 java.util.Map.of(), 5000));
         assertThrows(IOException.class, () ->
-            factory.execute("repo-bob", bob, "GET", java.net.URI.create("http://localhost/"),
+            factory.execute("repo-bob", bob, "GET", target("http://localhost/"),
                 java.util.Map.of(), 5000));
       }
       assertTrue(server.awaitHandshake());
@@ -297,7 +304,7 @@ class ProxiedHttpClientFactoryTest {
           OutboundProxyConfig.Type.SOCKS, "127.0.0.1", server.port(), null, null);
       try (CloseableHttpClient ignored = factory.clientFor("repo-a", authed)) {
         assertThrows(IOException.class, () ->
-            factory.execute("repo-a", authed, "GET", java.net.URI.create("http://localhost/"),
+            factory.execute("repo-a", authed, "GET", target("http://localhost/"),
                 java.util.Map.of(), 5000));
       }
       int authedAttempts = server.attempts().size();
@@ -307,7 +314,7 @@ class ProxiedHttpClientFactoryTest {
       factory.invalidate("repo-a", authed);
       try (CloseableHttpClient ignored = factory.clientFor("repo-a", anonymous)) {
         assertThrows(IOException.class, () ->
-            factory.execute("repo-a", anonymous, "GET", java.net.URI.create("http://localhost/"),
+            factory.execute("repo-a", anonymous, "GET", target("http://localhost/"),
                 java.util.Map.of(), 5000));
       }
       assertEquals(authedAttempts, server.attempts().size(),
@@ -339,11 +346,13 @@ class ProxiedHttpClientFactoryTest {
         ProxiedHttpClientFactory factory = new ProxiedHttpClientFactory(60000, 10000)) {
       OutboundProxyConfig config =
           new OutboundProxyConfig(OutboundProxyConfig.Type.HTTP, "127.0.0.1", proxy.port(), null, null);
+      ResolvedHttpTarget target =
+          target("http://localhost/org/foo/1.0/foo-1.0.jar");
       try (ProxiedHttpClientFactory.ProxiedResponse response = factory.execute(
           "repo-a",
           config,
           "GET",
-          URI.create("http://repo.example.com/org/foo/1.0/foo-1.0.jar"),
+          target,
           Map.of("X-Test", "yes"),
           5000)) {
         assertEquals(200, response.status());
@@ -353,7 +362,8 @@ class ProxiedHttpClientFactoryTest {
       }
       FakeHttpProxyServer.RecordedRequest recorded = proxy.requests().get(0);
       assertEquals("GET", recorded.method());
-      assertEquals("http://repo.example.com/org/foo/1.0/foo-1.0.jar", recorded.target());
+      assertPinnedProxyTarget(target, recorded);
+      assertEquals("localhost", recorded.header("Host"));
       assertEquals("yes", recorded.header("X-Test"));
     }
   }
@@ -366,7 +376,7 @@ class ProxiedHttpClientFactoryTest {
       OutboundProxyConfig config =
           new OutboundProxyConfig(OutboundProxyConfig.Type.HTTP, "127.0.0.1", proxy.port(), null, null);
       try (ProxiedHttpClientFactory.ProxiedResponse response = factory.execute(
-          "repo-a", config, "HEAD", URI.create("http://repo.example.com/artifact"), Map.of(), 5000)) {
+          "repo-a", config, "HEAD", target("http://localhost/artifact"), Map.of(), 5000)) {
         assertEquals(200, response.status());
         assertEquals("\"abc\"", response.header("etag"));
         assertEquals(0, response.body().readAllBytes().length);
@@ -389,7 +399,7 @@ class ProxiedHttpClientFactoryTest {
       OutboundProxyConfig config = new OutboundProxyConfig(
           OutboundProxyConfig.Type.HTTP, "127.0.0.1", proxy.port(), "proxy-user", "proxy-pass");
       try (ProxiedHttpClientFactory.ProxiedResponse response = factory.execute(
-          "repo-a", config, "GET", URI.create("http://repo.example.com/artifact"), Map.of(), 5000)) {
+          "repo-a", config, "GET", target("http://localhost/artifact"), Map.of(), 5000)) {
         assertEquals(200, response.status());
       }
       assertEquals(2, proxy.requests().size());
@@ -410,9 +420,9 @@ class ProxiedHttpClientFactoryTest {
       OutboundProxyConfig configTwo = new OutboundProxyConfig(
           OutboundProxyConfig.Type.HTTP, "127.0.0.1", second.port(), "user-two", "pw-two");
       try (ProxiedHttpClientFactory.ProxiedResponse ignored = factory.execute(
-              "repo-one", configOne, "GET", URI.create("http://repo.example.com/a"), Map.of(), 5000);
+              "repo-one", configOne, "GET", target("http://localhost/a"), Map.of(), 5000);
           ProxiedHttpClientFactory.ProxiedResponse ignored2 = factory.execute(
-              "repo-two", configTwo, "GET", URI.create("http://repo.example.com/b"), Map.of(), 5000)) {
+              "repo-two", configTwo, "GET", target("http://localhost/b"), Map.of(), 5000)) {
         assertEquals(200, ignored.status());
         assertEquals(200, ignored2.status());
       }
@@ -445,7 +455,7 @@ class ProxiedHttpClientFactoryTest {
       OutboundProxyConfig config =
           new OutboundProxyConfig(OutboundProxyConfig.Type.HTTP, "127.0.0.1", proxy.port(), null, null);
       try (ProxiedHttpClientFactory.ProxiedResponse response = factory.execute(
-          "repo-a", config, "GET", URI.create("http://repo.example.com/original"), Map.of(), 5000)) {
+          "repo-a", config, "GET", target("http://localhost/original"), Map.of(), 5000)) {
         assertEquals(302, response.status());
         assertEquals("http://elsewhere.example.com/redirected", response.header("Location"));
       }
@@ -462,11 +472,14 @@ class ProxiedHttpClientFactoryTest {
           new OutboundProxyConfig(OutboundProxyConfig.Type.HTTP, "127.0.0.1", proxy.port(), null, null);
       // The fake proxy answers CONNECT and then drops the tunnel, so the TLS handshake fails —
       // only the CONNECT request line matters here.
+      ResolvedHttpTarget target = target("https://localhost:8443/path");
       assertThrows(IOException.class, () -> factory.execute(
-          "repo-a", config, "GET", URI.create("https://secure.example.com:8443/path"), Map.of(), 5000));
+          "repo-a", config, "GET", target, Map.of(), 5000));
       FakeHttpProxyServer.RecordedRequest connect = proxy.requests().get(0);
       assertEquals("CONNECT", connect.method());
-      assertEquals("secure.example.com:8443", connect.target());
+      assertEquals(target.addresses().get(0),
+          java.net.InetAddress.getByName(URI.create("http://" + connect.target()).getHost()));
+      assertTrue(connect.target().endsWith(":8443"));
     }
   }
 
@@ -475,9 +488,9 @@ class ProxiedHttpClientFactoryTest {
     ProxiedHttpClientFactory factory = new ProxiedHttpClientFactory(100, 10000);
     try {
       OutboundProxyConfig stale =
-          new OutboundProxyConfig(OutboundProxyConfig.Type.HTTP, "10.0.0.6", 7890, null, null);
+          new OutboundProxyConfig(OutboundProxyConfig.Type.HTTP, "127.0.0.1", 1, null, null);
       OutboundProxyConfig active =
-          new OutboundProxyConfig(OutboundProxyConfig.Type.HTTP, "10.0.0.7", 7890, null, null);
+          new OutboundProxyConfig(OutboundProxyConfig.Type.HTTP, "127.0.0.1", 2, null, null);
       CloseableHttpClient staleClient = factory.clientFor("repo-stale", stale);
       assertNotNull(staleClient);
       Thread.sleep(1200);
@@ -485,7 +498,7 @@ class ProxiedHttpClientFactoryTest {
       while (System.nanoTime() < deadline) {
         factory.clientFor("repo-active", active); // touching the cache runs eviction maintenance
         try {
-          staleClient.executeOpen(null, new HttpGet("http://localhost/"), null);
+          probeClient(staleClient);
         } catch (IllegalStateException closed) {
           return;
         } catch (IOException stillOpen) {
@@ -510,7 +523,7 @@ class ProxiedHttpClientFactoryTest {
       assertNotSame(cached, factory.clientFor("repo-a", config),
           "invalidate must drop the cached client so the next lookup rebuilds it");
       assertThrows(IllegalStateException.class, () ->
-          cached.executeOpen(null, new HttpGet("http://localhost/"), null));
+          probeClient(cached));
     }
   }
 
@@ -557,7 +570,30 @@ class ProxiedHttpClientFactoryTest {
     factory.close();
     // After close the client must be shut down: executing against it throws IllegalStateException.
     assertThrows(IllegalStateException.class, () ->
-        client.executeOpen(null, new HttpGet("http://localhost/"), null));
+        probeClient(client));
+  }
+
+  private static void probeClient(CloseableHttpClient client) throws IOException {
+    java.net.InetAddress address = java.net.InetAddress.getLoopbackAddress();
+    HttpHost target = new HttpHost("http", address, address.getHostAddress(), 1);
+    try (var response = client.executeOpen(
+        target, new BasicClassicHttpRequest("GET", "/"), null)) {
+      // A live client may reach a test listener; closing is enough for this lifecycle probe.
+    }
+  }
+
+  private static ResolvedHttpTarget target(String url) {
+    return OutboundRequestPolicy.allowPrivateForTests()
+        .resolveHttpTarget(url, "outbound client test");
+  }
+
+  private static void assertPinnedProxyTarget(
+      ResolvedHttpTarget target, FakeHttpProxyServer.RecordedRequest recorded)
+      throws Exception {
+    URI routed = URI.create(recorded.target());
+    assertEquals(target.addresses().get(0), java.net.InetAddress.getByName(routed.getHost()));
+    assertEquals(target.uri().getRawPath(), routed.getRawPath());
+    assertEquals(target.uri().getRawQuery(), routed.getRawQuery());
   }
 
   /**
@@ -574,6 +610,7 @@ class ProxiedHttpClientFactoryTest {
     private final List<String> passwords = new CopyOnWriteArrayList<>();
     private final List<String> attempts = new CopyOnWriteArrayList<>();
     private final List<Integer> selectedMethods = new CopyOnWriteArrayList<>();
+    private final List<Integer> targetAddressTypes = new CopyOnWriteArrayList<>();
     private final CountDownLatch handshakeSeen = new CountDownLatch(1);
     private ServerSocket serverSocket;
     private Thread thread;
@@ -616,6 +653,11 @@ class ProxiedHttpClientFactoryTest {
     /** Auth method the server selected per handshake (0x00 anonymous, 0x02 username/password). */
     List<Integer> selectedMethods() {
       return selectedMethods;
+    }
+
+    /** SOCKS5 address types used by CONNECT (0x01 IPv4, 0x03 domain, 0x04 IPv6). */
+    List<Integer> targetAddressTypes() {
+      return targetAddressTypes;
     }
 
     boolean awaitHandshake() throws InterruptedException {
@@ -698,6 +740,7 @@ class ProxiedHttpClientFactoryTest {
         in.read(); // cmd
         in.read(); // rsv
         int atyp = in.read();
+        targetAddressTypes.add(atyp);
         if (atyp == 0x03) {
           int len = in.read();
           in.readNBytes(Math.max(0, len));

--- a/server/src/test/java/com/github/klboke/kkrepo/server/proxy/ProxiedHttpClientFactoryTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/proxy/ProxiedHttpClientFactoryTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
@@ -74,13 +75,74 @@ class ProxiedHttpClientFactoryTest {
           "http://127.0.0.1:" + upstream.getAddress().getPort() + "?source=test");
 
       try (ProxiedHttpClientFactory.ProxiedResponse response = factory.execute(
-          "repo-a", disabled, "GET", target, Map.of(), 5000)) {
+          "repo-a", disabled, null, target, Map.of(), 5000)) {
         assertEquals(200, response.status());
         assertEquals("/?source=test",
             new String(response.body().readAllBytes(), StandardCharsets.UTF_8));
       }
     } finally {
       upstream.stop(0);
+    }
+  }
+
+  @Test
+  void pinnedDirectClientSendsPostBodyAndHeaders() throws Exception {
+    AtomicReference<String> method = new AtomicReference<>();
+    AtomicReference<String> contentType = new AtomicReference<>();
+    AtomicReference<String> requestBody = new AtomicReference<>();
+    HttpServer upstream = HttpServer.create(
+        new InetSocketAddress(java.net.InetAddress.getByName("127.0.0.1"), 0), 0);
+    upstream.createContext("/token", exchange -> {
+      method.set(exchange.getRequestMethod());
+      contentType.set(exchange.getRequestHeaders().getFirst("Content-Type"));
+      requestBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+      byte[] response = "ok".getBytes(StandardCharsets.UTF_8);
+      exchange.sendResponseHeaders(200, response.length);
+      exchange.getResponseBody().write(response);
+      exchange.close();
+    });
+    upstream.start();
+    try (ProxiedHttpClientFactory factory = new ProxiedHttpClientFactory(60000, 10000)) {
+      ResolvedHttpTarget target = target(
+          "http://127.0.0.1:" + upstream.getAddress().getPort() + "/token");
+
+      try (ProxiedHttpClientFactory.ProxiedResponse response = factory.execute(
+          "security:oidc-token",
+          null,
+          "POST",
+          target,
+          Map.of("Content-Type", "application/x-www-form-urlencoded"),
+          "code=one-time".getBytes(StandardCharsets.UTF_8),
+          5000)) {
+        assertEquals(200, response.status());
+        assertEquals("ok", new String(response.body().readAllBytes(), StandardCharsets.UTF_8));
+      }
+      assertEquals("POST", method.get());
+      assertEquals("application/x-www-form-urlencoded", contentType.get());
+      assertEquals("code=one-time", requestBody.get());
+    } finally {
+      upstream.stop(0);
+    }
+  }
+
+  @Test
+  void failedPostIsNotRetriedAgainstAnotherResolvedAddress() throws Exception {
+    int closedPort;
+    try (ServerSocket socket = new ServerSocket(
+        0, 50, java.net.InetAddress.getByName("127.0.0.1"))) {
+      closedPort = socket.getLocalPort();
+    }
+    try (ProxiedHttpClientFactory factory = new ProxiedHttpClientFactory(60000, 1000)) {
+      ResolvedHttpTarget target = target("http://localhost:" + closedPort + "/token");
+
+      assertThrows(IOException.class, () -> factory.execute(
+          "security:oidc-token",
+          null,
+          "POST",
+          target,
+          Map.of("Content-Type", "application/x-www-form-urlencoded"),
+          "code=one-time".getBytes(StandardCharsets.UTF_8),
+          1000));
     }
   }
 

--- a/server/src/test/java/com/github/klboke/kkrepo/server/proxy/ProxiedHttpClientFactoryTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/proxy/ProxiedHttpClientFactoryTest.java
@@ -12,9 +12,11 @@ import static org.junit.jupiter.api.Assertions.fail;
 import com.github.klboke.kkrepo.server.security.OutboundRequestPolicy;
 import com.github.klboke.kkrepo.server.security.OutboundRequestPolicy.ResolvedHttpTarget;
 import com.github.klboke.kkrepo.server.support.FakeHttpProxyServer;
+import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URI;
@@ -31,6 +33,45 @@ import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
 import org.junit.jupiter.api.Test;
 
 class ProxiedHttpClientFactoryTest {
+
+  @Test
+  void executeRejectsMissingResolvedTargetCapability() throws Exception {
+    try (ProxiedHttpClientFactory factory = new ProxiedHttpClientFactory(60000, 10000)) {
+      IllegalArgumentException error = assertThrows(
+          IllegalArgumentException.class,
+          () -> factory.execute("repo-a", null, "GET", null, Map.of(), 5000));
+
+      assertEquals("resolved outbound target is required", error.getMessage());
+    }
+  }
+
+  @Test
+  void disabledProxyUsesPinnedDirectClientAndNormalizesEmptyPath() throws Exception {
+    HttpServer upstream = HttpServer.create(
+        new InetSocketAddress(java.net.InetAddress.getByName("127.0.0.1"), 0), 0);
+    upstream.createContext("/", exchange -> {
+      byte[] body = exchange.getRequestURI().toString().getBytes(StandardCharsets.UTF_8);
+      exchange.sendResponseHeaders(200, body.length);
+      exchange.getResponseBody().write(body);
+      exchange.close();
+    });
+    upstream.start();
+    try (ProxiedHttpClientFactory factory = new ProxiedHttpClientFactory(60000, 10000)) {
+      OutboundProxyConfig disabled =
+          new OutboundProxyConfig(OutboundProxyConfig.Type.HTTP, "", 0, null, null);
+      ResolvedHttpTarget target = target(
+          "http://127.0.0.1:" + upstream.getAddress().getPort() + "?source=test");
+
+      try (ProxiedHttpClientFactory.ProxiedResponse response = factory.execute(
+          "repo-a", disabled, "GET", target, Map.of(), 5000)) {
+        assertEquals(200, response.status());
+        assertEquals("/?source=test",
+            new String(response.body().readAllBytes(), StandardCharsets.UTF_8));
+      }
+    } finally {
+      upstream.stop(0);
+    }
+  }
 
   @Test
   void clientForAcceptsUsernameOnlyHttpProxyWithoutPassword() throws Exception {
@@ -214,6 +255,21 @@ class ProxiedHttpClientFactoryTest {
       assertTrue(server.targetAddressTypes().stream().allMatch(type -> type != 0x03),
           "SOCKS CONNECT must use a policy-approved IP, not ask the proxy to resolve a domain: "
               + server.targetAddressTypes());
+    } finally {
+      server.stop();
+    }
+  }
+
+  @Test
+  void standaloneSocksSocketRetainsUnresolvedDomainCompatibility() throws Exception {
+    RecordingSocksServer server = RecordingSocksServer.acceptingAny();
+    server.start();
+    try (Socks5TunnelSocket socket = new Socks5TunnelSocket(
+        new InetSocketAddress("127.0.0.1", server.port()), null, null)) {
+      socket.connect(InetSocketAddress.createUnresolved("artifact.example", 8080), 5000);
+      assertTrue(server.awaitHandshake());
+      assertEquals(List.of(0x03), server.targetAddressTypes(),
+          "an explicitly unresolved target must use the SOCKS domain address type");
     } finally {
       server.stop();
     }
@@ -480,6 +536,23 @@ class ProxiedHttpClientFactoryTest {
       assertEquals(target.addresses().get(0),
           java.net.InetAddress.getByName(URI.create("http://" + connect.target()).getHost()));
       assertTrue(connect.target().endsWith(":8443"));
+    }
+  }
+
+  @Test
+  void httpsTargetsWithoutExplicitPortUsePinnedPort443() throws Exception {
+    try (FakeHttpProxyServer proxy = FakeHttpProxyServer.start(request ->
+            FakeHttpProxyServer.FakeResponse.status(500, Map.of()));
+        ProxiedHttpClientFactory factory = new ProxiedHttpClientFactory(60000, 10000)) {
+      OutboundProxyConfig config =
+          new OutboundProxyConfig(OutboundProxyConfig.Type.HTTP, "127.0.0.1", proxy.port(), null, null);
+
+      assertThrows(IOException.class, () -> factory.execute(
+          "repo-a", config, "GET", target("https://127.0.0.1/path"), Map.of(), 5000));
+
+      FakeHttpProxyServer.RecordedRequest connect = proxy.requests().get(0);
+      assertEquals("CONNECT", connect.method());
+      assertEquals("127.0.0.1:443", connect.target());
     }
   }
 

--- a/server/src/test/java/com/github/klboke/kkrepo/server/security/OidcLoginControllerTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/security/OidcLoginControllerTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.klboke.kkrepo.auth.PermissionSubject;
 import com.github.klboke.kkrepo.persistence.jdbc.api.SecurityDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.SecurityRealmRecord;
+import com.github.klboke.kkrepo.server.proxy.ProxiedHttpClientFactory;
 import com.github.klboke.kkrepo.server.support.dao.SecurityDaoAdapter;
 import com.sun.net.httpserver.HttpServer;
 import jakarta.servlet.DispatcherType;
@@ -16,6 +17,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import java.lang.reflect.Proxy;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URLDecoder;
@@ -25,10 +27,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.server.ResponseStatusException;
 
 class OidcLoginControllerTest {
+  private final ProxiedHttpClientFactory transportFactory =
+      new ProxiedHttpClientFactory(60_000, 10_000);
+
+  @AfterEach
+  void closeTransportFactory() {
+    transportFactory.close();
+  }
 
   @Test
   void loginRedirectsToConfiguredAuthorizationEndpointAndStoresReturnState() throws Exception {
@@ -41,7 +52,7 @@ class OidcLoginControllerTest {
         "authorizationEndpoint", "https://localhost/oauth2/authorize",
         "redirectUri", "http://nexus.example.com/internal/security/oidc/callback",
         "scopes", "openid profile email groups")));
-    OidcLoginController controller = new OidcLoginController(authentication, new ObjectMapper());
+    OidcLoginController controller = controller(authentication);
 
     controller.login(request(session), response.proxy(), "/browse/");
 
@@ -67,12 +78,8 @@ class OidcLoginControllerTest {
         "issuerUri", "https://localhost",
         "authorizationEndpoint", "http://127.0.0.1/oauth2/authorize",
         "redirectUri", "http://nexus.example.com/internal/security/oidc/callback")));
-    OidcLoginController controller = new OidcLoginController(
-        authentication,
-        new ObjectMapper(),
-        new OutboundRequestPolicy(false, ""),
-        null,
-        "");
+    OidcLoginController controller = controller(
+        authentication, new OutboundRequestPolicy(false, ""), "");
 
     SecurityValidationException error = assertThrows(
         SecurityValidationException.class,
@@ -91,11 +98,9 @@ class OidcLoginControllerTest {
         "issuerUri", "https://issuer.example.com",
         "authorizationEndpoint", "https://login.example.net/oauth2/authorize",
         "redirectUri", "http://nexus.example.com/internal/security/oidc/callback")));
-    OidcLoginController controller = new OidcLoginController(
+    OidcLoginController controller = controller(
         authentication,
-        new ObjectMapper(),
         new OutboundRequestPolicy(false, "issuer.example.com,login.example.net"),
-        null,
         "");
 
     controller.login(request(session), response.proxy(), "/browse/");
@@ -114,11 +119,9 @@ class OidcLoginControllerTest {
         "clientId", "kkrepo",
         "issuerUri", "https://localhost",
         "authorizationEndpoint", "https://localhost/oauth2/authorize")));
-    OidcLoginController controller = new OidcLoginController(
+    OidcLoginController controller = controller(
         authentication,
-        new ObjectMapper(),
         OutboundRequestPolicy.allowPrivateForTests(),
-        null,
         "https://nexus.example.com/");
 
     controller.login(request(session), response.proxy(), "/browse/");
@@ -138,7 +141,7 @@ class OidcLoginControllerTest {
         "clientId", "kkrepo",
         "issuerUri", "https://localhost",
         "authorizationEndpoint", "https://localhost/oauth2/authorize")));
-    OidcLoginController controller = new OidcLoginController(authentication, new ObjectMapper());
+    OidcLoginController controller = controller(authentication);
 
     ResponseStatusException error = assertThrows(
         ResponseStatusException.class,
@@ -160,13 +163,37 @@ class OidcLoginControllerTest {
           "clientId", "kkrepo",
           "issuerUri", discovery.issuer(),
           "redirectUri", "http://nexus.example.com/internal/security/oidc/callback")));
-      OidcLoginController controller = new OidcLoginController(authentication, new ObjectMapper());
+      OidcLoginController controller = controller(authentication);
 
       controller.login(request(session), response.proxy(), "/browse/");
 
       URI redirect = URI.create(response.redirect);
       assertEquals("localhost", redirect.getHost());
       assertEquals("/oauth2/authorize", redirect.getPath());
+    }
+  }
+
+  @Test
+  void discoveryConnectsToThePolicyResolvedAddressWithoutASecondDnsLookup() throws Exception {
+    try (TestOidcDiscovery discovery =
+        oidcDiscoveryServer("issuer.rebind.invalid", "login.rebind.invalid", false)) {
+      SessionState session = new SessionState();
+      ResponseState response = new ResponseState();
+      StubAuthenticationService authentication = new StubAuthenticationService();
+      authentication.oidcRealm = Optional.of(oidcRealm(Map.of(
+          "clientId", "kkrepo",
+          "issuerUri", discovery.issuer(),
+          "redirectUri", "http://nexus.example.com/internal/security/oidc/callback")));
+      OutboundRequestPolicy pinnedPolicy = new OutboundRequestPolicy(
+          true,
+          "",
+          host -> new InetAddress[] {InetAddress.getByAddress(
+              host, new byte[] {127, 0, 0, 1})});
+      OidcLoginController controller = controller(authentication, pinnedPolicy, "");
+
+      controller.login(request(session), response.proxy(), "/browse/");
+
+      assertEquals("login.rebind.invalid", URI.create(response.redirect).getHost());
     }
   }
 
@@ -180,13 +207,42 @@ class OidcLoginControllerTest {
           "clientId", "kkrepo",
           "issuerUri", discovery.issuer(),
           "redirectUri", "http://nexus.example.com/internal/security/oidc/callback")));
-      OidcLoginController controller = new OidcLoginController(authentication, new ObjectMapper());
+      OidcLoginController controller = controller(authentication);
 
       SecurityValidationException error = assertThrows(
           SecurityValidationException.class,
           () -> controller.login(request(session), response.proxy(), "/browse/"));
 
       assertEquals("OIDC discovery issuer must match configured issuer", error.getMessage());
+    }
+  }
+
+  @Test
+  void discoveryRejectsNonSuccessfulResponse() throws Exception {
+    HttpServer discovery = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    discovery.createContext("/.well-known/openid-configuration", exchange -> {
+      exchange.sendResponseHeaders(503, -1);
+      exchange.close();
+    });
+    discovery.start();
+    try {
+      SessionState session = new SessionState();
+      StubAuthenticationService authentication = new StubAuthenticationService();
+      authentication.oidcRealm = Optional.of(oidcRealm(Map.of(
+          "clientId", "kkrepo",
+          "issuerUri", "http://127.0.0.1:" + discovery.getAddress().getPort(),
+          "redirectUri", "http://nexus.example.com/internal/security/oidc/callback")));
+      OidcLoginController controller = controller(authentication);
+
+      ResponseStatusException error = assertThrows(
+          ResponseStatusException.class,
+          () -> controller.login(
+              request(session), new ResponseState().proxy(), "/browse/"));
+
+      assertTrue(error.getStatusCode().isSameCodeAs(org.springframework.http.HttpStatus.BAD_REQUEST));
+      assertEquals("OIDC discovery endpoint returned 503", error.getReason());
+    } finally {
+      discovery.stop(0);
     }
   }
 
@@ -200,7 +256,7 @@ class OidcLoginControllerTest {
         "local",
         null,
         new PermissionSubject("Local", "admin", Set.of("nx-admin"), null));
-    OidcLoginController controller = new OidcLoginController(new StubAuthenticationService(), new ObjectMapper());
+    OidcLoginController controller = controller(new StubAuthenticationService());
 
     controller.basicLogin(request(session, Map.of(AuthenticatedSubject.REQUEST_ATTRIBUTE, subject)), response.proxy(), "/admin/#security-users");
 
@@ -221,7 +277,7 @@ class OidcLoginControllerTest {
         null,
         new PermissionSubject("Local", "admin", Set.of("nx-admin"), null));
     authentication.credentialSubject = Optional.of(subject);
-    OidcLoginController controller = new OidcLoginController(authentication, new ObjectMapper());
+    OidcLoginController controller = controller(authentication);
 
     OidcLoginController.LoginResult result = controller.passwordLogin(
         request(session),
@@ -238,7 +294,7 @@ class OidcLoginControllerTest {
   @Test
   void loginOptionsExposeActiveExternalRealms() {
     StubAuthenticationService authentication = new StubAuthenticationService();
-    OidcLoginController controller = new OidcLoginController(authentication, new ObjectMapper());
+    OidcLoginController controller = controller(authentication);
 
     assertEquals(false, controller.loginOptions().oidcEnabled());
     assertEquals(false, controller.loginOptions().ldapEnabled());
@@ -272,7 +328,7 @@ class OidcLoginControllerTest {
         new PermissionSubject("Local", "admin", Set.of("nx-admin"), null)));
     session.exists = true;
     ResponseState response = new ResponseState();
-    OidcLoginController controller = new OidcLoginController(new StubAuthenticationService(), new ObjectMapper());
+    OidcLoginController controller = controller(new StubAuthenticationService());
 
     controller.logout(request(session), response.proxy(), null);
 
@@ -297,7 +353,7 @@ class OidcLoginControllerTest {
         "authorizationEndpoint", "https://localhost/oauth2/authorize",
         "redirectUri", "http://nexus.example.com/callback")));
     authentication.subject = Optional.of(subject);
-    OidcLoginController controller = new OidcLoginController(authentication, new ObjectMapper());
+    OidcLoginController controller = controller(authentication);
     controller.login(request(session), response.proxy(), "/browse/");
     String state = query(URI.create(response.redirect)).get("state");
 
@@ -320,10 +376,79 @@ class OidcLoginControllerTest {
   }
 
   @Test
+  void callbackPostsTokenRequestToThePolicyResolvedAddress() throws Exception {
+    AtomicReference<String> requestMethod = new AtomicReference<>();
+    AtomicReference<String> requestContentType = new AtomicReference<>();
+    AtomicReference<String> requestBody = new AtomicReference<>();
+    HttpServer tokenServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    tokenServer.createContext("/oauth2/token", exchange -> {
+      requestMethod.set(exchange.getRequestMethod());
+      requestContentType.set(exchange.getRequestHeaders().getFirst("Content-Type"));
+      requestBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+      byte[] body = "{\"id_token\":\"header.claims.signature\"}"
+          .getBytes(StandardCharsets.UTF_8);
+      exchange.getResponseHeaders().add("Content-Type", "application/json");
+      exchange.sendResponseHeaders(200, body.length);
+      exchange.getResponseBody().write(body);
+      exchange.close();
+    });
+    tokenServer.start();
+    try {
+      int port = tokenServer.getAddress().getPort();
+      SessionState session = new SessionState();
+      ResponseState loginResponse = new ResponseState();
+      StubAuthenticationService authentication = new StubAuthenticationService();
+      authentication.oidcRealm = Optional.of(oidcRealm(Map.of(
+          "clientId", "kkrepo",
+          "clientSecret", "top-secret",
+          "issuerUri", "http://issuer.rebind.invalid:" + port,
+          "authorizationEndpoint", "http://login.rebind.invalid:" + port + "/oauth2/authorize",
+          "tokenEndpoint", "http://token.rebind.invalid:" + port + "/oauth2/token",
+          "redirectUri", "http://nexus.example.com/internal/security/oidc/callback")));
+      authentication.subject = Optional.of(new AuthenticatedSubject(
+          "OIDC",
+          "alice",
+          "oidc",
+          null,
+          new PermissionSubject("OIDC", "alice", Set.of("nx-admin"), null)));
+      OutboundRequestPolicy pinnedPolicy = new OutboundRequestPolicy(
+          true,
+          "",
+          host -> new InetAddress[] {InetAddress.getByAddress(
+              host, new byte[] {127, 0, 0, 1})});
+      OidcLoginController controller = controller(authentication, pinnedPolicy, "");
+      controller.login(request(session), loginResponse.proxy(), "/browse/");
+      String state = query(URI.create(loginResponse.redirect)).get("state");
+
+      ResponseState callbackResponse = new ResponseState();
+      controller.callback(
+          request(session),
+          callbackResponse.proxy(),
+          state,
+          "one-time-code",
+          null,
+          null,
+          null,
+          null);
+
+      assertEquals("POST", requestMethod.get());
+      assertEquals("application/x-www-form-urlencoded", requestContentType.get());
+      Map<String, String> form = query(URI.create("http://localhost/?" + requestBody.get()));
+      assertEquals("authorization_code", form.get("grant_type"));
+      assertEquals("one-time-code", form.get("code"));
+      assertEquals("top-secret", form.get("client_secret"));
+      assertEquals("header.claims.signature", authentication.presentedToken);
+      assertEquals("/browse/", callbackResponse.redirect);
+    } finally {
+      tokenServer.stop(0);
+    }
+  }
+
+  @Test
   void callbackRejectsMissingOrMismatchedState() {
     StubAuthenticationService authentication = new StubAuthenticationService();
     authentication.oidcRealm = Optional.of(oidcRealm(Map.of("clientId", "kkrepo")));
-    OidcLoginController controller = new OidcLoginController(authentication, new ObjectMapper());
+    OidcLoginController controller = controller(authentication);
 
     ResponseStatusException error = assertThrows(ResponseStatusException.class, () ->
         controller.callback(
@@ -337,6 +462,23 @@ class OidcLoginControllerTest {
             null));
 
     assertTrue(error.getStatusCode().isSameCodeAs(org.springframework.http.HttpStatus.UNAUTHORIZED));
+  }
+
+  private OidcLoginController controller(SecurityAuthenticationService authentication) {
+    return controller(authentication, OutboundRequestPolicy.allowPrivateForTests(), "");
+  }
+
+  private OidcLoginController controller(
+      SecurityAuthenticationService authentication,
+      OutboundRequestPolicy outboundPolicy,
+      String externalBaseUrl) {
+    return new OidcLoginController(
+        authentication,
+        new ObjectMapper(),
+        outboundPolicy,
+        transportFactory,
+        null,
+        externalBaseUrl);
   }
 
   private static SecurityRealmRecord oidcRealm(Map<String, Object> attributes) {
@@ -439,7 +581,12 @@ class OidcLoginControllerTest {
     private String presentedPassword;
 
     private StubAuthenticationService() {
-      super(new SessionRoleDao(), new ObjectMapper(), "X-Nexus-Plus-Token");
+      super(
+          new SessionRoleDao(),
+          new ObjectMapper(),
+          "X-Nexus-Plus-Token",
+          "nx-anonymous",
+          null);
     }
 
     @Override

--- a/server/src/test/java/com/github/klboke/kkrepo/server/security/OutboundRequestPolicyTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/security/OutboundRequestPolicyTest.java
@@ -1,8 +1,18 @@
 package com.github.klboke.kkrepo.server.security;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.github.klboke.kkrepo.server.proxy.ProxiedHttpClientFactory;
+import com.sun.net.httpserver.HttpServer;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
 class OutboundRequestPolicyTest {
@@ -24,10 +34,88 @@ class OutboundRequestPolicyTest {
   }
 
   @Test
+  void allowedHostConfigurationValidationDoesNotRequireDnsButConnectionsDo() {
+    OutboundRequestPolicy policy = new OutboundRequestPolicy(
+        false,
+        "packages.internal",
+        host -> {
+          throw new UnknownHostException(host);
+        });
+
+    assertDoesNotThrow(() ->
+        policy.validateHttpUri("https://packages.internal/repository/", "proxy.remoteUrl"));
+    assertThrows(SecurityValidationException.class, () ->
+        policy.resolveHttpTarget("https://packages.internal/repository/", "remote fetch"));
+  }
+
+  @Test
   void rejectsUnsupportedSchemes() {
     OutboundRequestPolicy policy = OutboundRequestPolicy.allowPrivateForTests();
 
     assertThrows(SecurityValidationException.class,
         () -> policy.validateHttpUri("file:///etc/passwd", "proxy.remoteUrl"));
+  }
+
+  @Test
+  void eachValidationUsesOneImmutableDnsSnapshot() throws Exception {
+    InetAddress publicAddress = InetAddress.getByName("93.184.216.34");
+    InetAddress loopback = InetAddress.getByName("127.0.0.1");
+    AtomicInteger lookups = new AtomicInteger();
+    OutboundRequestPolicy policy = new OutboundRequestPolicy(
+        false,
+        "",
+        host -> lookups.incrementAndGet() == 1
+            ? new InetAddress[] {publicAddress}
+            : new InetAddress[] {loopback});
+
+    OutboundRequestPolicy.ResolvedHttpTarget approved =
+        policy.resolveHttpTarget("https://packages.example/artifact", "remote fetch");
+
+    assertEquals(1, lookups.get());
+    assertEquals(java.util.List.of(publicAddress), approved.addresses());
+    assertThrows(
+        SecurityValidationException.class,
+        () -> policy.resolveHttpTarget("https://packages.example/artifact", "remote fetch"));
+    assertEquals(java.util.List.of(publicAddress), approved.addresses(),
+        "a later DNS answer must not mutate the approved connection capability");
+  }
+
+  @Test
+  void directClientUsesApprovedAddressWithoutResolvingHostAgain() throws Exception {
+    InetAddress loopback = InetAddress.getByName("127.0.0.1");
+    HttpServer upstream = HttpServer.create(new InetSocketAddress(loopback, 0), 0);
+    AtomicReference<String> receivedHost = new AtomicReference<>();
+    upstream.createContext("/artifact", exchange -> {
+      receivedHost.set(exchange.getRequestHeaders().getFirst("Host"));
+      byte[] body = "pinned".getBytes(StandardCharsets.UTF_8);
+      exchange.sendResponseHeaders(200, body.length);
+      exchange.getResponseBody().write(body);
+      exchange.close();
+    });
+    upstream.start();
+    int port = upstream.getAddress().getPort();
+    AtomicInteger lookups = new AtomicInteger();
+    OutboundRequestPolicy policy = new OutboundRequestPolicy(
+        false,
+        "packages.invalid",
+        host -> {
+          lookups.incrementAndGet();
+          return new InetAddress[] {loopback};
+        });
+    try (ProxiedHttpClientFactory factory = new ProxiedHttpClientFactory(60000, 10000)) {
+      OutboundRequestPolicy.ResolvedHttpTarget target = policy.resolveHttpTarget(
+          "http://packages.invalid:" + port + "/artifact", "remote fetch");
+      try (ProxiedHttpClientFactory.ProxiedResponse response = factory.execute(
+          "repo", null, "GET", target, Map.of(), 5000)) {
+        assertEquals(200, response.status());
+        assertEquals("pinned",
+            new String(response.body().readAllBytes(), StandardCharsets.UTF_8));
+      }
+    } finally {
+      upstream.stop(0);
+    }
+
+    assertEquals(1, lookups.get());
+    assertEquals("packages.invalid:" + port, receivedHost.get());
   }
 }

--- a/server/src/test/java/com/github/klboke/kkrepo/server/security/OutboundRequestPolicyTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/security/OutboundRequestPolicyTest.java
@@ -3,11 +3,13 @@ package com.github.klboke.kkrepo.server.security;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.klboke.kkrepo.server.proxy.ProxiedHttpClientFactory;
 import com.sun.net.httpserver.HttpServer;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -54,6 +56,72 @@ class OutboundRequestPolicyTest {
 
     assertThrows(SecurityValidationException.class,
         () -> policy.validateHttpUri("file:///etc/passwd", "proxy.remoteUrl"));
+  }
+
+  @Test
+  void rejectsMissingBlankAndMalformedRawUrls() {
+    OutboundRequestPolicy policy = OutboundRequestPolicy.allowPrivateForTests();
+
+    assertEquals(
+        "remote fetch URL is required",
+        assertThrows(
+            SecurityValidationException.class,
+            () -> policy.resolveHttpTarget((String) null, "remote fetch"))
+            .getMessage());
+    assertEquals(
+        "remote fetch URL is required",
+        assertThrows(
+            SecurityValidationException.class,
+            () -> policy.resolveHttpTarget("  ", "remote fetch"))
+            .getMessage());
+    SecurityValidationException malformed = assertThrows(
+        SecurityValidationException.class,
+        () -> policy.resolveHttpTarget("http://[", "remote fetch"));
+    assertTrue(malformed.getMessage().startsWith("remote fetch URL is not valid:"));
+  }
+
+  @Test
+  void rejectsResolverAnswersThatCannotIssueAConnectionCapability() {
+    OutboundRequestPolicy nullAnswer = new OutboundRequestPolicy(
+        false, "packages.example", host -> null);
+    OutboundRequestPolicy emptyAnswer = new OutboundRequestPolicy(
+        false, "packages.example", host -> new InetAddress[0]);
+    OutboundRequestPolicy nullAddress = new OutboundRequestPolicy(
+        false, "packages.example", host -> new InetAddress[] {null});
+
+    assertThrows(SecurityValidationException.class, () ->
+        nullAnswer.resolveHttpTarget("https://packages.example/artifact", "remote fetch"));
+    assertThrows(SecurityValidationException.class, () ->
+        emptyAnswer.resolveHttpTarget("https://packages.example/artifact", "remote fetch"));
+    assertThrows(SecurityValidationException.class, () ->
+        nullAddress.resolveHttpTarget("https://packages.example/artifact", "remote fetch"));
+  }
+
+  @Test
+  void rejectsInvalidUriComponentsBeforeDnsResolution() {
+    AtomicInteger lookups = new AtomicInteger();
+    OutboundRequestPolicy policy = new OutboundRequestPolicy(
+        true,
+        "",
+        host -> {
+          lookups.incrementAndGet();
+          return new InetAddress[] {InetAddress.getLoopbackAddress()};
+        });
+
+    assertThrows(SecurityValidationException.class, () ->
+        policy.resolveHttpTarget((URI) null, "remote fetch"));
+    assertThrows(SecurityValidationException.class, () ->
+        policy.resolveHttpTarget(URI.create("/relative/path"), "remote fetch"));
+    assertThrows(SecurityValidationException.class, () ->
+        policy.resolveHttpTarget(URI.create("http://user:secret@localhost/artifact"), "remote fetch"));
+    assertThrows(SecurityValidationException.class, () ->
+        policy.resolveHttpTarget(URI.create("http:///artifact"), "remote fetch"));
+    assertThrows(SecurityValidationException.class, () ->
+        policy.resolveHttpTarget(URI.create("http://localhost:0/artifact"), "remote fetch"));
+    assertThrows(SecurityValidationException.class, () ->
+        policy.resolveHttpTarget(URI.create("http://localhost:65536/artifact"), "remote fetch"));
+
+    assertEquals(0, lookups.get(), "invalid URI components must be rejected before DNS");
   }
 
   @Test

--- a/server/src/test/java/com/github/klboke/kkrepo/server/security/SecurityAuthenticationServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/security/SecurityAuthenticationServiceTest.java
@@ -10,6 +10,7 @@ import com.github.klboke.kkrepo.persistence.jdbc.api.model.ApiKeyRecord;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.SecurityAnonymousConfigRecord;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.SecurityRealmRecord;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.SecurityUserRecord;
+import com.github.klboke.kkrepo.server.proxy.ProxiedHttpClientFactory;
 import com.github.klboke.kkrepo.server.support.dao.SecurityDaoAdapter;
 import com.sun.net.httpserver.HttpServer;
 import com.unboundid.ldap.listener.InMemoryDirectoryServer;
@@ -37,6 +38,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.session.FindByIndexNameSessionRepository;
 
@@ -45,6 +47,13 @@ class SecurityAuthenticationServiceTest {
   private static final String NEXUS_SHIRO1_ADMIN123 = "$shiro1$SHA-512$1024$zjU1u+Zg9UNwuB+HEawvtA==$"
       + "IzF/OWzJxrqvB5FCe/2+UcZhhZYM2pTu0TEz7Ybnk65AbbEdUk9ntdtBzkN8P3gZby2qz6MHKqAe8Cjai9c4Gg==";
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private final ProxiedHttpClientFactory transportFactory =
+      new ProxiedHttpClientFactory(60_000, 10_000);
+
+  @AfterEach
+  void closeTransportFactory() {
+    transportFactory.close();
+  }
 
   @Test
   void exposesOnlyReplayableTerraformCredentialsForTheAuthenticatedSubject() {
@@ -561,6 +570,40 @@ class SecurityAuthenticationServiceTest {
   }
 
   @Test
+  void rejectsOidcBearerTokenWhenJwksEndpointIsNotSuccessful() throws Exception {
+    HttpServer jwks = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    jwks.createContext("/jwks", exchange -> {
+      exchange.sendResponseHeaders(503, -1);
+      exchange.close();
+    });
+    jwks.start();
+    try {
+      FakeSecurityDao dao = new FakeSecurityDao();
+      dao.realm(new SecurityRealmRecord(
+          1L,
+          "oidc",
+          "OIDC",
+          "OIDC",
+          true,
+          0,
+          Map.of(
+              "source", "OIDC",
+              "jwksUri", "http://127.0.0.1:" + jwks.getAddress().getPort() + "/jwks")));
+      SecurityAuthenticationService service = service(dao);
+
+      Optional<AuthenticatedSubject> authenticated = service.authenticate(request(Map.of(
+          "Authorization", "Bearer " + jwt(
+              "{\"alg\":\"RS256\",\"kid\":\"missing\"}",
+              "{\"sub\":\"alice\",\"exp\":4102444800}",
+              "signature"))));
+
+      assertFalse(authenticated.isPresent());
+    } finally {
+      jwks.stop(0);
+    }
+  }
+
+  @Test
   void authenticatesOidcBearerJwtAgainstLiveJwksAndMapsClaimsToExternalRoles() throws Exception {
     KeyPair keyPair = rsaKeyPair();
     String kid = "test-key";
@@ -579,11 +622,16 @@ class SecurityAuthenticationServiceTest {
               "source", "OIDC",
               "issuer", "https://issuer.example.com",
               "audience", "kkrepo",
-              "jwksUri", "http://127.0.0.1:" + jwks.getAddress().getPort() + "/jwks",
+              "jwksUri", "http://jwks.rebind.invalid:" + jwks.getAddress().getPort() + "/jwks",
               "userIdClaim", "preferred_username",
               "groupsClaim", "groups",
               "rolesClaim", "roles")));
-      SecurityAuthenticationService service = service(dao);
+      OutboundRequestPolicy pinnedPolicy = new OutboundRequestPolicy(
+          true,
+          "",
+          host -> new InetAddress[] {InetAddress.getByAddress(
+              host, new byte[] {127, 0, 0, 1})});
+      SecurityAuthenticationService service = service(dao, "nx-anonymous", pinnedPolicy);
       String token = signedJwt(
           keyPair,
           kid,
@@ -797,16 +845,31 @@ class SecurityAuthenticationServiceTest {
         new SecurityRealmRecord(3L, "oidc", "OIDC", "OIDC", true, 20, Map.of())));
   }
 
-  private static SecurityAuthenticationService service(FakeSecurityDao dao) {
-    return new SecurityAuthenticationService(dao, new ObjectMapper(), "X-Nexus-Plus-Token");
+  private SecurityAuthenticationService service(FakeSecurityDao dao) {
+    return service(dao, "nx-anonymous");
   }
 
-  private static SecurityAuthenticationService service(FakeSecurityDao dao, String defaultAuthenticatedRoleId) {
+  private SecurityAuthenticationService service(
+      FakeSecurityDao dao, String defaultAuthenticatedRoleId) {
+    return service(
+        dao, defaultAuthenticatedRoleId, OutboundRequestPolicy.allowPrivateForTests());
+  }
+
+  private SecurityAuthenticationService service(
+      FakeSecurityDao dao,
+      String defaultAuthenticatedRoleId,
+      OutboundRequestPolicy outboundPolicy) {
     return new SecurityAuthenticationService(
         dao,
         new ObjectMapper(),
         "X-Nexus-Plus-Token",
-        defaultAuthenticatedRoleId);
+        defaultAuthenticatedRoleId,
+        null,
+        outboundPolicy,
+        transportFactory,
+        null,
+        null,
+        null);
   }
 
   private static SecurityUserRecord user(Long id, String source, String userId, String passwordHash) {


### PR DESCRIPTION
## What

- bind outbound URL validation to the exact IP address used by direct, HTTP CONNECT, and SOCKS connections
- preserve the original hostname for HTTP Host, TLS SNI, and certificate verification
- re-resolve and revalidate every redirect before connecting
- migrate Docker registry/token and OIDC discovery/JWKS/token server-side calls to the DNS-pinned transport
- construct Terraform upstream URLs with `RemoteUrlBuilder` so request-derived paths cannot replace the configured authority
- build outbound request bodies through Apache's request builder, avoiding the response-only XSS sink model while preserving the form-encoded token request
- add DNS-rebinding, IPv6, redirect, request-body, and proxy-routing regression coverage

## Why

CodeQL alerts [#3](https://github.com/klboke/kkRepo/security/code-scanning/3), [#14](https://github.com/klboke/kkRepo/security/code-scanning/14), and [#15](https://github.com/klboke/kkRepo/security/code-scanning/15) are three sinks on one request-path-to-Terraform-upstream data flow. Strict Terraform path parsing limits direct authority injection, but validation and connection establishment previously performed separate DNS resolution, leaving a real DNS rebinding / TOCTOU gap.

The policy now issues an immutable resolved target capability, and the outbound transport connects only to its approved IP addresses. The same rule now covers the remaining Docker and OIDC server-side fetches.

CodeQL alert [#16](https://github.com/klboke/kkRepo/security/code-scanning/16) was a false XSS classification of an Apache outbound request entity. Using `ClassicRequestBuilder` preserves the exact outbound body behavior without passing through the response-oriented `HttpEntityContainer#setEntity` sink model. The latest analysis marks it fixed.

## Compatibility note

DNS-pinned outbound transport currently uses Apache HttpClient 5 classic HTTP/1.1. If `kkrepo.proxy.remote-http-version=HTTP_2` is configured, kkrepo logs an explicit downgrade warning.

## Checks

- `mvn -pl server -am test` — 26 modules successful; server 1,299 tests, 0 failures, 0 errors
- latest outbound/OIDC/Docker regression suite — 101 tests, 0 failures, 0 errors
- GitHub CI and CodeQL — all enabled checks passed; 0 open PR/branch code-scanning alerts
- Codecov patch coverage — 92.46231%
- `git diff --check`