### PR TITLE
Release kkRepo 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable public changes to kkrepo are documented in this file.
 
 This project follows a pragmatic early-stage release process. Until a stable `1.0.0` release is announced, minor versions may include behavior changes, but releases should call out migration impact, compatibility changes, and operational notes.
 
+## 0.5.1 - 2026-07-18
+
+### Changed
+
+- Quickstart defaults, Dockerfile packaging, deployment documentation, and the Helm application version now use `0.5.1`.
+- DNS-pinned outbound requests use Apache HttpClient 5 classic HTTP/1.1. Deployments configured with `kkrepo.proxy.remote-http-version=HTTP_2` log an explicit downgrade warning.
+
+### Fixed
+
+- Outbound URL validation now binds the approved DNS answers to the addresses used by direct, HTTP CONNECT, and SOCKS connections while preserving the original hostname for HTTP Host, TLS SNI, and certificate verification. Redirects are re-resolved and revalidated before connecting, closing the DNS-rebinding/TOCTOU SSRF gap in shared proxy fetches and Docker authentication flows. (#138)
+- Terraform upstream paths now use `RemoteUrlBuilder`, preventing request-derived paths from replacing the configured upstream authority. (#138)
+
+### Compatibility And Validation
+
+- Regression coverage verifies immutable DNS snapshots, multi-address failover, direct and proxied DNS pinning, redirect revalidation, TLS hostname verification, Docker registry/token routing, and Terraform upstream URL construction. (#138)
+- The full Maven reactor, focused outbound/Terraform suites, GitHub CI, CodeQL, and Codecov patch checks pass for the fix. (#138)
+
+### Upgrade Notes
+
+- `0.5.0` deployments should upgrade promptly, especially when proxy repositories are reachable by untrusted users or can access private networks or cloud metadata endpoints.
+- This patch does not add a database migration or require configuration changes. Existing MySQL and PostgreSQL installations can upgrade in place.
+
 ## 0.5.0 - 2026-07-18
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:25-jre-jammy
 
 WORKDIR /app
 
-ARG JAR_FILE=server/target/kkrepo-server-0.5.0.jar
+ARG JAR_FILE=server/target/kkrepo-server-0.5.1.jar
 
 RUN groupadd --system kkrepo \
     && useradd --system --gid kkrepo --home-dir /app --shell /usr/sbin/nologin kkrepo

--- a/deploy/helm/kkrepo/Chart.yaml
+++ b/deploy/helm/kkrepo/Chart.yaml
@@ -3,5 +3,5 @@ name: kkrepo
 description: Multi-replica kkRepo artifact repository with an external MySQL or PostgreSQL database
 type: application
 version: 0.1.0
-appVersion: "0.5.0"
+appVersion: "0.5.1"
 kubeVersion: ">=1.27.0-0"

--- a/docker-compose.quickstart-postgresql.yml
+++ b/docker-compose.quickstart-postgresql.yml
@@ -25,7 +25,7 @@ services:
     command: ["sh", "-c", "mkdir -p /data/blobs && chown -R 999:999 /data"]
 
   kkrepo:
-    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.5.0}
+    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.5.1}
     depends_on:
       postgresql:
         condition: service_healthy

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -26,7 +26,7 @@ services:
     command: ["sh", "-c", "mkdir -p /data/blobs && chown -R 999:999 /data"]
 
   kkrepo:
-    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.5.0}
+    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.5.1}
     depends_on:
       mysql:
         condition: service_healthy

--- a/docs/en/build-deployment-guide.md
+++ b/docs/en/build-deployment-guide.md
@@ -45,7 +45,7 @@ bash quickstart.sh
 
 By default, it starts:
 
-- `ghcr.io/klboke/kkrepo:0.5.0`
+- `ghcr.io/klboke/kkrepo:0.5.1`
 - MySQL 8.0
 - Persistent MySQL and File blob storage volumes for local trials
 
@@ -137,7 +137,7 @@ Note: a normal `server` module jar does not contain a Spring Boot executable ent
 Pull the latest public release image:
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:0.5.0
+docker pull ghcr.io/klboke/kkrepo:0.5.1
 ```
 
 You can also use `latest` to follow the latest public release:

--- a/docs/zh/build-deployment-guide.md
+++ b/docs/zh/build-deployment-guide.md
@@ -45,7 +45,7 @@ bash quickstart.sh
 
 默认会启动：
 
-- `ghcr.io/klboke/kkrepo:0.5.0`
+- `ghcr.io/klboke/kkrepo:0.5.1`
 - MySQL 8.0
 - 用于本地试用的持久化 MySQL volume 和 File blob storage volume
 
@@ -137,7 +137,7 @@ server/target/kkrepo-server-<version>.jar
 拉取最新公开发行镜像：
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:0.5.0
+docker pull ghcr.io/klboke/kkrepo:0.5.1
 ```
 
 也可以使用 `latest` 跟随最新公开发行版本：

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
   </modules>
 
   <properties>
-    <revision>0.5.0</revision>
+    <revision>0.5.1</revision>
     <java.version>25</java.version>
     <spring.boot.version>4.1.0</spring.boot.version>
     <apollo.client.version>2.5.0</apollo.client.version>

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -211,7 +211,7 @@ if [[ -f .env ]]; then
   load_env_file_defaults .env
 fi
 
-: "${KKREPO_IMAGE_TAG:=0.5.0}"
+: "${KKREPO_IMAGE_TAG:=0.5.1}"
 : "${KKREPO_HTTP_PORT:=19090}"
 : "${KKREPO_MANAGEMENT_PORT:=19091}"
 : "${KKREPO_PROJECT_NAME:=kkrepo-quickstart}"


### PR DESCRIPTION
## What

- bump the Maven project, Dockerfile, quickstarts, Helm app version, and deployment docs to `0.5.1`
- document the DNS-pinned outbound request fix from #138
- call out the Apache HttpClient 5 HTTP/1.1 compatibility behavior
- document the in-place upgrade path with no database migration

## Why

`0.5.1` is the security patch release for the DNS-rebinding/TOCTOU SSRF issue fixed by #138. The existing `v0.5.0` tag and artifacts remain immutable.

## Checks

- `mvn -pl server -am test` — 26 modules successful; server 1,299 tests, 0 failures, 0 errors
- MySQL and PostgreSQL persistence contracts and server smoke tests passed
- `mvn -q -N -DforceStdout help:evaluate -Dexpression=project.version` — `0.5.1`
- `git diff --check`
