### PR TITLE
Add npm minimum release age protection

### DIFF
--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js
@@ -1930,6 +1930,11 @@ function refreshRepositoryRecipeControls() {
     format !== "cargo";
   document.getElementById("repository-swift-proxy-note").hidden =
     !(format === "swift" && type === "PROXY");
+  const minimumReleaseAgeVisible = format === "npm" && type === "PROXY";
+  document.getElementById("repository-minimum-release-age-field").hidden =
+    !minimumReleaseAgeVisible;
+  document.getElementById("repository-minimum-release-age-note").hidden =
+    !minimumReleaseAgeVisible;
   refreshDockerConnectorControls();
   document.getElementById("repository-blobstore").closest("label").hidden = false;
   refreshRepositoryBlobStoreLock();
@@ -1992,10 +1997,14 @@ function repositoryFormPayload() {
   } else if (type === "PROXY") {
     const content = document.getElementById("repository-content-max-age").value;
     const metadata = document.getElementById("repository-metadata-max-age").value;
+    const minimumReleaseAge = document.getElementById("repository-minimum-release-age").value;
     payload.proxy = {
       remoteUrl: document.getElementById("repository-remote-url").value.trim(),
       contentMaxAgeMinutes: content === "" ? null : Number(content),
       metadataMaxAgeMinutes: metadata === "" ? null : Number(metadata),
+      minimumReleaseAgeMinutes: recipe.format === "npm"
+        ? (minimumReleaseAge === "" ? 0 : Number(minimumReleaseAge))
+        : null,
       autoBlock: document.getElementById("repository-auto-block").checked,
       remoteUsername: textInputValue("repository-remote-username"),
       remotePassword: textInputValue("repository-remote-password"),
@@ -2058,6 +2067,7 @@ function setRepositoryFormDefaults() {
   document.getElementById("repository-outbound-proxy-password-clear").checked = false;
   document.getElementById("repository-content-max-age").value = "1440";
   document.getElementById("repository-metadata-max-age").value = "1440";
+  document.getElementById("repository-minimum-release-age").value = "0";
   document.getElementById("repository-auto-block").checked = true;
   document.getElementById("repository-docker-connector-enabled").checked = false;
   document.getElementById("repository-docker-connector-port").value = "";
@@ -2153,6 +2163,8 @@ function showEditRepositoryForm(name) {
     document.getElementById("repository-outbound-proxy-password-clear").checked = false;
     document.getElementById("repository-content-max-age").value = repo.proxy.contentMaxAgeMinutes ?? "1440";
     document.getElementById("repository-metadata-max-age").value = repo.proxy.metadataMaxAgeMinutes ?? "1440";
+    document.getElementById("repository-minimum-release-age").value =
+      repo.proxy.minimumReleaseAgeMinutes ?? "0";
     document.getElementById("repository-auto-block").checked = repo.proxy.autoBlock !== false;
   }
   if (repo.type === "GROUP" && repo.group && Array.isArray(repo.group.memberNames)) {

--- a/admin-ui/src/main/resources/META-INF/resources/admin/index.html
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/index.html
@@ -209,6 +209,16 @@
                 <span>Metadata max age (min)</span>
                 <input id="repository-metadata-max-age" type="number" min="-1" value="1440">
               </label>
+              <label id="repository-minimum-release-age-field" hidden>
+                <span>Minimum release age (min)</span>
+                <input id="repository-minimum-release-age" type="number" min="0" value="0">
+              </label>
+              <p class="form-note full-width" id="repository-minimum-release-age-note" hidden>
+                npm proxy only. A version is hidden from package metadata and its tarball is blocked
+                until this many minutes have passed since publication. Use 0 to disable this policy
+                and preserve existing behavior. This is independent of content and metadata cache
+                max age. Versions with a missing or invalid publish time are blocked while enabled.
+              </p>
               <label class="checkbox-field">
                 <input id="repository-auto-block" type="checkbox" checked>
                 <span>Auto-block remote</span>

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminNpmMinimumReleaseAgeContractTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminNpmMinimumReleaseAgeContractTest.java
@@ -1,0 +1,32 @@
+package com.github.klboke.kkrepo.admin.ui;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import org.junit.jupiter.api.Test;
+
+class AdminNpmMinimumReleaseAgeContractTest {
+
+  @Test
+  void npmProxyFormExplainsAndPersistsMinimumReleaseAge() throws IOException {
+    String index = resource("/META-INF/resources/admin/index.html");
+    String javascript = resource("/META-INF/resources/admin/assets/admin.js");
+
+    assertTrue(index.contains("id=\"repository-minimum-release-age\""));
+    assertTrue(index.contains("Use 0 to disable this policy"));
+    assertTrue(index.contains("independent of content and metadata cache"));
+    assertTrue(index.contains("missing or invalid publish time are blocked"));
+    assertTrue(javascript.contains("format === \"npm\" && type === \"PROXY\""));
+    assertTrue(javascript.contains("minimumReleaseAgeMinutes: recipe.format === \"npm\""));
+    assertTrue(javascript.contains("repo.proxy.minimumReleaseAgeMinutes ?? \"0\""));
+  }
+
+  private String resource(String path) throws IOException {
+    try (InputStream stream = getClass().getResourceAsStream(path)) {
+      return new String(Objects.requireNonNull(stream).readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+}

--- a/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/api/NpmReleaseIndexDao.java
+++ b/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/api/NpmReleaseIndexDao.java
@@ -1,0 +1,83 @@
+package com.github.klboke.kkrepo.persistence.jdbc.api;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Durable, rebuildable npm publish-time index tied to one package-root blob revision.
+ *
+ * <p>The raw packument blob remains the source of truth. This index exists so every replica can
+ * enforce release age without downloading and parsing that blob on tarball requests.
+ */
+public interface NpmReleaseIndexDao {
+  Optional<Status> findStatus(long packageRootAssetId, long sourceBlobId);
+
+  Optional<Snapshot> findSnapshot(long packageRootAssetId, long sourceBlobId);
+
+  /** Empty optional means the requested blob revision has not been indexed. */
+  Optional<List<Release>> findByTarball(
+      long packageRootAssetId, long sourceBlobId, String tarballName);
+
+  /**
+   * Loads everything needed to enforce one tarball request in a single database round trip.
+   * Empty optional means the requested blob revision has not been indexed.
+   */
+  Optional<TarballPolicy> findTarballPolicy(
+      long packageRootAssetId,
+      long sourceBlobId,
+      String tarballName,
+      Instant publishedAfterExclusive,
+      Instant publishedAtOrBefore);
+
+  boolean hasMaturityBoundary(
+      long packageRootAssetId,
+      long sourceBlobId,
+      Instant publishedAfterExclusive,
+      Instant publishedAtOrBefore);
+
+  Optional<Instant> findNextPublishedAfter(
+      long packageRootAssetId, long sourceBlobId, Instant publishedAfterExclusive);
+
+  /**
+   * Atomically replaces the index only if the package-root asset still points at the expected
+   * blob. The asset row is locked so concurrent metadata writers cannot publish mismatched state.
+   */
+  boolean replaceIfCurrent(
+      long packageRootAssetId,
+      long sourceBlobId,
+      boolean completePublishTimes,
+      List<Release> releases,
+      Instant indexedAt);
+
+  record Status(
+      long packageRootAssetId,
+      long sourceBlobId,
+      boolean completePublishTimes,
+      int releaseCount,
+      Instant indexedAt) {
+  }
+
+  record Snapshot(Status status, List<Release> releases) {
+    public Snapshot {
+      releases = releases == null ? List.of() : List.copyOf(releases);
+    }
+  }
+
+  record TarballPolicy(
+      Status status,
+      boolean maturityBoundaryCrossed,
+      List<Release> releases) {
+    public TarballPolicy {
+      releases = releases == null ? List.of() : List.copyOf(releases);
+    }
+  }
+
+  record Release(
+      int ordinal,
+      String version,
+      Instant publishedAt,
+      String invalidReason,
+      String tarballName) {
+  }
+}

--- a/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/api/PersistenceStores.java
+++ b/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/api/PersistenceStores.java
@@ -28,6 +28,8 @@ public interface PersistenceStores extends AutoCloseable {
 
   MigrationJobDao migrationJobs();
 
+  NpmReleaseIndexDao npmReleaseIndexes();
+
   ProxyStateDao proxyStates();
 
   PubUploadSessionDao pubUploadSessions();

--- a/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/JdbcNpmReleaseIndexDao.java
+++ b/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/JdbcNpmReleaseIndexDao.java
@@ -1,0 +1,264 @@
+package com.github.klboke.kkrepo.persistence.jdbc.internal;
+
+import static com.github.klboke.kkrepo.persistence.jdbc.internal.support.JdbcRows.nullableInstant;
+import static com.github.klboke.kkrepo.persistence.jdbc.internal.support.JdbcRows.nullableTimestamp;
+
+import com.github.klboke.kkrepo.persistence.jdbc.api.NpmReleaseIndexDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.PersistenceHashes;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+public class JdbcNpmReleaseIndexDao implements NpmReleaseIndexDao {
+  private static final int RELEASE_INSERT_CHUNK_SIZE = 250;
+  private static final String RELEASE_INSERT_PREFIX = """
+      INSERT INTO npm_release_index_entry
+        (package_root_asset_id, source_blob_id, ordinal, version, version_hash,
+         published_at, invalid_reason, tarball_name, tarball_name_hash)
+      VALUES
+      """;
+  private static final String RELEASE_VALUES = "(?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+  private final JdbcTemplate jdbc;
+
+  public JdbcNpmReleaseIndexDao(JdbcTemplate jdbc) {
+    this.jdbc = jdbc;
+  }
+
+  @Override
+  public Optional<Status> findStatus(long packageRootAssetId, long sourceBlobId) {
+    return jdbc.query("""
+        SELECT package_root_asset_id, source_blob_id, complete_publish_times,
+               release_count, indexed_at
+        FROM npm_release_index_revision
+        WHERE package_root_asset_id = ? AND source_blob_id = ?
+        """, (rs, row) -> new Status(
+        rs.getLong("package_root_asset_id"),
+        rs.getLong("source_blob_id"),
+        rs.getBoolean("complete_publish_times"),
+        rs.getInt("release_count"),
+        nullableInstant(rs, "indexed_at")), packageRootAssetId, sourceBlobId)
+        .stream()
+        .findFirst();
+  }
+
+  @Override
+  public Optional<Snapshot> findSnapshot(long packageRootAssetId, long sourceBlobId) {
+    Optional<Status> status = findStatus(packageRootAssetId, sourceBlobId);
+    if (status.isEmpty()) {
+      return Optional.empty();
+    }
+    List<Release> releases = jdbc.query("""
+        SELECT ordinal, version, published_at, invalid_reason, tarball_name
+        FROM npm_release_index_entry
+        WHERE package_root_asset_id = ? AND source_blob_id = ?
+        ORDER BY ordinal
+        """, (rs, row) -> mapRelease(rs), packageRootAssetId, sourceBlobId);
+    if (releases.size() != status.get().releaseCount()) {
+      return Optional.empty();
+    }
+    return Optional.of(new Snapshot(status.get(), releases));
+  }
+
+  @Override
+  public Optional<List<Release>> findByTarball(
+      long packageRootAssetId,
+      long sourceBlobId,
+      String tarballName) {
+    return findTarballPolicy(
+        packageRootAssetId, sourceBlobId, tarballName, null, null)
+        .map(TarballPolicy::releases);
+  }
+
+  @Override
+  public Optional<TarballPolicy> findTarballPolicy(
+      long packageRootAssetId,
+      long sourceBlobId,
+      String tarballName,
+      Instant publishedAfterExclusive,
+      Instant publishedAtOrBefore) {
+    byte[] hash = PersistenceHashes.sha256(tarballName);
+    boolean checkBoundary = publishedAfterExclusive != null
+        && publishedAtOrBefore != null
+        && publishedAtOrBefore.isAfter(publishedAfterExclusive);
+    return jdbc.query("""
+        SELECT r.package_root_asset_id, r.source_blob_id, r.complete_publish_times,
+               r.release_count, r.indexed_at,
+               CASE WHEN ? AND EXISTS (
+                 SELECT 1
+                 FROM npm_release_index_entry boundary_entry
+                 WHERE boundary_entry.package_root_asset_id = r.package_root_asset_id
+                   AND boundary_entry.source_blob_id = r.source_blob_id
+                   AND boundary_entry.invalid_reason IS NULL
+                   AND boundary_entry.published_at > ?
+                   AND boundary_entry.published_at <= ?
+               ) THEN TRUE ELSE FALSE END AS maturity_boundary_crossed,
+               e.ordinal, e.version, e.published_at, e.invalid_reason, e.tarball_name
+        FROM npm_release_index_revision r
+        LEFT JOIN npm_release_index_entry e
+          ON e.package_root_asset_id = r.package_root_asset_id
+         AND e.source_blob_id = r.source_blob_id
+         AND e.tarball_name_hash = ?
+        WHERE r.package_root_asset_id = ? AND r.source_blob_id = ?
+        ORDER BY e.ordinal
+        """, rs -> {
+      if (!rs.next()) {
+        return Optional.empty();
+      }
+      Status status = new Status(
+          rs.getLong("package_root_asset_id"),
+          rs.getLong("source_blob_id"),
+          rs.getBoolean("complete_publish_times"),
+          rs.getInt("release_count"),
+          nullableInstant(rs, "indexed_at"));
+      boolean maturityBoundaryCrossed = rs.getBoolean("maturity_boundary_crossed");
+      java.util.ArrayList<Release> releases = new java.util.ArrayList<>();
+      do {
+        if (rs.getObject("ordinal") != null) {
+          Release release = mapRelease(rs);
+          if (Objects.equals(tarballName, release.tarballName())) {
+            releases.add(release);
+          }
+        }
+      } while (rs.next());
+      return Optional.of(new TarballPolicy(
+          status, maturityBoundaryCrossed, List.copyOf(releases)));
+    }, checkBoundary, nullableTimestamp(publishedAfterExclusive),
+        nullableTimestamp(publishedAtOrBefore), hash, packageRootAssetId, sourceBlobId);
+  }
+
+  @Override
+  public boolean hasMaturityBoundary(
+      long packageRootAssetId,
+      long sourceBlobId,
+      Instant publishedAfterExclusive,
+      Instant publishedAtOrBefore) {
+    if (publishedAfterExclusive == null || publishedAtOrBefore == null
+        || !publishedAtOrBefore.isAfter(publishedAfterExclusive)) {
+      return false;
+    }
+    Integer count = jdbc.queryForObject("""
+        SELECT COUNT(*)
+        FROM npm_release_index_revision r
+        JOIN npm_release_index_entry e
+          ON e.package_root_asset_id = r.package_root_asset_id
+         AND e.source_blob_id = r.source_blob_id
+        WHERE r.package_root_asset_id = ? AND r.source_blob_id = ?
+          AND e.invalid_reason IS NULL
+          AND e.published_at > ? AND e.published_at <= ?
+        """, Integer.class, packageRootAssetId, sourceBlobId,
+        nullableTimestamp(publishedAfterExclusive), nullableTimestamp(publishedAtOrBefore));
+    return count != null && count > 0;
+  }
+
+  @Override
+  public Optional<Instant> findNextPublishedAfter(
+      long packageRootAssetId,
+      long sourceBlobId,
+      Instant publishedAfterExclusive) {
+    if (publishedAfterExclusive == null) {
+      return Optional.empty();
+    }
+    return jdbc.query("""
+        SELECT MIN(e.published_at) AS next_published_at
+        FROM npm_release_index_revision r
+        JOIN npm_release_index_entry e
+          ON e.package_root_asset_id = r.package_root_asset_id
+         AND e.source_blob_id = r.source_blob_id
+        WHERE r.package_root_asset_id = ? AND r.source_blob_id = ?
+          AND e.invalid_reason IS NULL AND e.published_at > ?
+        """, rs -> {
+      if (!rs.next()) {
+        return Optional.<Instant>empty();
+      }
+      return Optional.ofNullable(nullableInstant(rs, "next_published_at"));
+    }, packageRootAssetId, sourceBlobId, nullableTimestamp(publishedAfterExclusive));
+  }
+
+  @Override
+  @Transactional
+  public boolean replaceIfCurrent(
+      long packageRootAssetId,
+      long sourceBlobId,
+      boolean completePublishTimes,
+      List<Release> releases,
+      Instant indexedAt) {
+    Long currentBlobId = jdbc.query("""
+        SELECT asset_blob_id FROM asset WHERE id = ? FOR UPDATE
+        """, rs -> {
+      if (!rs.next()) {
+        return null;
+      }
+      Number value = (Number) rs.getObject("asset_blob_id");
+      return value == null ? null : value.longValue();
+    },
+        packageRootAssetId);
+    if (currentBlobId == null || currentBlobId != sourceBlobId) {
+      return false;
+    }
+
+    List<Release> safeReleases = releases == null ? List.of() : List.copyOf(releases);
+    jdbc.update(
+        "DELETE FROM npm_release_index_revision WHERE package_root_asset_id = ?",
+        packageRootAssetId);
+    jdbc.update("""
+        INSERT INTO npm_release_index_revision
+          (package_root_asset_id, source_blob_id, complete_publish_times,
+           release_count, indexed_at)
+        VALUES (?, ?, ?, ?, ?)
+        """, packageRootAssetId, sourceBlobId, completePublishTimes,
+        safeReleases.size(), nullableTimestamp(indexedAt == null ? Instant.now() : indexedAt));
+    insertReleases(packageRootAssetId, sourceBlobId, safeReleases);
+    return true;
+  }
+
+  /** Uses portable multi-row inserts so performance does not depend on JDBC rewrite flags. */
+  private void insertReleases(
+      long packageRootAssetId,
+      long sourceBlobId,
+      List<Release> releases) {
+    for (int start = 0; start < releases.size(); start += RELEASE_INSERT_CHUNK_SIZE) {
+      int end = Math.min(start + RELEASE_INSERT_CHUNK_SIZE, releases.size());
+      int count = end - start;
+      StringBuilder sql = new StringBuilder(
+          RELEASE_INSERT_PREFIX.length() + count * (RELEASE_VALUES.length() + 2));
+      sql.append(RELEASE_INSERT_PREFIX);
+      Object[] arguments = new Object[count * 9];
+      int argument = 0;
+      for (int index = start; index < end; index++) {
+        if (index > start) {
+          sql.append(", ");
+        }
+        sql.append(RELEASE_VALUES);
+        Release release = releases.get(index);
+        arguments[argument++] = packageRootAssetId;
+        arguments[argument++] = sourceBlobId;
+        arguments[argument++] = release.ordinal();
+        arguments[argument++] = release.version();
+        arguments[argument++] = PersistenceHashes.sha256(release.version());
+        arguments[argument++] = nullableTimestamp(release.publishedAt());
+        arguments[argument++] = release.invalidReason();
+        arguments[argument++] = release.tarballName();
+        arguments[argument++] = release.tarballName() == null
+            ? null
+            : PersistenceHashes.sha256(release.tarballName());
+      }
+      jdbc.update(sql.toString(), arguments);
+    }
+  }
+
+  private static Release mapRelease(java.sql.ResultSet rs) throws SQLException {
+    return new Release(
+        rs.getInt("ordinal"),
+        rs.getString("version"),
+        nullableInstant(rs, "published_at"),
+        rs.getString("invalid_reason"),
+        rs.getString("tarball_name"));
+  }
+}

--- a/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/JdbcPersistenceStoreFactory.java
+++ b/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/JdbcPersistenceStoreFactory.java
@@ -15,6 +15,7 @@ import com.github.klboke.kkrepo.persistence.jdbc.api.MaintenanceCursorDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.MetadataRebuildDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.MigrationCheckpointDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.MigrationJobDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.NpmReleaseIndexDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.PersistenceStoreFactory;
 import com.github.klboke.kkrepo.persistence.jdbc.api.PersistenceStores;
 import com.github.klboke.kkrepo.persistence.jdbc.api.ProxyStateDao;
@@ -63,6 +64,7 @@ public final class JdbcPersistenceStoreFactory implements PersistenceStoreFactor
         new JdbcMetadataRebuildDao(jdbc, dialect),
         new JdbcMigrationCheckpointDao(jdbc),
         new JdbcMigrationJobDao(jdbc, json),
+        new JdbcNpmReleaseIndexDao(jdbc),
         new JdbcProxyStateDao(jdbc, 30),
         new JdbcPubUploadSessionDao(jdbc, json),
         new JdbcRepositoryDao(jdbc, json),
@@ -89,6 +91,7 @@ public final class JdbcPersistenceStoreFactory implements PersistenceStoreFactor
       MetadataRebuildDao metadataRebuild,
       MigrationCheckpointDao migrationCheckpoints,
       MigrationJobDao migrationJobs,
+      NpmReleaseIndexDao npmReleaseIndexes,
       ProxyStateDao proxyStates,
       PubUploadSessionDao pubUploadSessions,
       RepositoryDao repositories,

--- a/persistence-jdbc/src/test/java/com/github/klboke/kkrepo/persistence/jdbc/contract/PersistenceApiContract.java
+++ b/persistence-jdbc/src/test/java/com/github/klboke/kkrepo/persistence/jdbc/contract/PersistenceApiContract.java
@@ -81,6 +81,8 @@ public abstract class PersistenceApiContract {
         "migration_checkpoint",
         "migration_job",
         "migration_validation_result",
+        "npm_release_index_entry",
+        "npm_release_index_revision",
         "proxy_remote_state",
         "pub_upload_session",
         "repository",

--- a/persistence-mysql/src/main/resources/db/migration/mysql/V34__npm_release_age_index.sql
+++ b/persistence-mysql/src/main/resources/db/migration/mysql/V34__npm_release_age_index.sql
@@ -1,0 +1,33 @@
+CREATE TABLE npm_release_index_revision (
+  package_root_asset_id BIGINT UNSIGNED NOT NULL,
+  source_blob_id BIGINT UNSIGNED NOT NULL,
+  complete_publish_times BOOLEAN NOT NULL,
+  release_count INT NOT NULL,
+  indexed_at DATETIME(3) NOT NULL,
+  PRIMARY KEY (package_root_asset_id),
+  KEY idx_npm_release_revision_blob (source_blob_id),
+  CONSTRAINT fk_npm_release_revision_asset
+    FOREIGN KEY (package_root_asset_id) REFERENCES asset(id) ON DELETE CASCADE,
+  CONSTRAINT fk_npm_release_revision_blob
+    FOREIGN KEY (source_blob_id) REFERENCES asset_blob(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE npm_release_index_entry (
+  package_root_asset_id BIGINT UNSIGNED NOT NULL,
+  source_blob_id BIGINT UNSIGNED NOT NULL,
+  ordinal INT NOT NULL,
+  version VARCHAR(512) NOT NULL,
+  version_hash BINARY(32) NOT NULL,
+  published_at DATETIME(3) NULL,
+  invalid_reason VARCHAR(128) NULL,
+  tarball_name VARCHAR(1024) NULL,
+  tarball_name_hash BINARY(32) NULL,
+  PRIMARY KEY (package_root_asset_id, version_hash),
+  KEY idx_npm_release_tarball
+    (package_root_asset_id, source_blob_id, tarball_name_hash),
+  KEY idx_npm_release_published
+    (package_root_asset_id, source_blob_id, published_at),
+  CONSTRAINT fk_npm_release_entry_revision
+    FOREIGN KEY (package_root_asset_id)
+    REFERENCES npm_release_index_revision(package_root_asset_id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/MySqlV29MigrationCompatibilityTest.java
+++ b/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/MySqlV29MigrationCompatibilityTest.java
@@ -32,7 +32,7 @@ class MySqlV29MigrationCompatibilityTest extends MySqlIntegrationTestSupport {
     assertTrue(flyway().validateWithResult().validationSuccessful);
     var result = flyway().migrate();
     assertEquals(0, result.migrationsExecuted);
-    assertEquals("33", flyway().info().current().getVersion().getVersion());
+    assertEquals("34", flyway().info().current().getVersion().getVersion());
   }
 
   private static String hex(byte[] bytes) {

--- a/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/NpmReleaseIndexDaoMySqlIntegrationTest.java
+++ b/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/NpmReleaseIndexDaoMySqlIntegrationTest.java
@@ -27,7 +27,17 @@ class NpmReleaseIndexDaoMySqlIntegrationTest extends MySqlIntegrationTestSupport
     List<Release> firstRevision = List.of(
         new Release(0, "1.0.0", FIRST_PUBLISHED, null, "demo-1.0.0.tgz"),
         new Release(1, "2.0.0", SECOND_PUBLISHED, null, "demo-2.0.0.tgz"),
-        new Release(2, "broken", null, "missing-publish-time", "demo-broken.tgz"));
+        new Release(2, "broken", null, "missing-publish-time", "demo-2.0.0.tgz"));
+
+    assertTrue(dao.findSnapshot(assetId, firstBlobId).isEmpty());
+    assertTrue(dao.findTarballPolicy(
+        assetId, firstBlobId, "missing.tgz", null, null).isEmpty());
+    assertFalse(dao.hasMaturityBoundary(assetId, firstBlobId, null, SECOND_PUBLISHED));
+    assertFalse(dao.hasMaturityBoundary(
+        assetId, firstBlobId, SECOND_PUBLISHED, SECOND_PUBLISHED));
+    assertTrue(dao.findNextPublishedAfter(assetId, firstBlobId, null).isEmpty());
+    assertFalse(inTransaction(() -> dao.replaceIfCurrent(
+        Long.MAX_VALUE, firstBlobId, true, List.of(), null)));
 
     assertTrue(inTransaction(() -> dao.replaceIfCurrent(
         assetId, firstBlobId, false, firstRevision, INDEXED_AT)));
@@ -35,14 +45,14 @@ class NpmReleaseIndexDaoMySqlIntegrationTest extends MySqlIntegrationTestSupport
     assertFalse(snapshot.status().completePublishTimes());
     assertEquals(firstRevision, snapshot.releases());
     assertEquals(
-        List.of(firstRevision.get(1)),
+        List.of(firstRevision.get(1), firstRevision.get(2)),
         dao.findByTarball(assetId, firstBlobId, "demo-2.0.0.tgz").orElseThrow());
     var tarballPolicy = dao.findTarballPolicy(
         assetId, firstBlobId, "demo-2.0.0.tgz", FIRST_PUBLISHED, SECOND_PUBLISHED)
         .orElseThrow();
     assertEquals(3, tarballPolicy.status().releaseCount());
     assertTrue(tarballPolicy.maturityBoundaryCrossed());
-    assertEquals(List.of(firstRevision.get(1)), tarballPolicy.releases());
+    assertEquals(List.of(firstRevision.get(1), firstRevision.get(2)), tarballPolicy.releases());
     assertTrue(dao.findByTarball(assetId, firstBlobId, "missing.tgz").orElseThrow().isEmpty());
     assertTrue(dao.hasMaturityBoundary(
         assetId, firstBlobId, FIRST_PUBLISHED, SECOND_PUBLISHED));
@@ -52,6 +62,14 @@ class NpmReleaseIndexDaoMySqlIntegrationTest extends MySqlIntegrationTestSupport
         SECOND_PUBLISHED,
         dao.findNextPublishedAfter(assetId, firstBlobId, FIRST_PUBLISHED).orElseThrow());
 
+    jdbc().update(
+        "UPDATE npm_release_index_revision SET release_count = 99 WHERE package_root_asset_id = ?",
+        assetId);
+    assertTrue(dao.findSnapshot(assetId, firstBlobId).isEmpty());
+    jdbc().update(
+        "UPDATE npm_release_index_revision SET release_count = ? WHERE package_root_asset_id = ?",
+        firstRevision.size(), assetId);
+
     assertFalse(inTransaction(() -> dao.replaceIfCurrent(
         assetId, secondBlobId, true, List.of(), INDEXED_AT)));
     jdbc().update("UPDATE asset SET asset_blob_id = ? WHERE id = ?", secondBlobId, assetId);
@@ -59,12 +77,20 @@ class NpmReleaseIndexDaoMySqlIntegrationTest extends MySqlIntegrationTestSupport
         assetId, firstBlobId, true, List.of(), INDEXED_AT)));
 
     List<Release> secondRevision = List.of(
-        new Release(0, "3.0.0", SECOND_PUBLISHED, null, "demo-3.0.0.tgz"));
+        new Release(0, "3.0.0", SECOND_PUBLISHED, null, null));
     assertTrue(inTransaction(() -> dao.replaceIfCurrent(
         assetId, secondBlobId, true, secondRevision, INDEXED_AT.plusSeconds(1))));
     assertTrue(dao.findStatus(assetId, firstBlobId).isEmpty());
     assertTrue(dao.findByTarball(assetId, firstBlobId, "demo-2.0.0.tgz").isEmpty());
     assertEquals(secondRevision, dao.findSnapshot(assetId, secondBlobId).orElseThrow().releases());
+
+    jdbc().update("UPDATE asset SET asset_blob_id = NULL WHERE id = ?", assetId);
+    assertFalse(inTransaction(() -> dao.replaceIfCurrent(
+        assetId, secondBlobId, true, List.of(), null)));
+    jdbc().update("UPDATE asset SET asset_blob_id = ? WHERE id = ?", secondBlobId, assetId);
+    assertTrue(inTransaction(() -> dao.replaceIfCurrent(
+        assetId, secondBlobId, true, null, null)));
+    assertTrue(dao.findSnapshot(assetId, secondBlobId).orElseThrow().releases().isEmpty());
   }
 
   private long insertBlob(long repositoryId, String objectKey) {

--- a/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/NpmReleaseIndexDaoMySqlIntegrationTest.java
+++ b/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/NpmReleaseIndexDaoMySqlIntegrationTest.java
@@ -1,0 +1,98 @@
+package com.github.klboke.kkrepo.persistence.mysql.dao;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.klboke.kkrepo.persistence.jdbc.api.NpmReleaseIndexDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.NpmReleaseIndexDao.Release;
+import com.github.klboke.kkrepo.persistence.jdbc.internal.support.HashColumns;
+import com.github.klboke.kkrepo.persistence.mysql.support.MySqlIntegrationTestSupport;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class NpmReleaseIndexDaoMySqlIntegrationTest extends MySqlIntegrationTestSupport {
+  private static final Instant FIRST_PUBLISHED = Instant.parse("2026-07-19T10:00:00Z");
+  private static final Instant SECOND_PUBLISHED = Instant.parse("2026-07-19T11:00:00Z");
+  private static final Instant INDEXED_AT = Instant.parse("2026-07-19T12:00:00Z");
+
+  @Test
+  void indexIsRevisionFencedAndSupportsTargetedMaturityQueries() {
+    long repositoryId = insertRepository("npm-proxy", "npm");
+    long firstBlobId = insertBlob(repositoryId, "npm/demo/packument-v1.json");
+    long secondBlobId = insertBlob(repositoryId, "npm/demo/packument-v2.json");
+    long assetId = insertPackageRootAsset(repositoryId, firstBlobId);
+    NpmReleaseIndexDao dao = stores().npmReleaseIndexes();
+    List<Release> firstRevision = List.of(
+        new Release(0, "1.0.0", FIRST_PUBLISHED, null, "demo-1.0.0.tgz"),
+        new Release(1, "2.0.0", SECOND_PUBLISHED, null, "demo-2.0.0.tgz"),
+        new Release(2, "broken", null, "missing-publish-time", "demo-broken.tgz"));
+
+    assertTrue(inTransaction(() -> dao.replaceIfCurrent(
+        assetId, firstBlobId, false, firstRevision, INDEXED_AT)));
+    var snapshot = dao.findSnapshot(assetId, firstBlobId).orElseThrow();
+    assertFalse(snapshot.status().completePublishTimes());
+    assertEquals(firstRevision, snapshot.releases());
+    assertEquals(
+        List.of(firstRevision.get(1)),
+        dao.findByTarball(assetId, firstBlobId, "demo-2.0.0.tgz").orElseThrow());
+    var tarballPolicy = dao.findTarballPolicy(
+        assetId, firstBlobId, "demo-2.0.0.tgz", FIRST_PUBLISHED, SECOND_PUBLISHED)
+        .orElseThrow();
+    assertEquals(3, tarballPolicy.status().releaseCount());
+    assertTrue(tarballPolicy.maturityBoundaryCrossed());
+    assertEquals(List.of(firstRevision.get(1)), tarballPolicy.releases());
+    assertTrue(dao.findByTarball(assetId, firstBlobId, "missing.tgz").orElseThrow().isEmpty());
+    assertTrue(dao.hasMaturityBoundary(
+        assetId, firstBlobId, FIRST_PUBLISHED, SECOND_PUBLISHED));
+    assertFalse(dao.hasMaturityBoundary(
+        assetId, firstBlobId, SECOND_PUBLISHED, SECOND_PUBLISHED.plusSeconds(1)));
+    assertEquals(
+        SECOND_PUBLISHED,
+        dao.findNextPublishedAfter(assetId, firstBlobId, FIRST_PUBLISHED).orElseThrow());
+
+    assertFalse(inTransaction(() -> dao.replaceIfCurrent(
+        assetId, secondBlobId, true, List.of(), INDEXED_AT)));
+    jdbc().update("UPDATE asset SET asset_blob_id = ? WHERE id = ?", secondBlobId, assetId);
+    assertFalse(inTransaction(() -> dao.replaceIfCurrent(
+        assetId, firstBlobId, true, List.of(), INDEXED_AT)));
+
+    List<Release> secondRevision = List.of(
+        new Release(0, "3.0.0", SECOND_PUBLISHED, null, "demo-3.0.0.tgz"));
+    assertTrue(inTransaction(() -> dao.replaceIfCurrent(
+        assetId, secondBlobId, true, secondRevision, INDEXED_AT.plusSeconds(1))));
+    assertTrue(dao.findStatus(assetId, firstBlobId).isEmpty());
+    assertTrue(dao.findByTarball(assetId, firstBlobId, "demo-2.0.0.tgz").isEmpty());
+    assertEquals(secondRevision, dao.findSnapshot(assetId, secondBlobId).orElseThrow().releases());
+  }
+
+  private long insertBlob(long repositoryId, String objectKey) {
+    long blobStoreId = jdbc().queryForObject(
+        "SELECT blob_store_id FROM repository WHERE id = ?", Long.class, repositoryId);
+    String blobRef = "default@" + objectKey;
+    jdbc().update("""
+        INSERT INTO asset_blob
+          (blob_store_id, blob_ref, blob_ref_hash, object_key, object_key_hash,
+           size, content_type, attributes_json)
+        VALUES (?, ?, ?, ?, ?, 1, 'application/json', JSON_OBJECT())
+        """, blobStoreId, blobRef, HashColumns.blobRefHash(blobRef), objectKey,
+        HashColumns.objectKeyHash(objectKey));
+    return jdbc().queryForObject(
+        "SELECT id FROM asset_blob WHERE blob_store_id = ? AND blob_ref_hash = ?",
+        Long.class, blobStoreId, HashColumns.blobRefHash(blobRef));
+  }
+
+  private long insertPackageRootAsset(long repositoryId, long blobId) {
+    String path = "demo";
+    jdbc().update("""
+        INSERT INTO asset
+          (repository_id, asset_blob_id, format, path, path_hash, name, kind,
+           content_type, size, attributes_json)
+        VALUES (?, ?, 'npm', ?, ?, ?, 'PACKAGE_ROOT', 'application/json', 1, JSON_OBJECT())
+        """, repositoryId, blobId, path, HashColumns.pathHash(path), path);
+    return jdbc().queryForObject(
+        "SELECT id FROM asset WHERE repository_id = ? AND path_hash = ?",
+        Long.class, repositoryId, HashColumns.pathHash(path));
+  }
+}

--- a/persistence-postgresql/src/main/resources/db/migration/postgresql/V34__npm_release_age_index.sql
+++ b/persistence-postgresql/src/main/resources/db/migration/postgresql/V34__npm_release_age_index.sql
@@ -1,0 +1,30 @@
+CREATE TABLE npm_release_index_revision (
+  package_root_asset_id BIGINT PRIMARY KEY REFERENCES asset(id) ON DELETE CASCADE,
+  source_blob_id BIGINT NOT NULL REFERENCES asset_blob(id) ON DELETE CASCADE,
+  complete_publish_times BOOLEAN NOT NULL,
+  release_count INTEGER NOT NULL,
+  indexed_at TIMESTAMPTZ(3) NOT NULL
+);
+
+CREATE INDEX idx_npm_release_revision_blob
+  ON npm_release_index_revision(source_blob_id);
+
+CREATE TABLE npm_release_index_entry (
+  package_root_asset_id BIGINT NOT NULL
+    REFERENCES npm_release_index_revision(package_root_asset_id) ON DELETE CASCADE,
+  source_blob_id BIGINT NOT NULL,
+  ordinal INTEGER NOT NULL,
+  version VARCHAR(512) NOT NULL,
+  version_hash BYTEA NOT NULL,
+  published_at TIMESTAMPTZ(3) NULL,
+  invalid_reason VARCHAR(128) NULL,
+  tarball_name VARCHAR(1024) NULL,
+  tarball_name_hash BYTEA NULL,
+  PRIMARY KEY (package_root_asset_id, version_hash)
+);
+
+CREATE INDEX idx_npm_release_tarball
+  ON npm_release_index_entry(package_root_asset_id, source_blob_id, tarball_name_hash);
+
+CREATE INDEX idx_npm_release_published
+  ON npm_release_index_entry(package_root_asset_id, source_blob_id, published_at);

--- a/persistence-postgresql/src/test/java/com/github/klboke/kkrepo/persistence/postgresql/NpmReleaseIndexDaoPostgreSqlIntegrationTest.java
+++ b/persistence-postgresql/src/test/java/com/github/klboke/kkrepo/persistence/postgresql/NpmReleaseIndexDaoPostgreSqlIntegrationTest.java
@@ -1,0 +1,115 @@
+package com.github.klboke.kkrepo.persistence.postgresql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.klboke.kkrepo.persistence.jdbc.api.NpmReleaseIndexDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.NpmReleaseIndexDao.Release;
+import com.github.klboke.kkrepo.persistence.jdbc.internal.support.HashColumns;
+import com.github.klboke.kkrepo.persistence.postgresql.support.PostgreSqlIntegrationTestSupport;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class NpmReleaseIndexDaoPostgreSqlIntegrationTest extends PostgreSqlIntegrationTestSupport {
+  private static final Instant FIRST_PUBLISHED = Instant.parse("2026-07-19T10:00:00Z");
+  private static final Instant SECOND_PUBLISHED = Instant.parse("2026-07-19T11:00:00Z");
+  private static final Instant INDEXED_AT = Instant.parse("2026-07-19T12:00:00Z");
+
+  @Test
+  void indexIsRevisionFencedAndSupportsTargetedMaturityQueries() {
+    long repositoryId = insertRepository("npm-proxy", "npm");
+    long firstBlobId = insertBlob(repositoryId, "npm/demo/packument-v1.json");
+    long secondBlobId = insertBlob(repositoryId, "npm/demo/packument-v2.json");
+    long assetId = insertPackageRootAsset(repositoryId, firstBlobId);
+    NpmReleaseIndexDao dao = stores().npmReleaseIndexes();
+    List<Release> firstRevision = List.of(
+        new Release(0, "1.0.0", FIRST_PUBLISHED, null, "demo-1.0.0.tgz"),
+        new Release(1, "2.0.0", SECOND_PUBLISHED, null, "demo-2.0.0.tgz"),
+        new Release(2, "broken", null, "missing-publish-time", "demo-broken.tgz"));
+
+    assertTrue(inTransaction(() -> dao.replaceIfCurrent(
+        assetId, firstBlobId, false, firstRevision, INDEXED_AT)));
+    var snapshot = dao.findSnapshot(assetId, firstBlobId).orElseThrow();
+    assertFalse(snapshot.status().completePublishTimes());
+    assertEquals(firstRevision, snapshot.releases());
+    assertEquals(
+        List.of(firstRevision.get(1)),
+        dao.findByTarball(assetId, firstBlobId, "demo-2.0.0.tgz").orElseThrow());
+    var tarballPolicy = dao.findTarballPolicy(
+        assetId, firstBlobId, "demo-2.0.0.tgz", FIRST_PUBLISHED, SECOND_PUBLISHED)
+        .orElseThrow();
+    assertEquals(3, tarballPolicy.status().releaseCount());
+    assertTrue(tarballPolicy.maturityBoundaryCrossed());
+    assertEquals(List.of(firstRevision.get(1)), tarballPolicy.releases());
+    assertTrue(dao.findByTarball(assetId, firstBlobId, "missing.tgz").orElseThrow().isEmpty());
+    assertTrue(dao.hasMaturityBoundary(
+        assetId, firstBlobId, FIRST_PUBLISHED, SECOND_PUBLISHED));
+    assertFalse(dao.hasMaturityBoundary(
+        assetId, firstBlobId, SECOND_PUBLISHED, SECOND_PUBLISHED.plusSeconds(1)));
+    assertEquals(
+        SECOND_PUBLISHED,
+        dao.findNextPublishedAfter(assetId, firstBlobId, FIRST_PUBLISHED).orElseThrow());
+
+    assertFalse(inTransaction(() -> dao.replaceIfCurrent(
+        assetId, secondBlobId, true, List.of(), INDEXED_AT)));
+    jdbc().update("UPDATE asset SET asset_blob_id = ? WHERE id = ?", secondBlobId, assetId);
+    assertFalse(inTransaction(() -> dao.replaceIfCurrent(
+        assetId, firstBlobId, true, List.of(), INDEXED_AT)));
+
+    List<Release> secondRevision = List.of(
+        new Release(0, "3.0.0", SECOND_PUBLISHED, null, "demo-3.0.0.tgz"));
+    assertTrue(inTransaction(() -> dao.replaceIfCurrent(
+        assetId, secondBlobId, true, secondRevision, INDEXED_AT.plusSeconds(1))));
+    assertTrue(dao.findStatus(assetId, firstBlobId).isEmpty());
+    assertTrue(dao.findByTarball(assetId, firstBlobId, "demo-2.0.0.tgz").isEmpty());
+    assertEquals(secondRevision, dao.findSnapshot(assetId, secondBlobId).orElseThrow().releases());
+  }
+
+  private long insertRepository(String name, String format) {
+    jdbc().update("""
+        INSERT INTO blob_store (name, type, attributes_json)
+        VALUES (?, 'S3', CAST('{}' AS jsonb))
+        """, name + "-store");
+    long blobStoreId = jdbc().queryForObject(
+        "SELECT id FROM blob_store WHERE name = ?", Long.class, name + "-store");
+    jdbc().update("""
+        INSERT INTO repository
+          (name, format, type, recipe_name, blob_store_id, attributes_json)
+        VALUES (?, ?, 'proxy', ?, ?, CAST('{}' AS jsonb))
+        """, name, format, format + "-proxy", blobStoreId);
+    return jdbc().queryForObject(
+        "SELECT id FROM repository WHERE name = ?", Long.class, name);
+  }
+
+  private long insertBlob(long repositoryId, String objectKey) {
+    long blobStoreId = jdbc().queryForObject(
+        "SELECT blob_store_id FROM repository WHERE id = ?", Long.class, repositoryId);
+    String blobRef = "default@" + objectKey;
+    jdbc().update("""
+        INSERT INTO asset_blob
+          (blob_store_id, blob_ref, blob_ref_hash, object_key, object_key_hash,
+           size, content_type, attributes_json)
+        VALUES (?, ?, ?, ?, ?, 1, 'application/json', CAST('{}' AS jsonb))
+        """, blobStoreId, blobRef, HashColumns.blobRefHash(blobRef), objectKey,
+        HashColumns.objectKeyHash(objectKey));
+    return jdbc().queryForObject(
+        "SELECT id FROM asset_blob WHERE blob_store_id = ? AND blob_ref_hash = ?",
+        Long.class, blobStoreId, HashColumns.blobRefHash(blobRef));
+  }
+
+  private long insertPackageRootAsset(long repositoryId, long blobId) {
+    String path = "demo";
+    jdbc().update("""
+        INSERT INTO asset
+          (repository_id, asset_blob_id, format, path, path_hash, name, kind,
+           content_type, size, attributes_json)
+        VALUES (?, ?, 'npm', ?, ?, ?, 'PACKAGE_ROOT', 'application/json', 1,
+                CAST('{}' AS jsonb))
+        """, repositoryId, blobId, path, HashColumns.pathHash(path), path);
+    return jdbc().queryForObject(
+        "SELECT id FROM asset WHERE repository_id = ? AND path_hash = ?",
+        Long.class, repositoryId, HashColumns.pathHash(path));
+  }
+}

--- a/persistence-postgresql/src/test/java/com/github/klboke/kkrepo/persistence/postgresql/PostgreSqlMigrationCompatibilityTest.java
+++ b/persistence-postgresql/src/test/java/com/github/klboke/kkrepo/persistence/postgresql/PostgreSqlMigrationCompatibilityTest.java
@@ -13,6 +13,6 @@ class PostgreSqlMigrationCompatibilityTest extends PostgreSqlIntegrationTestSupp
     assertTrue(flyway().validateWithResult().validationSuccessful);
     var result = flyway().migrate();
     assertEquals(0, result.migrationsExecuted);
-    assertEquals("33", flyway().info().current().getVersion().getVersion());
+    assertEquals("34", flyway().info().current().getVersion().getVersion());
   }
 }

--- a/protocol-npm/pom.xml
+++ b/protocol-npm/pom.xml
@@ -20,5 +20,10 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/protocol-npm/src/main/java/com/github/klboke/kkrepo/protocol/npm/NpmMetadata.java
+++ b/protocol-npm/src/main/java/com/github/klboke/kkrepo/protocol/npm/NpmMetadata.java
@@ -266,7 +266,7 @@ public final class NpmMetadata {
   }
 
   @SuppressWarnings("unchecked")
-  private static boolean hasInstallScript(Object scriptsRaw) {
+  public static boolean hasInstallScript(Object scriptsRaw) {
     if (!(scriptsRaw instanceof Map<?, ?> rawScripts)) {
       return false;
     }
@@ -274,6 +274,14 @@ public final class NpmMetadata {
     return scripts.containsKey("preinstall")
         || scripts.containsKey("install")
         || scripts.containsKey("postinstall");
+  }
+
+  public static boolean isAbbreviatedRootField(String field) {
+    return ABBREVIATED_ROOT_FIELDS.contains(field);
+  }
+
+  public static boolean isAbbreviatedVersionField(String field) {
+    return ABBREVIATED_VERSION_FIELDS.contains(field);
   }
 
   @SuppressWarnings("unchecked")

--- a/protocol-npm/src/main/java/com/github/klboke/kkrepo/protocol/npm/NpmMinimumReleaseAge.java
+++ b/protocol-npm/src/main/java/com/github/klboke/kkrepo/protocol/npm/NpmMinimumReleaseAge.java
@@ -1,0 +1,466 @@
+package com.github.klboke.kkrepo.protocol.npm;
+
+import java.time.DateTimeException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.maven.artifact.versioning.ComparableVersion;
+
+/**
+ * Applies a publish-age gate to an npm packument.
+ *
+ * <p>The upstream packument remains the source of truth and should be stored unmodified. This
+ * class produces a response copy with versions that have not reached the configured age removed,
+ * and repairs dist-tags so they never point at a hidden version. Missing or invalid per-version
+ * publish timestamps fail closed while the gate is enabled.
+ */
+public final class NpmMinimumReleaseAge {
+  private static final Pattern SEMVER_MAJOR = Pattern.compile("^[v=]?(\\d+)(?:\\.|$)");
+
+  private NpmMinimumReleaseAge() {
+  }
+
+  public static Map<String, Object> filter(
+      Map<String, Object> packageRoot,
+      Instant evaluatedAt,
+      int minimumReleaseAgeMinutes) {
+    return analyze(packageRoot, minimumReleaseAgeMinutes).filter(packageRoot, evaluatedAt);
+  }
+
+  public static Eligibility eligibility(
+      Map<String, Object> packageRoot,
+      String version,
+      Instant evaluatedAt,
+      int minimumReleaseAgeMinutes) {
+    return analyze(packageRoot, minimumReleaseAgeMinutes).eligibility(version, evaluatedAt);
+  }
+
+  /**
+   * Returns true when a version became eligible after the last upstream verification. Callers use
+   * this to revalidate the raw packument even when its ordinary metadata TTL has not expired.
+   */
+  public static boolean crossedMaturityBoundary(
+      Map<String, Object> packageRoot,
+      Instant lastVerifiedAt,
+      Instant now,
+      int minimumReleaseAgeMinutes) {
+    return analyze(packageRoot, minimumReleaseAgeMinutes)
+        .crossedMaturityBoundary(lastVerifiedAt, now);
+  }
+
+  public static boolean hasCompletePublishTimes(Map<String, Object> packageRoot) {
+    return analyze(packageRoot, 1).hasCompletePublishTimes();
+  }
+
+  /** Returns every version whose dist.tarball resolves to the requested tarball filename. */
+  @SuppressWarnings("unchecked")
+  public static List<String> versionsForTarball(
+      Map<String, Object> packageRoot,
+      String tarballName) {
+    return analyze(packageRoot, 1).versionsForTarball(tarballName);
+  }
+
+  /**
+   * Parses publish timestamps and tarball mappings once so hot request paths can reuse the compact
+   * derived state instead of repeatedly walking and parsing a full packument.
+   */
+  public static Analysis analyze(
+      Map<String, Object> packageRoot,
+      int minimumReleaseAgeMinutes) {
+    return analyze(index(packageRoot), minimumReleaseAgeMinutes);
+  }
+
+  /**
+   * Extracts the policy-relevant fields from a packument independently of a repository policy.
+   * The result can be persisted as a shared, rebuildable index and reused after a node restart.
+   */
+  public static ReleaseIndex index(Map<String, Object> packageRoot) {
+    List<IndexedRelease> indexed = new ArrayList<>();
+    for (Map.Entry<String, Object> entry : NpmMetadata.versions(packageRoot).entrySet()) {
+      String version = entry.getKey();
+      String declaredVersion = version(entry);
+      Optional<Instant> publishedAt = publishedAt(packageRoot, version);
+      String invalidReason = null;
+      if (!version.equals(declaredVersion)) {
+        invalidReason = "version metadata does not match packument key";
+      } else if (publishedAt.isEmpty()) {
+        invalidReason = "missing or invalid publish time";
+      }
+      indexed.add(new IndexedRelease(
+          version,
+          publishedAt.orElse(null),
+          invalidReason,
+          tarball(entry.getValue())));
+    }
+    return new ReleaseIndex(indexed);
+  }
+
+  /** Builds policy state from a durable release index without reading the raw packument blob. */
+  public static Analysis analyze(
+      ReleaseIndex releaseIndex,
+      int minimumReleaseAgeMinutes) {
+    boolean disabled = minimumReleaseAgeMinutes <= 0;
+    Map<String, Release> releases = new LinkedHashMap<>();
+    Map<String, List<String>> tarballVersions = new LinkedHashMap<>();
+    List<Instant> transitions = new ArrayList<>();
+    boolean complete = true;
+
+    for (IndexedRelease indexed : releaseIndex.releases()) {
+      String version = indexed.version();
+      Instant publishedAt = indexed.publishedAt();
+      Instant availableAt = null;
+      String invalidReason = disabled ? null : indexed.invalidReason();
+      if (!disabled) {
+        if (invalidReason != null || publishedAt == null) {
+          complete = false;
+        } else {
+          try {
+            availableAt = publishedAt.plus(Duration.ofMinutes(minimumReleaseAgeMinutes));
+            transitions.add(availableAt);
+          } catch (ArithmeticException | DateTimeException e) {
+            complete = false;
+            invalidReason = "invalid publish time";
+          }
+        }
+      }
+      releases.put(version, new Release(publishedAt, availableAt, invalidReason));
+
+      String tarball = indexed.tarballName();
+      if (tarball != null) {
+        tarballVersions.computeIfAbsent(tarball, ignored -> new ArrayList<>()).add(version);
+      }
+    }
+    transitions.sort(Comparator.naturalOrder());
+    Map<String, List<String>> immutableTarballs = new LinkedHashMap<>();
+    tarballVersions.forEach((name, versions) -> immutableTarballs.put(name, List.copyOf(versions)));
+    return new Analysis(
+        disabled,
+        Collections.unmodifiableMap(releases),
+        Collections.unmodifiableMap(immutableTarballs),
+        List.copyOf(transitions),
+        disabled || complete);
+  }
+
+  private static String version(Map.Entry<String, Object> entry) {
+    if (entry.getValue() instanceof Map<?, ?> rawVersion) {
+      return NpmMetadata.stringValue(rawVersion.get(NpmMetadata.VERSION), entry.getKey());
+    }
+    return entry.getKey();
+  }
+
+  private static String tarball(Object rawVersion) {
+    if (!(rawVersion instanceof Map<?, ?> version)) {
+      return null;
+    }
+    Object rawDist = version.get(NpmMetadata.DIST);
+    if (!(rawDist instanceof Map<?, ?> dist)) {
+      return null;
+    }
+    Object rawTarball = dist.get(NpmMetadata.TARBALL);
+    return rawTarball == null ? null : NpmMetadata.extractTarballName(rawTarball.toString());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Optional<Instant> publishedAt(Map<String, Object> packageRoot, String version) {
+    if (packageRoot == null || version == null) {
+      return Optional.empty();
+    }
+    Object rawTime = packageRoot.get(NpmMetadata.TIME);
+    if (!(rawTime instanceof Map<?, ?> time)) {
+      return Optional.empty();
+    }
+    Object raw = ((Map<String, Object>) time).get(version);
+    if (raw == null || raw.toString().isBlank()) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.of(OffsetDateTime.parse(
+          raw.toString(), DateTimeFormatter.ISO_OFFSET_DATE_TIME).toInstant());
+    } catch (DateTimeParseException first) {
+      try {
+        return Optional.of(Instant.parse(raw.toString()));
+      } catch (DateTimeParseException ignored) {
+        return Optional.empty();
+      }
+    }
+  }
+
+  private static Optional<String> replacementForTag(
+      String tag,
+      String originalTarget,
+      List<String> eligibleVersions,
+      Map<String, Object> filteredVersions) {
+    if (eligibleVersions.isEmpty() || originalTarget == null) {
+      return Optional.empty();
+    }
+    boolean prerelease = isPrerelease(originalTarget);
+    Integer major = major(originalTarget);
+    List<String> candidates = eligibleVersions.stream()
+        .filter(version -> isPrerelease(version) == prerelease)
+        .filter(version -> "latest".equals(tag) || major == null || major.equals(major(version)))
+        .toList();
+    return candidates.stream().max(Comparator
+        .comparing((String version) -> !isDeprecated(filteredVersions.get(version)))
+        .thenComparing(ComparableVersion::new));
+  }
+
+  private static boolean isDeprecated(Object rawVersion) {
+    if (!(rawVersion instanceof Map<?, ?> version)) {
+      return false;
+    }
+    Object deprecated = version.get("deprecated");
+    return deprecated != null && !deprecated.toString().isBlank();
+  }
+
+  private static boolean isPrerelease(String version) {
+    return version != null && version.indexOf('-') >= 0;
+  }
+
+  private static Integer major(String version) {
+    if (version == null) {
+      return null;
+    }
+    Matcher matcher = SEMVER_MAJOR.matcher(version);
+    if (!matcher.find()) {
+      return null;
+    }
+    try {
+      return Integer.valueOf(matcher.group(1));
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+
+  /** Immutable, compact policy state derived from one raw packument revision. */
+  public static final class Analysis {
+    private final boolean disabled;
+    private final Map<String, Release> releases;
+    private final Map<String, List<String>> tarballVersions;
+    private final List<Instant> transitions;
+    private final boolean completePublishTimes;
+
+    private Analysis(
+        boolean disabled,
+        Map<String, Release> releases,
+        Map<String, List<String>> tarballVersions,
+        List<Instant> transitions,
+        boolean completePublishTimes) {
+      this.disabled = disabled;
+      this.releases = releases;
+      this.tarballVersions = tarballVersions;
+      this.transitions = transitions;
+      this.completePublishTimes = completePublishTimes;
+    }
+
+    public Eligibility eligibility(String version, Instant evaluatedAt) {
+      if (disabled && releases.containsKey(version)) {
+        return new Eligibility(true, null, null, null);
+      }
+      Release release = releases.get(version);
+      if (release == null) {
+        return new Eligibility(false, "version is absent from package metadata", null, null);
+      }
+      if (release.invalidReason() != null || release.availableAt() == null) {
+        return new Eligibility(
+            false,
+            release.invalidReason() == null ? "invalid publish time" : release.invalidReason(),
+            release.publishedAt(),
+            null);
+      }
+      boolean eligible = evaluatedAt != null && !evaluatedAt.isBefore(release.availableAt());
+      return new Eligibility(
+          eligible,
+          eligible ? null : "release has not reached the minimum age",
+          release.publishedAt(),
+          release.availableAt());
+    }
+
+    public Map<String, Object> filter(
+        Map<String, Object> packageRoot,
+        Instant evaluatedAt) {
+      Map<String, Object> filtered = NpmMetadata.deepCopy(packageRoot);
+      return filterPreparedCopy(filtered, evaluatedAt);
+    }
+
+    /**
+     * Applies the policy to a caller-owned response copy and returns that same map.
+     *
+     * <p>This avoids copying a full packument when the caller has already produced an isolated
+     * install-v1 projection. The supplied map is mutated and must never be the durable raw
+     * packument.
+     */
+    public Map<String, Object> filterPreparedCopy(
+        Map<String, Object> preparedCopy,
+        Instant evaluatedAt) {
+      if (disabled) {
+        return preparedCopy;
+      }
+      Map<String, Object> versions = NpmMetadata.versions(preparedCopy);
+      List<String> eligibleVersions = new ArrayList<>();
+      Iterator<Map.Entry<String, Object>> iterator = versions.entrySet().iterator();
+      while (iterator.hasNext()) {
+        Map.Entry<String, Object> entry = iterator.next();
+        if (eligibility(entry.getKey(), evaluatedAt).eligible()) {
+          eligibleVersions.add(entry.getKey());
+        } else {
+          iterator.remove();
+        }
+      }
+      Map<String, Object> tags = filteredDistTags(
+          preparedCopy, evaluatedAt, eligibleVersions);
+      Map<String, Object> responseTags = NpmMetadata.distTags(preparedCopy);
+      responseTags.clear();
+      responseTags.putAll(tags);
+      return preparedCopy;
+    }
+
+    public Map<String, Object> filteredDistTags(
+        Map<String, Object> packageRoot,
+        Instant evaluatedAt) {
+      if (disabled) {
+        return new LinkedHashMap<>(NpmMetadata.distTags(packageRoot));
+      }
+      List<String> eligibleVersions = visibleVersions(evaluatedAt);
+      return filteredDistTags(packageRoot, evaluatedAt, eligibleVersions);
+    }
+
+    public List<String> visibleVersions(Instant evaluatedAt) {
+      if (disabled) {
+        return List.copyOf(releases.keySet());
+      }
+      List<String> eligibleVersions = new ArrayList<>();
+      for (String version : releases.keySet()) {
+        if (eligibility(version, evaluatedAt).eligible()) {
+          eligibleVersions.add(version);
+        }
+      }
+      return List.copyOf(eligibleVersions);
+    }
+
+    public Map<String, Object> filteredDistTags(
+        Map<String, Object> packageRoot,
+        Instant evaluatedAt,
+        List<String> eligibleVersions) {
+      Map<String, Object> originalVersions = NpmMetadata.versions(packageRoot);
+      Map<String, Object> tags = new LinkedHashMap<>();
+      for (Map.Entry<String, Object> entry : NpmMetadata.distTags(packageRoot).entrySet()) {
+        String target = NpmMetadata.stringValue(entry.getValue(), null);
+        if (target != null && eligibility(target, evaluatedAt).eligible()) {
+          tags.put(entry.getKey(), target);
+          continue;
+        }
+        replacementForTag(entry.getKey(), target, eligibleVersions, originalVersions)
+            .ifPresent(replacement -> tags.put(entry.getKey(), replacement));
+      }
+      return tags;
+    }
+
+    public boolean crossedMaturityBoundary(Instant lastVerifiedAt, Instant now) {
+      return !disabled
+          && lastVerifiedAt != null
+          && now != null
+          && now.isAfter(lastVerifiedAt)
+          && visibilityGeneration(now) > visibilityGeneration(lastVerifiedAt);
+    }
+
+    /** Stable response-cache generation; it changes only when another version becomes mature. */
+    public int visibilityGeneration(Instant evaluatedAt) {
+      if (disabled) {
+        return releases.size();
+      }
+      if (evaluatedAt == null || transitions.isEmpty()) {
+        return 0;
+      }
+      int low = 0;
+      int high = transitions.size();
+      while (low < high) {
+        int mid = (low + high) >>> 1;
+        if (!transitions.get(mid).isAfter(evaluatedAt)) {
+          low = mid + 1;
+        } else {
+          high = mid;
+        }
+      }
+      return low;
+    }
+
+    public Optional<Instant> nextMaturityAfter(Instant evaluatedAt) {
+      if (disabled || transitions.isEmpty()) {
+        return Optional.empty();
+      }
+      int generation = visibilityGeneration(evaluatedAt);
+      return generation >= transitions.size()
+          ? Optional.empty()
+          : Optional.of(transitions.get(generation));
+    }
+
+    public boolean hasCompletePublishTimes() {
+      return completePublishTimes;
+    }
+
+    public List<String> versionsForTarball(String tarballName) {
+      String expected = NpmMetadata.extractTarballName(tarballName);
+      if (expected == null) {
+        return List.of();
+      }
+      return tarballVersions.getOrDefault(expected, List.of());
+    }
+
+    public int versionCount() {
+      return releases.size();
+    }
+
+    /** Approximate entry count used to bound node-local derived caches. */
+    public int cacheWeight() {
+      long weight = releases.size();
+      for (List<String> versions : tarballVersions.values()) {
+        weight += 1L + versions.size();
+      }
+      return (int) Math.max(1, Math.min(Integer.MAX_VALUE, weight));
+    }
+  }
+
+  private record Release(
+      Instant publishedAt,
+      Instant availableAt,
+      String invalidReason) {
+  }
+
+  /** Policy-independent release data suitable for durable persistence. */
+  public record IndexedRelease(
+      String version,
+      Instant publishedAt,
+      String invalidReason,
+      String tarballName) {
+    public IndexedRelease {
+      if (version == null || version.isBlank()) {
+        throw new IllegalArgumentException("indexed npm release version is required");
+      }
+    }
+  }
+
+  public record ReleaseIndex(List<IndexedRelease> releases) {
+    public ReleaseIndex {
+      releases = releases == null ? List.of() : List.copyOf(releases);
+    }
+  }
+
+  public record Eligibility(
+      boolean eligible,
+      String reason,
+      Instant publishedAt,
+      Instant availableAt) {
+  }
+}

--- a/protocol-npm/src/main/java/com/github/klboke/kkrepo/protocol/npm/NpmMinimumReleaseAge.java
+++ b/protocol-npm/src/main/java/com/github/klboke/kkrepo/protocol/npm/NpmMinimumReleaseAge.java
@@ -9,11 +9,13 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.maven.artifact.versioning.ComparableVersion;
@@ -323,6 +325,10 @@ public final class NpmMinimumReleaseAge {
       Map<String, Object> responseTags = NpmMetadata.distTags(preparedCopy);
       responseTags.clear();
       responseTags.putAll(tags);
+      Map<String, Object> time = filteredTime(preparedCopy, eligibleVersions);
+      if (time != null) {
+        preparedCopy.put(NpmMetadata.TIME, time);
+      }
       return preparedCopy;
     }
 
@@ -347,6 +353,28 @@ public final class NpmMinimumReleaseAge {
         }
       }
       return List.copyOf(eligibleVersions);
+    }
+
+    /**
+     * Removes timestamps for hidden versions while preserving package-level fields such as
+     * {@code created} and {@code modified}, plus any upstream extension fields.
+     */
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> filteredTime(
+        Map<String, Object> packageRoot,
+        List<String> visibleVersions) {
+      Object rawTime = packageRoot.get(NpmMetadata.TIME);
+      if (!(rawTime instanceof Map<?, ?> time)) {
+        return null;
+      }
+      Set<String> visible = new HashSet<>(visibleVersions);
+      Map<String, Object> filtered = new LinkedHashMap<>();
+      for (Map.Entry<String, Object> entry : ((Map<String, Object>) time).entrySet()) {
+        if (!releases.containsKey(entry.getKey()) || visible.contains(entry.getKey())) {
+          filtered.put(entry.getKey(), entry.getValue());
+        }
+      }
+      return filtered;
     }
 
     public Map<String, Object> filteredDistTags(

--- a/protocol-npm/src/test/java/com/github/klboke/kkrepo/protocol/npm/NpmMinimumReleaseAgeTest.java
+++ b/protocol-npm/src/test/java/com/github/klboke/kkrepo/protocol/npm/NpmMinimumReleaseAgeTest.java
@@ -25,7 +25,11 @@ class NpmMinimumReleaseAgeTest {
     assertEquals(Map.of("latest", "1.0.0"), NpmMetadata.distTags(filtered));
     assertEquals(1, NpmMetadata.versions(filtered).size());
     assertTrue(NpmMetadata.versions(filtered).containsKey("1.0.0"));
+    assertEquals(
+        Map.of("1.0.0", "2026-07-17T12:00:00Z"),
+        filtered.get(NpmMetadata.TIME));
     assertTrue(NpmMetadata.versions(root).containsKey("1.1.0"), "raw upstream metadata must remain intact");
+    assertTrue(((Map<?, ?>) root.get(NpmMetadata.TIME)).containsKey("1.1.0"));
   }
 
   @Test
@@ -41,7 +45,32 @@ class NpmMinimumReleaseAgeTest {
     assertSame(prepared, filtered, "the isolated response projection should be filtered in place");
     assertEquals(Map.of("latest", "1.0.0"), NpmMetadata.distTags(filtered));
     assertEquals(List.of("1.0.0"), List.copyOf(NpmMetadata.versions(filtered).keySet()));
+    assertEquals(
+        Map.of("1.0.0", "2026-07-17T12:00:00Z"),
+        filtered.get(NpmMetadata.TIME));
     assertTrue(NpmMetadata.versions(root).containsKey("1.1.0"), "the raw packument must remain intact");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void preservesPackageLevelTimeFieldsWhileRemovingHiddenVersionTimes() {
+    Map<String, Object> root = packument(
+        Map.of("1.0.0", "2026-07-17T12:00:00Z", "1.1.0", "2026-07-19T11:30:01Z"),
+        Map.of("latest", "1.1.0"));
+    Map<String, Object> time = (Map<String, Object>) root.get(NpmMetadata.TIME);
+    time.put("created", "2026-07-17T12:00:00Z");
+    time.put("modified", "2026-07-19T11:30:01Z");
+    time.put("registry-extension", "preserved");
+
+    Map<String, Object> filtered = NpmMinimumReleaseAge.filter(root, NOW, 60);
+
+    assertEquals(
+        Map.of(
+            "1.0.0", "2026-07-17T12:00:00Z",
+            "created", "2026-07-17T12:00:00Z",
+            "modified", "2026-07-19T11:30:01Z",
+            "registry-extension", "preserved"),
+        filtered.get(NpmMetadata.TIME));
   }
 
   @Test

--- a/protocol-npm/src/test/java/com/github/klboke/kkrepo/protocol/npm/NpmMinimumReleaseAgeTest.java
+++ b/protocol-npm/src/test/java/com/github/klboke/kkrepo/protocol/npm/NpmMinimumReleaseAgeTest.java
@@ -2,7 +2,9 @@ package com.github.klboke.kkrepo.protocol.npm;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
@@ -149,6 +151,131 @@ class NpmMinimumReleaseAgeTest {
   }
 
   @Test
+  void disabledAnalysisCoversKnownAndUnknownVersionsWithoutTransitions() {
+    Map<String, Object> root = new LinkedHashMap<>();
+    NpmMetadata.versions(root).put("1.0.0", version("1.0.0"));
+    NpmMetadata.distTags(root).put("latest", "1.0.0");
+    NpmMinimumReleaseAge.Analysis analysis = NpmMinimumReleaseAge.analyze(root, 0);
+
+    assertTrue(analysis.eligibility("1.0.0", null).eligible());
+    assertFalse(analysis.eligibility("missing", NOW).eligible());
+    assertEquals(Map.of("latest", "1.0.0"), analysis.filteredDistTags(root, NOW));
+    assertEquals(List.of("1.0.0"), analysis.visibleVersions(null));
+    assertEquals(1, analysis.visibilityGeneration(null));
+    assertTrue(analysis.nextMaturityAfter(NOW).isEmpty());
+    assertFalse(analysis.crossedMaturityBoundary(Instant.EPOCH, NOW));
+    assertEquals(1, analysis.versionCount());
+    assertTrue(analysis.cacheWeight() >= 1);
+  }
+
+  @Test
+  void malformedVersionShapesAndPublishTimesFailClosedWithoutInventingTarballs() {
+    Map<String, Object> root = new LinkedHashMap<>();
+    Map<String, Object> versions = NpmMetadata.versions(root);
+    versions.put("1.0.0", "not-an-object");
+    versions.put("1.1.0", new LinkedHashMap<>(Map.of(
+        "version", "1.1.0", "dist", "not-an-object")));
+    versions.put("1.2.0", new LinkedHashMap<>(Map.of(
+        "version", "1.2.0", "dist", Map.of())));
+    versions.put("1.3.0", version("1.3.0"));
+    root.put(NpmMetadata.TIME, new LinkedHashMap<>(Map.of(
+        "1.0.0", "2026-07-17T12:00:00Z",
+        "1.1.0", "2026-07-17T12:00:00Z",
+        "1.2.0", "",
+        "1.3.0", "not-a-time")));
+
+    NpmMinimumReleaseAge.ReleaseIndex index = NpmMinimumReleaseAge.index(root);
+    NpmMinimumReleaseAge.Analysis analysis = NpmMinimumReleaseAge.analyze(index, 60);
+
+    assertTrue(analysis.eligibility("1.0.0", NOW).eligible());
+    assertTrue(analysis.eligibility("1.1.0", NOW).eligible());
+    assertFalse(analysis.eligibility("1.2.0", NOW).eligible());
+    assertFalse(analysis.eligibility("1.3.0", NOW).eligible());
+    assertTrue(analysis.versionsForTarball("anything.tgz").isEmpty());
+    assertFalse(analysis.hasCompletePublishTimes());
+  }
+
+  @Test
+  void overflowingAvailabilityAndNullEvaluationFailClosed() {
+    NpmMinimumReleaseAge.Analysis overflow = NpmMinimumReleaseAge.analyze(
+        new NpmMinimumReleaseAge.ReleaseIndex(List.of(
+            new NpmMinimumReleaseAge.IndexedRelease(
+                "1.0.0", Instant.MAX, null, "demo.tgz"))),
+        1);
+    NpmMinimumReleaseAge.Analysis ordinary = NpmMinimumReleaseAge.analyze(
+        new NpmMinimumReleaseAge.ReleaseIndex(List.of(
+            new NpmMinimumReleaseAge.IndexedRelease(
+                "2.0.0", Instant.parse("2026-07-19T10:00:00Z"), null, null))),
+        60);
+
+    assertFalse(overflow.eligibility("1.0.0", NOW).eligible());
+    assertEquals("invalid publish time", overflow.eligibility("1.0.0", NOW).reason());
+    assertFalse(overflow.hasCompletePublishTimes());
+    assertFalse(ordinary.eligibility("2.0.0", null).eligible());
+    assertEquals("release has not reached the minimum age",
+        ordinary.eligibility("2.0.0", null).reason());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void repairsStablePrereleaseAndCustomTagsUsingEligibleCompatibleVersions() {
+    Map<String, Object> root = packument(
+        Map.of(
+            "1.0.0", "2026-07-17T12:00:00Z",
+            "1.1.0", "2026-07-17T12:00:00Z",
+            "1.2.0", "2026-07-19T11:30:01Z",
+            "2.0.0-alpha.1", "2026-07-17T12:00:00Z",
+            "2.0.0-beta.1", "2026-07-19T11:30:01Z",
+            "999999999999999999.0.0-beta.1", "2026-07-19T11:30:01Z"),
+        Map.of(
+            "latest", "1.2.0",
+            "next", "2.0.0-beta.1",
+            "overflow", "999999999999999999.0.0-beta.1"));
+    ((Map<String, Object>) NpmMetadata.versions(root).get("1.0.0"))
+        .put("deprecated", "use 1.0.0");
+    NpmMetadata.distTags(root).put("stable", "1.0.0");
+    NpmMetadata.distTags(root).put("missing", null);
+
+    Map<String, Object> tags = NpmMinimumReleaseAge.analyze(root, 60)
+        .filteredDistTags(root, NOW);
+
+    assertEquals("1.1.0", tags.get("latest"));
+    assertEquals("2.0.0-alpha.1", tags.get("next"));
+    assertEquals("2.0.0-alpha.1", tags.get("overflow"));
+    assertEquals("1.0.0", tags.get("stable"));
+    assertFalse(tags.containsKey("missing"));
+  }
+
+  @Test
+  void handlesMissingTimeMapNullTarballAndEmptyReleaseIndex() {
+    Map<String, Object> root = new LinkedHashMap<>();
+    NpmMetadata.versions(root).put("1.0.0", version("1.0.0"));
+    root.put(NpmMetadata.TIME, "not-an-object");
+    NpmMinimumReleaseAge.Analysis analysis = NpmMinimumReleaseAge.analyze(root, 60);
+    Map<String, Object> copy = NpmMetadata.deepCopy(root);
+
+    assertFalse(analysis.eligibility("1.0.0", NOW).eligible());
+    assertSame(copy, analysis.filterPreparedCopy(copy, NOW));
+    assertEquals("not-an-object", copy.get(NpmMetadata.TIME));
+    assertEquals(0, analysis.visibilityGeneration(null));
+    assertTrue(analysis.nextMaturityAfter(null).isEmpty());
+    assertTrue(analysis.versionsForTarball(null).isEmpty());
+    assertTrue(new NpmMinimumReleaseAge.ReleaseIndex(null).releases().isEmpty());
+    assertEquals(1, NpmMinimumReleaseAge.analyze(
+        new NpmMinimumReleaseAge.ReleaseIndex(null), 60).cacheWeight());
+  }
+
+  @Test
+  void validatesIndexedReleaseIdentity() {
+    assertThrows(IllegalArgumentException.class,
+        () -> new NpmMinimumReleaseAge.IndexedRelease(null, null, null, null));
+    assertThrows(IllegalArgumentException.class,
+        () -> new NpmMinimumReleaseAge.IndexedRelease(" ", null, null, null));
+    assertNull(new NpmMinimumReleaseAge.IndexedRelease(
+        "1.0.0", null, null, null).tarballName());
+  }
+
+  @Test
   @SuppressWarnings("unchecked")
   void findsEveryVersionThatSharesATarballFilename() {
     Map<String, Object> root = packument(
@@ -176,6 +303,79 @@ class NpmMinimumReleaseAgeTest {
     assertFalse(analysis.eligibility("1.0.0", NOW).eligible());
     assertFalse(analysis.hasCompletePublishTimes());
     assertEquals(List.of("1.0.0"), analysis.versionsForTarball("demo-1.0.0.tgz"));
+  }
+
+  @Test
+  void nullPublishDataAndLeapSecondTimestampFailOrParseDeterministically() {
+    NpmMinimumReleaseAge.Analysis missing = NpmMinimumReleaseAge.analyze(
+        new NpmMinimumReleaseAge.ReleaseIndex(List.of(
+            new NpmMinimumReleaseAge.IndexedRelease("1.0.0", null, null, null))),
+        60);
+    Map<String, Object> leapSecond = packument(
+        Map.of("2.0.0", "2016-12-31T23:59:60Z"), Map.of("latest", "2.0.0"));
+
+    assertEquals("invalid publish time", missing.eligibility("1.0.0", NOW).reason());
+    assertFalse(missing.hasCompletePublishTimes());
+    assertTrue(NpmMinimumReleaseAge.analyze(leapSecond, 60)
+        .eligibility("2.0.0", NOW).eligible());
+  }
+
+  @Test
+  void tagRepairHandlesLegacyVersionDocumentsAndNonSemverTargets() {
+    Map<String, Object> root = new LinkedHashMap<>();
+    NpmMetadata.versions(root).put("1.0.0-alpha.1", "legacy-version-document");
+    NpmMetadata.versions(root).put("2.0.0-alpha.1", version("2.0.0-alpha.1"));
+    NpmMetadata.versions(root).put("release-channel", version("release-channel"));
+    root.put(NpmMetadata.TIME, new LinkedHashMap<>(Map.of(
+        "1.0.0-alpha.1", "2026-07-17T12:00:00Z",
+        "2.0.0-alpha.1", "2026-07-17T12:00:00Z",
+        "release-channel", "2026-07-19T11:30:00Z")));
+    root.put(NpmMetadata.DIST_TAGS, new LinkedHashMap<>(Map.of(
+        "next", "release-channel")));
+
+    Map<String, Object> tags = NpmMinimumReleaseAge.analyze(root, 60)
+        .filteredDistTags(root, NOW);
+
+    assertEquals("2.0.0-alpha.1", tags.get("next"));
+  }
+
+  @Test
+  void maturityBoundaryChecksEveryNullAndOrderingGuard() {
+    NpmMinimumReleaseAge.Analysis analysis = NpmMinimumReleaseAge.analyze(
+        packument(Map.of("1.0.0", "2026-07-19T11:00:00Z"), Map.of("latest", "1.0.0")),
+        60);
+
+    assertFalse(analysis.crossedMaturityBoundary(null, NOW));
+    assertFalse(analysis.crossedMaturityBoundary(Instant.EPOCH, null));
+    assertFalse(analysis.crossedMaturityBoundary(NOW, NOW.minusSeconds(1)));
+    assertFalse(analysis.crossedMaturityBoundary(NOW, NOW));
+    assertEquals(0, analysis.visibilityGeneration(null));
+    assertEquals(0, NpmMinimumReleaseAge.analyze(
+        new NpmMinimumReleaseAge.ReleaseIndex(List.of()), 60).visibilityGeneration(NOW));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void tagRepairTreatsBlankDeprecationAsActiveAndHandlesNoEligibleCandidate() {
+    Map<String, Object> root = packument(
+        Map.of(
+            "1.0.0", "2026-07-17T12:00:00Z",
+            "2.0.0", "2026-07-17T12:00:00Z",
+            "3.0.0", "2026-07-19T11:30:00Z"),
+        Map.of("latest", "3.0.0", "three", "3.0.0"));
+    ((Map<String, Object>) NpmMetadata.versions(root).get("2.0.0"))
+        .put("deprecated", " ");
+
+    Map<String, Object> tags = NpmMinimumReleaseAge.analyze(root, 60)
+        .filteredDistTags(root, NOW);
+
+    assertEquals("2.0.0", tags.get("latest"));
+    assertFalse(tags.containsKey("three"));
+
+    Map<String, Object> allImmature = packument(
+        Map.of("4.0.0", "2026-07-19T11:30:00Z"), Map.of("latest", "4.0.0"));
+    assertTrue(NpmMinimumReleaseAge.analyze(allImmature, 60)
+        .filteredDistTags(allImmature, NOW).isEmpty());
   }
 
   private static Map<String, Object> packument(

--- a/protocol-npm/src/test/java/com/github/klboke/kkrepo/protocol/npm/NpmMinimumReleaseAgeTest.java
+++ b/protocol-npm/src/test/java/com/github/klboke/kkrepo/protocol/npm/NpmMinimumReleaseAgeTest.java
@@ -1,0 +1,169 @@
+package com.github.klboke.kkrepo.protocol.npm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class NpmMinimumReleaseAgeTest {
+  private static final Instant NOW = Instant.parse("2026-07-19T12:00:00Z");
+
+  @Test
+  void filtersImmatureVersionsAndRewindsLatestWithoutMutatingSource() {
+    Map<String, Object> root = packument(
+        Map.of("1.0.0", "2026-07-17T12:00:00Z", "1.1.0", "2026-07-19T11:30:01Z"),
+        Map.of("latest", "1.1.0"));
+
+    Map<String, Object> filtered = NpmMinimumReleaseAge.filter(root, NOW, 60);
+
+    assertEquals(Map.of("latest", "1.0.0"), NpmMetadata.distTags(filtered));
+    assertEquals(1, NpmMetadata.versions(filtered).size());
+    assertTrue(NpmMetadata.versions(filtered).containsKey("1.0.0"));
+    assertTrue(NpmMetadata.versions(root).containsKey("1.1.0"), "raw upstream metadata must remain intact");
+  }
+
+  @Test
+  void filtersAnAlreadyIsolatedInstallProjectionWithoutAnotherDeepCopy() {
+    Map<String, Object> root = packument(
+        Map.of("1.0.0", "2026-07-17T12:00:00Z", "1.1.0", "2026-07-19T11:30:01Z"),
+        Map.of("latest", "1.1.0"));
+    Map<String, Object> prepared = NpmMetadata.abbreviatePackageRoot(root);
+    NpmMinimumReleaseAge.Analysis analysis = NpmMinimumReleaseAge.analyze(root, 60);
+
+    Map<String, Object> filtered = analysis.filterPreparedCopy(prepared, NOW);
+
+    assertSame(prepared, filtered, "the isolated response projection should be filtered in place");
+    assertEquals(Map.of("latest", "1.0.0"), NpmMetadata.distTags(filtered));
+    assertEquals(List.of("1.0.0"), List.copyOf(NpmMetadata.versions(filtered).keySet()));
+    assertTrue(NpmMetadata.versions(root).containsKey("1.1.0"), "the raw packument must remain intact");
+  }
+
+  @Test
+  void exactBoundaryIsEligibleAndMissingOrInvalidTimesFailClosed() {
+    Map<String, Object> root = packument(
+        Map.of("1.0.0", "2026-07-19T11:00:00Z", "1.1.0", "not-a-time"),
+        Map.of("latest", "1.1.0"));
+    NpmMetadata.versions(root).put("2.0.0", version("2.0.0"));
+
+    assertTrue(NpmMinimumReleaseAge.eligibility(root, "1.0.0", NOW, 60).eligible());
+    assertFalse(NpmMinimumReleaseAge.eligibility(root, "1.1.0", NOW, 60).eligible());
+    assertFalse(NpmMinimumReleaseAge.eligibility(root, "2.0.0", NOW, 60).eligible());
+    assertFalse(NpmMinimumReleaseAge.hasCompletePublishTimes(root));
+  }
+
+  @Test
+  void detectsMaturityBoundaryIndependentlyOfMetadataTtl() {
+    Map<String, Object> root = packument(
+        Map.of("1.0.0", "2026-07-19T11:00:00Z"),
+        Map.of("latest", "1.0.0"));
+
+    assertTrue(NpmMinimumReleaseAge.crossedMaturityBoundary(
+        root, Instant.parse("2026-07-19T11:59:59Z"), NOW, 60));
+    assertFalse(NpmMinimumReleaseAge.crossedMaturityBoundary(
+        root, NOW, Instant.parse("2026-07-19T12:00:01Z"), 60));
+  }
+
+  @Test
+  void analysisExposesStableGenerationsAndTheExactNextTransition() {
+    Map<String, Object> root = packument(
+        Map.of(
+            "1.0.0", "2026-07-19T10:00:00Z",
+            "1.1.0", "2026-07-19T11:30:00Z"),
+        Map.of("latest", "1.1.0"));
+    NpmMinimumReleaseAge.Analysis analysis = NpmMinimumReleaseAge.analyze(root, 60);
+
+    assertEquals(1, analysis.visibilityGeneration(NOW));
+    assertEquals(
+        Instant.parse("2026-07-19T12:30:00Z"),
+        analysis.nextMaturityAfter(NOW).orElseThrow());
+    assertEquals(2, analysis.visibilityGeneration(Instant.parse("2026-07-19T12:30:00Z")));
+    assertTrue(analysis.nextMaturityAfter(Instant.parse("2026-07-19T12:30:00Z")).isEmpty());
+  }
+
+  @Test
+  void persistedReleaseIndexPreservesPolicySemanticsWithoutThePackument() {
+    Map<String, Object> root = packument(
+        Map.of(
+            "1.0.0", "2026-07-19T10:00:00Z",
+            "1.1.0", "2026-07-19T11:30:00Z"),
+        Map.of("latest", "1.1.0"));
+    NpmMinimumReleaseAge.Analysis fromPackument = NpmMinimumReleaseAge.analyze(root, 60);
+    NpmMinimumReleaseAge.Analysis fromIndex = NpmMinimumReleaseAge.analyze(
+        NpmMinimumReleaseAge.index(root), 60);
+
+    assertEquals(fromPackument.eligibility("1.0.0", NOW), fromIndex.eligibility("1.0.0", NOW));
+    assertEquals(fromPackument.eligibility("1.1.0", NOW), fromIndex.eligibility("1.1.0", NOW));
+    assertEquals(fromPackument.visibleVersions(NOW), fromIndex.visibleVersions(NOW));
+    assertEquals(
+        fromPackument.versionsForTarball("demo-1.1.0.tgz"),
+        fromIndex.versionsForTarball("demo-1.1.0.tgz"));
+    assertEquals(fromPackument.nextMaturityAfter(NOW), fromIndex.nextMaturityAfter(NOW));
+    assertEquals(fromPackument.hasCompletePublishTimes(), fromIndex.hasCompletePublishTimes());
+  }
+
+  @Test
+  void zeroLeavesExistingBehaviorUnchangedEvenWithoutPublishTimes() {
+    Map<String, Object> root = new LinkedHashMap<>();
+    NpmMetadata.versions(root).put("1.0.0", version("1.0.0"));
+    NpmMetadata.distTags(root).put("latest", "1.0.0");
+
+    Map<String, Object> filtered = NpmMinimumReleaseAge.filter(root, NOW, 0);
+
+    assertTrue(NpmMetadata.versions(filtered).containsKey("1.0.0"));
+    assertEquals("1.0.0", NpmMetadata.distTags(filtered).get("latest"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void findsEveryVersionThatSharesATarballFilename() {
+    Map<String, Object> root = packument(
+        Map.of("1.0.0", "2026-07-18T12:00:00Z", "2.0.0", "2026-07-19T11:30:00Z"),
+        Map.of("latest", "2.0.0"));
+    Map<String, Object> second = (Map<String, Object>) NpmMetadata.versions(root).get("2.0.0");
+    second.put("dist", new LinkedHashMap<>(Map.of(
+        "tarball", "https://registry.npmjs.org/demo/-/demo-1.0.0.tgz")));
+
+    assertEquals(
+        List.of("1.0.0", "2.0.0"),
+        NpmMinimumReleaseAge.versionsForTarball(root, "demo-1.0.0.tgz"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void mismatchedVersionDocumentIdentityFailsClosed() {
+    Map<String, Object> root = packument(
+        Map.of("1.0.0", "2026-07-17T12:00:00Z"),
+        Map.of("latest", "1.0.0"));
+    ((Map<String, Object>) NpmMetadata.versions(root).get("1.0.0"))
+        .put("version", "9.9.9");
+    NpmMinimumReleaseAge.Analysis analysis = NpmMinimumReleaseAge.analyze(root, 60);
+
+    assertFalse(analysis.eligibility("1.0.0", NOW).eligible());
+    assertFalse(analysis.hasCompletePublishTimes());
+    assertEquals(List.of("1.0.0"), analysis.versionsForTarball("demo-1.0.0.tgz"));
+  }
+
+  private static Map<String, Object> packument(
+      Map<String, String> publishTimes,
+      Map<String, String> distTags) {
+    Map<String, Object> root = new LinkedHashMap<>();
+    publishTimes.keySet().stream().sorted().forEach(
+        version -> NpmMetadata.versions(root).put(version, version(version)));
+    root.put(NpmMetadata.TIME, new LinkedHashMap<>(publishTimes));
+    root.put(NpmMetadata.DIST_TAGS, new LinkedHashMap<>(distTags));
+    return root;
+  }
+
+  private static Map<String, Object> version(String version) {
+    return new LinkedHashMap<>(Map.of(
+        "name", "demo",
+        "version", version,
+        "dist", Map.of("tarball", "https://registry.npmjs.org/demo/-/demo-" + version + ".tgz")));
+  }
+}

--- a/server/src/main/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcher.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcher.java
@@ -163,7 +163,7 @@ public class HttpRemoteFetcher {
       throws IOException {
     URI uri = target.uri();
     Map<String, String> headers = new LinkedHashMap<>();
-    headers.put("Accept", "*/*");
+    headers.put("Accept", req.accept() == null || req.accept().isBlank() ? "*/*" : req.accept());
     headers.put("User-Agent", "kkrepo/0.1");
     if (req.etag() != null && !req.etag().isBlank()) {
       headers.put("If-None-Match", "\"" + req.etag() + "\"");
@@ -205,7 +205,8 @@ public class HttpRemoteFetcher {
             redirectTrustedHost,
             redirectAuthorization,
             req.allowedUnsignedRedirectHosts(),
-            req.outboundProxy());
+            req.outboundProxy(),
+            req.accept());
         return fetchInternal(
             redirectedRequest,
             redirects + 1,
@@ -323,7 +324,26 @@ public class HttpRemoteFetcher {
       String trustedHost,
       String authorizationHeader,
       Set<String> allowedUnsignedRedirectHosts,
-      OutboundProxyConfig outboundProxy) {
+      OutboundProxyConfig outboundProxy,
+      String accept) {
+    /** Compatibility constructor for callers that do not need a custom Accept header. */
+    public Request(
+        String url,
+        String etag,
+        Instant lastModified,
+        Duration timeout,
+        TimeoutProfile timeoutProfile,
+        boolean headOnly,
+        String repository,
+        String format,
+        String trustedHost,
+        String authorizationHeader,
+        Set<String> allowedUnsignedRedirectHosts,
+        OutboundProxyConfig outboundProxy) {
+      this(url, etag, lastModified, timeout, timeoutProfile, headOnly, repository, format,
+          trustedHost, authorizationHeader, allowedUnsignedRedirectHosts, outboundProxy, null);
+    }
+
     public Request(String url, String etag, Instant lastModified, Duration timeout, boolean headOnly) {
       this(url, etag, lastModified, timeout, TimeoutProfile.DEFAULT, headOnly, null, null, null, null, Set.of(), null);
     }
@@ -371,12 +391,17 @@ public class HttpRemoteFetcher {
 
     public Request withConditional(String etag, Instant lastModified) {
       return new Request(url, etag, lastModified, timeout, timeoutProfile, headOnly,
-          repository, format, trustedHost, authorizationHeader, allowedUnsignedRedirectHosts, outboundProxy);
+          repository, format, trustedHost, authorizationHeader, allowedUnsignedRedirectHosts, outboundProxy, accept);
     }
 
     public Request withTimeoutProfile(TimeoutProfile timeoutProfile) {
       return new Request(url, etag, lastModified, timeout, timeoutProfile, headOnly,
-          repository, format, trustedHost, authorizationHeader, allowedUnsignedRedirectHosts, outboundProxy);
+          repository, format, trustedHost, authorizationHeader, allowedUnsignedRedirectHosts, outboundProxy, accept);
+    }
+
+    public Request withAccept(String accept) {
+      return new Request(url, etag, lastModified, timeout, timeoutProfile, headOnly,
+          repository, format, trustedHost, authorizationHeader, allowedUnsignedRedirectHosts, outboundProxy, accept);
     }
 
     public Request withRepository(RepositoryRuntime runtime) {
@@ -397,7 +422,8 @@ public class HttpRemoteFetcher {
           trusted,
           includeAuthorization && trusted != null ? remoteAuthorizationHeader(runtime) : null,
           Set.of(),
-          runtime == null ? null : runtime.outboundProxy());
+          runtime == null ? null : runtime.outboundProxy(),
+          accept);
     }
 
     public Request withRepositoryAllowingUnsignedRedirects(
@@ -423,7 +449,8 @@ public class HttpRemoteFetcher {
           trusted,
           includeAuthorization && trusted != null ? remoteAuthorizationHeader(runtime) : null,
           allowedUnsignedRedirectHosts,
-          runtime == null ? null : runtime.outboundProxy());
+          runtime == null ? null : runtime.outboundProxy(),
+          accept);
     }
 
     public String method() {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/maven/MavenErrorAdvice.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/maven/MavenErrorAdvice.java
@@ -9,6 +9,7 @@ import com.github.klboke.kkrepo.server.pub.PubExceptions;
 import com.github.klboke.kkrepo.server.pub.PubResponses;
 import com.github.klboke.kkrepo.protocol.pub.PubContentTypes;
 import java.util.Map;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -71,6 +72,15 @@ public class MavenErrorAdvice {
   @ExceptionHandler(NpmExceptions.WritePolicyDenied.class)
   public ResponseEntity<Map<String, Object>> npmWriteDenied(NpmExceptions.WritePolicyDenied e) {
     return npmBody(HttpStatus.BAD_REQUEST, e.getMessage());
+  }
+
+  @ExceptionHandler(NpmExceptions.ReleaseAgeDenied.class)
+  public ResponseEntity<Map<String, Object>> npmReleaseAgeDenied(NpmExceptions.ReleaseAgeDenied e) {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND)
+        .header(HttpHeaders.CACHE_CONTROL, "no-store")
+        .body(Map.of(
+            "success", false,
+            "error", e.getMessage() == null ? HttpStatus.NOT_FOUND.getReasonPhrase() : e.getMessage()));
   }
 
   @ExceptionHandler(NpmExceptions.MethodNotAllowed.class)

--- a/server/src/main/java/com/github/klboke/kkrepo/server/maven/MavenResponse.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/maven/MavenResponse.java
@@ -20,15 +20,24 @@ public final class MavenResponse {
   private final String etag;
   private final Instant lastModified;
   private final Map<String, String> headers;
+  private final Map<String, Object> internalAttributes;
 
   private MavenResponse(int status, InputStream body, long contentLength, String contentType,
       String etag, Instant lastModified, Map<String, String> headers) {
-    this(status, body, null, contentLength, contentType, etag, lastModified, headers);
+    this(status, body, null, contentLength, contentType, etag, lastModified, headers,
+        new HashMap<>());
   }
 
   private MavenResponse(int status, InputStream body, BodySupplier bodySupplier,
       long contentLength, String contentType, String etag, Instant lastModified,
       Map<String, String> headers) {
+    this(status, body, bodySupplier, contentLength, contentType, etag, lastModified, headers,
+        new HashMap<>());
+  }
+
+  private MavenResponse(int status, InputStream body, BodySupplier bodySupplier,
+      long contentLength, String contentType, String etag, Instant lastModified,
+      Map<String, String> headers, Map<String, Object> internalAttributes) {
     this.status = status;
     this.body = body;
     this.bodySupplier = bodySupplier;
@@ -37,6 +46,7 @@ public final class MavenResponse {
     this.etag = etag;
     this.lastModified = lastModified;
     this.headers = headers;
+    this.internalAttributes = internalAttributes;
   }
 
   public static MavenResponse ok(InputStream body, long contentLength, String contentType,
@@ -67,12 +77,28 @@ public final class MavenResponse {
   }
 
   public MavenResponse withStatus(int status) {
-    return new MavenResponse(status, body, bodySupplier, contentLength, contentType, etag, lastModified, headers);
+    return new MavenResponse(
+        status, body, bodySupplier, contentLength, contentType, etag, lastModified, headers,
+        internalAttributes);
   }
 
   public MavenResponse withHeader(String name, String value) {
     headers.put(name, value);
     return this;
+  }
+
+  /** Attaches service-internal context that controllers never expose as HTTP headers. */
+  public MavenResponse withInternalAttribute(String name, Object value) {
+    if (value == null) {
+      internalAttributes.remove(name);
+    } else {
+      internalAttributes.put(name, value);
+    }
+    return this;
+  }
+
+  public Object internalAttribute(String name) {
+    return internalAttributes.get(name);
   }
 
   void closeBodyIfOpen() {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/maven/RepositoryRuntime.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/maven/RepositoryRuntime.java
@@ -37,7 +37,43 @@ public record RepositoryRuntime(
     String dockerConnectorPublicUrl,
     Boolean cargoRequireAuthentication,
     List<RepositoryRuntime> members,
-    OutboundProxyConfig outboundProxy) {
+    OutboundProxyConfig outboundProxy,
+    Integer minimumReleaseAgeMinutes) {
+
+  /** Compatibility constructor for runtime snapshots created before npm release-age protection. */
+  public RepositoryRuntime(
+      long id,
+      String name,
+      RepositoryFormat format,
+      RepositoryType type,
+      String recipeName,
+      boolean online,
+      Long blobStoreId,
+      String writePolicy,
+      String versionPolicy,
+      String layoutPolicy,
+      boolean strictContentTypeValidation,
+      String proxyRemoteUrl,
+      Integer contentMaxAgeMinutes,
+      Integer metadataMaxAgeMinutes,
+      Boolean autoBlock,
+      String proxyRemoteUsername,
+      String proxyRemotePassword,
+      String proxyRemoteBearerToken,
+      String rawContentDisposition,
+      Boolean dockerConnectorEnabled,
+      Integer dockerConnectorPort,
+      String dockerConnectorPublicUrl,
+      Boolean cargoRequireAuthentication,
+      List<RepositoryRuntime> members,
+      OutboundProxyConfig outboundProxy) {
+    this(id, name, format, type, recipeName, online, blobStoreId, writePolicy,
+        versionPolicy, layoutPolicy, strictContentTypeValidation, proxyRemoteUrl,
+        contentMaxAgeMinutes, metadataMaxAgeMinutes, autoBlock, proxyRemoteUsername,
+        proxyRemotePassword, proxyRemoteBearerToken, rawContentDisposition,
+        dockerConnectorEnabled, dockerConnectorPort, dockerConnectorPublicUrl,
+        cargoRequireAuthentication, members, outboundProxy, null);
+  }
 
   public RepositoryRuntime(
       long id,
@@ -229,6 +265,54 @@ public record RepositoryRuntime(
         null);
   }
 
+  public RepositoryRuntime(
+      long id,
+      String name,
+      RepositoryFormat format,
+      RepositoryType type,
+      String recipeName,
+      boolean online,
+      Long blobStoreId,
+      String writePolicy,
+      String versionPolicy,
+      String layoutPolicy,
+      boolean strictContentTypeValidation,
+      String proxyRemoteUrl,
+      Integer contentMaxAgeMinutes,
+      Integer metadataMaxAgeMinutes,
+      Boolean autoBlock,
+      String rawContentDisposition,
+      List<RepositoryRuntime> members,
+      Integer minimumReleaseAgeMinutes) {
+    this(
+        id,
+        name,
+        format,
+        type,
+        recipeName,
+        online,
+        blobStoreId,
+        writePolicy,
+        versionPolicy,
+        layoutPolicy,
+        strictContentTypeValidation,
+        proxyRemoteUrl,
+        contentMaxAgeMinutes,
+        metadataMaxAgeMinutes,
+        autoBlock,
+        null,
+        null,
+        null,
+        rawContentDisposition,
+        null,
+        null,
+        null,
+        null,
+        members,
+        null,
+        minimumReleaseAgeMinutes);
+  }
+
   public boolean isHosted() {
     return type == RepositoryType.HOSTED;
   }
@@ -296,6 +380,16 @@ public record RepositoryRuntime(
 
   public boolean autoBlockOrDefault() {
     return autoBlock == null ? true : autoBlock;
+  }
+
+  public int minimumReleaseAgeMinutesOrDefault() {
+    return minimumReleaseAgeMinutes == null ? 0 : minimumReleaseAgeMinutes;
+  }
+
+  public boolean minimumReleaseAgeEnabled() {
+    return format == RepositoryFormat.NPM
+        && isProxy()
+        && minimumReleaseAgeMinutesOrDefault() > 0;
   }
 
   public String rawContentDispositionOrDefault() {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/maven/RepositoryRuntimeRegistry.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/maven/RepositoryRuntimeRegistry.java
@@ -178,6 +178,7 @@ public class RepositoryRuntimeRegistry {
 
     Integer contentMaxAge = null;
     Integer metadataMaxAge = null;
+    Integer minimumReleaseAge = null;
     Boolean autoBlock = null;
     String proxyRemoteUsername = null;
     String proxyRemotePassword = null;
@@ -186,6 +187,7 @@ public class RepositoryRuntimeRegistry {
     if (proxyRaw instanceof Map<?, ?> proxyMap) {
       contentMaxAge = asInt(proxyMap.get("contentMaxAgeMinutes"));
       metadataMaxAge = asInt(proxyMap.get("metadataMaxAgeMinutes"));
+      minimumReleaseAge = asInt(proxyMap.get("minimumReleaseAgeMinutes"));
       autoBlock = asBool(proxyMap.get("autoBlock"));
       Object username = proxyMap.get("remoteUsername");
       if (username != null && !username.toString().isBlank()) {
@@ -267,7 +269,8 @@ public class RepositoryRuntimeRegistry {
         dockerConnectorPublicUrl,
         cargoRequireAuthentication,
         members,
-        outboundProxy);
+        outboundProxy,
+        minimumReleaseAge);
   }
 
   private static com.github.klboke.kkrepo.server.proxy.OutboundProxyConfig readOutboundProxy(Map<?, ?> proxyMap) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmAssetWriter.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmAssetWriter.java
@@ -6,10 +6,12 @@ import com.github.klboke.kkrepo.core.RepositoryFormat;
 import com.github.klboke.kkrepo.persistence.jdbc.api.AssetDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.BrowseNodeDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.ComponentDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.NpmReleaseIndexDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.PersistenceHashes;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.AssetBlobRecord;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.AssetRecord;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.ComponentRecord;
-import com.github.klboke.kkrepo.persistence.jdbc.api.PersistenceHashes;
+import com.github.klboke.kkrepo.protocol.npm.NpmMinimumReleaseAge;
 import com.github.klboke.kkrepo.protocol.npm.NpmPackageId;
 import com.github.klboke.kkrepo.server.blob.BlobReferenceCodec;
 import com.github.klboke.kkrepo.server.blob.TempBlobFiles;
@@ -34,6 +36,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -49,6 +52,7 @@ public class NpmAssetWriter {
   private final AssetMetadataCache assetMetadataCache;
   private final NpmGroupPackumentCache packumentCache;
   private final GroupMemberAssetCache groupMemberAssetCache;
+  private final NpmReleaseIndexDao releaseIndexDao;
 
   public NpmAssetWriter(
       AssetDao assetDao,
@@ -58,6 +62,20 @@ public class NpmAssetWriter {
       AssetMetadataCache assetMetadataCache,
       NpmGroupPackumentCache packumentCache,
       GroupMemberAssetCache groupMemberAssetCache) {
+    this(assetDao, componentDao, browseNodeDao, transactionRetry, assetMetadataCache,
+        packumentCache, groupMemberAssetCache, null);
+  }
+
+  @Autowired
+  public NpmAssetWriter(
+      AssetDao assetDao,
+      ComponentDao componentDao,
+      BrowseNodeDao browseNodeDao,
+      TransientTransactionRetry transactionRetry,
+      AssetMetadataCache assetMetadataCache,
+      NpmGroupPackumentCache packumentCache,
+      GroupMemberAssetCache groupMemberAssetCache,
+      NpmReleaseIndexDao releaseIndexDao) {
     this.assetDao = assetDao;
     this.componentDao = componentDao;
     this.browseNodeDao = browseNodeDao;
@@ -65,6 +83,7 @@ public class NpmAssetWriter {
     this.assetMetadataCache = assetMetadataCache;
     this.packumentCache = packumentCache;
     this.groupMemberAssetCache = groupMemberAssetCache;
+    this.releaseIndexDao = releaseIndexDao;
   }
 
   public record Stored(AssetRecord asset, AssetBlobRecord blob, Digests digests, boolean created, Path responseFile) {
@@ -101,7 +120,21 @@ public class NpmAssetWriter {
       String createdByIp,
       Map<String, String> extraBlobAttributes) {
     return writePackageRoot(runtime, storage, blobStoreId, packageId, json,
-        createdBy, createdByIp, extraBlobAttributes, Map.of(), true);
+        createdBy, createdByIp, extraBlobAttributes, Map.of(), true, null);
+  }
+
+  public Stored writePackageRoot(
+      RepositoryRuntime runtime,
+      BlobStorage storage,
+      long blobStoreId,
+      NpmPackageId packageId,
+      byte[] json,
+      String createdBy,
+      String createdByIp,
+      Map<String, String> extraBlobAttributes,
+      NpmMinimumReleaseAge.ReleaseIndex releaseIndex) {
+    return writePackageRoot(runtime, storage, blobStoreId, packageId, json,
+        createdBy, createdByIp, extraBlobAttributes, Map.of(), true, releaseIndex);
   }
 
   public Stored writePackageRoot(
@@ -115,10 +148,26 @@ public class NpmAssetWriter {
       Map<String, String> extraBlobAttributes,
       Map<String, Object> extraAssetAttributes,
       boolean notifyGroupCaches) {
+    return writePackageRoot(runtime, storage, blobStoreId, packageId, json, createdBy,
+        createdByIp, extraBlobAttributes, extraAssetAttributes, notifyGroupCaches, null);
+  }
+
+  private Stored writePackageRoot(
+      RepositoryRuntime runtime,
+      BlobStorage storage,
+      long blobStoreId,
+      NpmPackageId packageId,
+      byte[] json,
+      String createdBy,
+      String createdByIp,
+      Map<String, String> extraBlobAttributes,
+      Map<String, Object> extraAssetAttributes,
+      boolean notifyGroupCaches,
+      NpmMinimumReleaseAge.ReleaseIndex releaseIndex) {
     return write(runtime, storage, blobStoreId, packageId.id(), packageId, null,
         new ByteArrayInputStream(json), NpmResponseSupport.JSON, PACKAGE_ROOT,
         createdBy, createdByIp, extraBlobAttributes, extraAssetAttributes,
-        false, notifyGroupCaches, true);
+        false, notifyGroupCaches, true, releaseIndex);
   }
 
   public Stored writePackageRootCache(
@@ -136,7 +185,7 @@ public class NpmAssetWriter {
     return write(runtime, storage, blobStoreId, variant.cachePath(packageId), packageId, null,
         new ByteArrayInputStream(json), NpmResponseSupport.JSON, variant.assetKind(),
         createdBy, createdByIp, extraBlobAttributes, extraAssetAttributes,
-        false, notifyGroupCaches, variant == NpmPackumentVariant.FULL);
+        false, notifyGroupCaches, variant == NpmPackumentVariant.FULL, null);
   }
 
   public Stored writeTarball(
@@ -217,13 +266,36 @@ public class NpmAssetWriter {
       boolean keepResponseFile,
       boolean notifyGroupCaches,
       boolean indexBrowseNode) {
+    return write(runtime, storage, blobStoreId, path, packageId, version, body, contentType,
+        kind, createdBy, createdByIp, extraBlobAttributes, extraAssetAttributes,
+        keepResponseFile, notifyGroupCaches, indexBrowseNode, null);
+  }
+
+  private Stored write(
+      RepositoryRuntime runtime,
+      BlobStorage storage,
+      long blobStoreId,
+      String path,
+      NpmPackageId packageId,
+      String version,
+      InputStream body,
+      String contentType,
+      String kind,
+      String createdBy,
+      String createdByIp,
+      Map<String, String> extraBlobAttributes,
+      Map<String, Object> extraAssetAttributes,
+      boolean keepResponseFile,
+      boolean notifyGroupCaches,
+      boolean indexBrowseNode,
+      NpmMinimumReleaseAge.ReleaseIndex releaseIndex) {
     DigestedUpload upload = uploadWithDigests(runtime, storage, blobStoreId, path, body, extraBlobAttributes);
     try {
       Stored stored = executePersist(
           "Persist npm asset " + runtime.name() + "/" + path,
           () -> persist(runtime, blobStoreId, path, packageId, version, contentType, kind,
               createdBy, createdByIp, extraBlobAttributes, extraAssetAttributes, notifyGroupCaches,
-              upload, keepResponseFile ? upload.tempFile() : null, indexBrowseNode));
+              upload, keepResponseFile ? upload.tempFile() : null, indexBrowseNode, releaseIndex));
       cleanupUnusedUploadedBlob(storage, blobStoreId, upload, stored.blob());
       if (!keepResponseFile) {
         TempBlobFiles.deleteQuietly(upload.tempFile());
@@ -258,7 +330,8 @@ public class NpmAssetWriter {
       boolean notifyGroupCaches,
       DigestedUpload upload,
       Path responseFile,
-      boolean indexBrowseNode) {
+      boolean indexBrowseNode,
+      NpmMinimumReleaseAge.ReleaseIndex releaseIndex) {
     Instant now = Instant.now();
     BlobReference ref = upload.reference();
     Digests digests = upload.digests();
@@ -360,6 +433,20 @@ public class NpmAssetWriter {
     }
     if (indexBrowseNode) {
       browseNodeDao.upsertPathAncestors(runtime.id(), path, persistedAsset.id(), componentId);
+    }
+    if (releaseIndex != null && releaseIndexDao != null && PACKAGE_ROOT.equals(kind)) {
+      boolean indexed = releaseIndexDao.replaceIfCurrent(
+          persistedAsset.id(),
+          blobId,
+          releaseIndex.releases().stream()
+              .allMatch(release -> release.invalidReason() == null),
+          toReleaseRows(releaseIndex),
+          now);
+      if (!indexed) {
+        throw new IllegalStateException(
+            "npm release index revision no longer matches package root "
+                + runtime.name() + "/" + path);
+      }
     }
     assetMetadataCache.evictAfterCommit(runtime.id(), path);
     if (notifyGroupCaches && packumentCache != null) {
@@ -566,6 +653,21 @@ public class NpmAssetWriter {
     String path = asset.path();
     int tarballSegment = path == null ? -1 : path.indexOf("/-/");
     return tarballSegment <= 0 ? null : path.substring(0, tarballSegment);
+  }
+
+  private static java.util.List<NpmReleaseIndexDao.Release> toReleaseRows(
+      NpmMinimumReleaseAge.ReleaseIndex releaseIndex) {
+    java.util.List<NpmReleaseIndexDao.Release> rows = new java.util.ArrayList<>();
+    int ordinal = 0;
+    for (NpmMinimumReleaseAge.IndexedRelease release : releaseIndex.releases()) {
+      rows.add(new NpmReleaseIndexDao.Release(
+          ordinal++,
+          release.version(),
+          release.publishedAt(),
+          release.invalidReason(),
+          release.tarballName()));
+    }
+    return java.util.List.copyOf(rows);
   }
 
 }

--- a/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmExceptions.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmExceptions.java
@@ -26,6 +26,12 @@ public final class NpmExceptions {
     }
   }
 
+  public static class ReleaseAgeDenied extends RuntimeException {
+    public ReleaseAgeDenied(String message) {
+      super(message);
+    }
+  }
+
   public static class BadUpstreamException extends RuntimeException {
     public BadUpstreamException(String message) {
       super(message);

--- a/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmGroupPackumentCache.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmGroupPackumentCache.java
@@ -41,6 +41,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 public class NpmGroupPackumentCache {
   private static final Logger log = LoggerFactory.getLogger(NpmGroupPackumentCache.class);
   private static final String VARIANT_ATTRIBUTE = "packumentVariant";
+  private static final String POLICY_VALID_UNTIL_ATTRIBUTE = "minimumReleaseAgeValidUntil";
   private static final Object PENDING_MEMBERS_KEY =
       NpmGroupPackumentCache.class.getName() + ".PENDING_MEMBERS";
   private static final Object PENDING_MEMBER_PACKAGES_KEY =
@@ -99,6 +100,11 @@ public class NpmGroupPackumentCache {
     if (!variant.assetKind().equals(snapshot.kind())) {
       return Optional.empty();
     }
+    Instant policyValidUntil = instantAttribute(
+        snapshot.attributes(), POLICY_VALID_UNTIL_ATTRIBUTE);
+    if (policyValidUntil != null && !now.isBefore(policyValidUntil)) {
+      return Optional.empty();
+    }
     NexusLikeCacheInfo cacheInfo = NexusLikeCacheInfo.fromAttributes(snapshot.attributes()).orElse(null);
     if (cacheController.isStale(
         group.id(),
@@ -119,14 +125,46 @@ public class NpmGroupPackumentCache {
       RepositoryRuntime group,
       Instant now,
       NpmPackumentVariant variant) {
+    return freshAttributes(group, now, variant, null);
+  }
+
+  public Map<String, Object> freshAttributes(
+      RepositoryRuntime group,
+      Instant now,
+      NpmPackumentVariant variant,
+      Instant minimumReleaseAgeValidUntil) {
     if (!enabled) {
       return Map.of();
     }
     Map<String, Object> base = new LinkedHashMap<>();
     base.put(VARIANT_ATTRIBUTE, variant.name());
+    if (minimumReleaseAgeValidUntil != null) {
+      base.put(POLICY_VALID_UNTIL_ATTRIBUTE, minimumReleaseAgeValidUntil.toString());
+    }
     return NexusLikeCacheInfo.applyToAttributes(
         base,
         cacheController.current(group.id(), NexusCacheType.METADATA, now));
+  }
+
+  public Instant minimumReleaseAgeValidUntil(CachedAssetMetadata metadata) {
+    return metadata == null
+        ? null
+        : instantAttribute(metadata.attributes(), POLICY_VALID_UNTIL_ATTRIBUTE);
+  }
+
+  private static Instant instantAttribute(Map<String, Object> attributes, String name) {
+    if (attributes == null) {
+      return null;
+    }
+    Object value = attributes.get(name);
+    if (value == null || value.toString().isBlank()) {
+      return null;
+    }
+    try {
+      return Instant.parse(value.toString());
+    } catch (RuntimeException ignored) {
+      return null;
+    }
   }
 
   /**

--- a/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmGroupService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmGroupService.java
@@ -86,7 +86,8 @@ public class NpmGroupService {
       NpmPackumentVariant variant) {
     PackageRootContent content = getOrBuildPackageRoot(group, packageId, repositoryBaseUrl, variant, Instant.now());
     return packageRootResponse(
-        packageId, repositoryBaseUrl, content.packageRoot(), content.lastModified(), headOnly, variant);
+        packageId, repositoryBaseUrl, content.packageRoot(), content.lastModified(), headOnly,
+        variant, content.minimumReleaseAgeValidUntil());
   }
 
   private PackageRootContent getOrBuildPackageRoot(
@@ -95,9 +96,6 @@ public class NpmGroupService {
       String repositoryBaseUrl,
       NpmPackumentVariant variant,
       Instant now) {
-    if (variant == NpmPackumentVariant.FULL) {
-      return getOrBuildFullPackageRoot(group, packageId, repositoryBaseUrl, now);
-    }
     if (packumentCache != null) {
       Optional<CachedAssetMetadata> cached = packumentCache.findFresh(group, packageId, variant, now);
       if (cached.isPresent()) {
@@ -108,42 +106,21 @@ public class NpmGroupService {
       }
     }
 
-    PackageRootContent full = getOrBuildFullPackageRoot(group, packageId, repositoryBaseUrl, now);
-    Map<String, Object> abbreviated = NpmMetadata.abbreviatePackageRoot(full.packageRoot());
+    MergedPackageRoot merged = mergePackageRoot(
+        group,
+        packageId,
+        repositoryBaseUrl,
+        containsMinimumReleaseAgeProxy(group),
+        variant);
     Instant lastModified = now;
     if (packumentCache != null && packumentCache.enabled()) {
       NpmAssetWriter.Stored stored = storePackageRoot(
-          group, packageId, variant, NpmResponseSupport.write(mapper, abbreviated), now);
+          group, packageId, variant, merged.bytes(), now,
+          merged.minimumReleaseAgeValidUntil());
       lastModified = stored.asset().lastUpdatedAt();
     }
-    return new PackageRootContent(abbreviated, lastModified);
-  }
-
-  private PackageRootContent getOrBuildFullPackageRoot(
-      RepositoryRuntime group,
-      NpmPackageId packageId,
-      String repositoryBaseUrl,
-      Instant now) {
-    if (packumentCache != null) {
-      Optional<CachedAssetMetadata> cached = packumentCache.findFresh(
-          group, packageId, NpmPackumentVariant.FULL, now);
-      if (cached.isPresent()) {
-        Optional<PackageRootContent> loaded = loadCachedPackageRoot(
-            group, packageId, NpmPackumentVariant.FULL, cached.get());
-        if (loaded.isPresent()) {
-          return loaded.get();
-        }
-      }
-    }
-
-    MergedPackageRoot merged = mergePackageRoot(group, packageId, repositoryBaseUrl);
-    Instant lastModified = now;
-    if (packumentCache != null && packumentCache.enabled()) {
-      NpmAssetWriter.Stored stored = storePackageRoot(
-          group, packageId, NpmPackumentVariant.FULL, merged.bytes(), now);
-      lastModified = stored.asset().lastUpdatedAt();
-    }
-    return new PackageRootContent(merged.packageRoot(), lastModified);
+    return new PackageRootContent(
+        merged.packageRoot(), lastModified, merged.minimumReleaseAgeValidUntil());
   }
 
   private Optional<PackageRootContent> loadCachedPackageRoot(
@@ -161,7 +138,10 @@ public class NpmGroupService {
       if (in == null) {
         return Optional.empty();
       }
-      return Optional.of(new PackageRootContent(mapper.readValue(in, MAP_TYPE), cached.lastUpdatedAt()));
+      return Optional.of(new PackageRootContent(
+          mapper.readValue(in, MAP_TYPE),
+          cached.lastUpdatedAt(),
+          packumentCache.minimumReleaseAgeValidUntil(cached)));
     } catch (IOException e) {
       throw new IllegalStateException(
           "Failed reading cached npm group package root "
@@ -174,7 +154,8 @@ public class NpmGroupService {
       NpmPackageId packageId,
       NpmPackumentVariant variant,
       byte[] bytes,
-      Instant now) {
+      Instant now,
+      Instant minimumReleaseAgeValidUntil) {
     long blobStoreId = requireBlobStore(group);
     BlobStorage storage = blobStorageRegistry.forBlobStoreId(blobStoreId);
     return writer.writePackageRootCache(
@@ -187,23 +168,38 @@ public class NpmGroupService {
         "group",
         group.name(),
         Map.of(),
-        packumentCache.freshAttributes(group, now, variant),
+        packumentCache.freshAttributes(group, now, variant, minimumReleaseAgeValidUntil),
         variant == NpmPackumentVariant.FULL);
   }
 
   private MergedPackageRoot mergePackageRoot(
       RepositoryRuntime group,
       NpmPackageId packageId,
-      String repositoryBaseUrl) {
+      String repositoryBaseUrl,
+      boolean policyAware,
+      NpmPackumentVariant variant) {
     List<Map<String, Object>> roots = new ArrayList<>();
+    Instant minimumReleaseAgeValidUntil = null;
     for (RepositoryRuntime member : group.members()) {
       try {
         MavenResponse response = dispatch(member,
             new NpmPath(NpmPath.Kind.PACKAGE_ROOT, packageId.id(), packageId, null, null, null, null),
-            repositoryBaseUrl, false);
+            repositoryBaseUrl, false, variant);
         try (InputStream body = response.body()) {
           if (body != null) {
             roots.add(mapper.readValue(body, MAP_TYPE));
+            if (policyAware) {
+              Object rawValidUntil = response.internalAttribute(
+                  NpmProxyService.POLICY_VALID_UNTIL_CONTEXT);
+              Instant memberValidUntil = rawValidUntil instanceof Instant instant
+                  ? instant
+                  : null;
+              if (memberValidUntil != null
+                  && (minimumReleaseAgeValidUntil == null
+                      || memberValidUntil.isBefore(minimumReleaseAgeValidUntil))) {
+                minimumReleaseAgeValidUntil = memberValidUntil;
+              }
+            }
           }
         }
       } catch (NpmExceptions.NpmNotFoundException | NpmExceptions.BadUpstreamException
@@ -217,7 +213,8 @@ public class NpmGroupService {
       throw new NpmExceptions.NpmNotFoundException("Package '" + packageId.id() + "' not found");
     }
     Map<String, Object> merged = roots.size() == 1 ? roots.get(0) : NpmMetadata.merge(roots);
-    return new MergedPackageRoot(merged, NpmResponseSupport.write(mapper, merged));
+    return new MergedPackageRoot(
+        merged, NpmResponseSupport.write(mapper, merged), minimumReleaseAgeValidUntil);
   }
 
   private MavenResponse packageRootResponse(
@@ -226,22 +223,21 @@ public class NpmGroupService {
       Map<String, Object> packageRoot,
       Instant lastModified,
       boolean headOnly,
-      NpmPackumentVariant variant) {
-    Map<String, Object> copy = NpmMetadata.deepCopy(packageRoot);
-    NpmMetadata.rewriteTarballUrls(copy, packageId, repositoryBaseUrl);
-    if (variant.abbreviated()) {
-      copy = NpmMetadata.abbreviatePackageRoot(copy);
-    }
-    byte[] bytes = NpmResponseSupport.write(mapper, copy);
-    if (headOnly) {
-      return MavenResponse.noBody(200, bytes.length, NpmResponseSupport.JSON, null, lastModified);
-    }
-    return MavenResponse.ok(new ByteArrayInputStream(bytes), bytes.length,
-        NpmResponseSupport.JSON, null, lastModified);
+      NpmPackumentVariant variant,
+      Instant minimumReleaseAgeValidUntil) {
+    byte[] bytes = NpmPackumentResponseWriter.write(
+        mapper, packageRoot, null, null, variant, packageId, repositoryBaseUrl);
+    MavenResponse response = headOnly
+        ? MavenResponse.noBody(200, bytes.length, NpmResponseSupport.JSON, null, lastModified)
+        : MavenResponse.ok(new ByteArrayInputStream(bytes), bytes.length,
+            NpmResponseSupport.JSON, null, lastModified);
+    return response.withInternalAttribute(
+        NpmProxyService.POLICY_VALID_UNTIL_CONTEXT, minimumReleaseAgeValidUntil);
   }
 
   private MavenResponse getMergedDistTags(RepositoryRuntime group, NpmPackageId packageId, boolean headOnly) {
-    PackageRootContent packageRoot = getOrBuildFullPackageRoot(group, packageId, group.name(), Instant.now());
+    PackageRootContent packageRoot = getOrBuildPackageRoot(
+        group, packageId, group.name(), NpmPackumentVariant.FULL, Instant.now());
     byte[] bytes = NpmResponseSupport.write(mapper, NpmMetadata.distTags(packageRoot.packageRoot()));
     if (headOnly) {
       return MavenResponse.noBody(200, bytes.length, NpmResponseSupport.JSON, null, packageRoot.lastModified());
@@ -255,6 +251,7 @@ public class NpmGroupService {
       NpmPath path,
       String repositoryBaseUrl,
       boolean headOnly) {
+    NpmExceptions.ReleaseAgeDenied releaseAgeDenied = null;
     NexusCacheType cacheType = NexusCacheType.CONTENT;
     String cachePath = groupMemberCachePath(path);
     Optional<Long> cachedMemberId = groupMemberAssetCache == null
@@ -268,6 +265,9 @@ public class NpmGroupService {
       if (cachedMember != null) {
         try {
           return dispatch(cachedMember, path, repositoryBaseUrl, headOnly);
+        } catch (NpmExceptions.ReleaseAgeDenied denied) {
+          releaseAgeDenied = denied;
+          groupMemberAssetCache.evict(group, cachePath, cacheType);
         } catch (NpmExceptions.NpmNotFoundException | NpmExceptions.BadUpstreamException
             | NpmExceptions.MethodNotAllowed ignored) {
           groupMemberAssetCache.evict(group, cachePath, cacheType);
@@ -281,13 +281,35 @@ public class NpmGroupService {
           groupMemberAssetCache.put(group, cachePath, cacheType, member.id());
         }
         return response;
+      } catch (NpmExceptions.ReleaseAgeDenied denied) {
+        if (releaseAgeDenied == null) {
+          releaseAgeDenied = denied;
+        }
       } catch (NpmExceptions.NpmNotFoundException ignored) {
       } catch (NpmExceptions.BadUpstreamException e) {
         // Nexus group repositories only return successful member responses; keep probing.
       } catch (NpmExceptions.MethodNotAllowed ignored) {
       }
     }
+    if (releaseAgeDenied != null) {
+      throw releaseAgeDenied;
+    }
     throw new NpmExceptions.NpmNotFoundException(path.rawPath());
+  }
+
+  private static boolean containsMinimumReleaseAgeProxy(RepositoryRuntime runtime) {
+    if (runtime == null) {
+      return false;
+    }
+    if (runtime.minimumReleaseAgeEnabled()) {
+      return true;
+    }
+    for (RepositoryRuntime member : runtime.members()) {
+      if (containsMinimumReleaseAgeProxy(member)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private static String groupMemberCachePath(NpmPath path) {
@@ -302,10 +324,25 @@ public class NpmGroupService {
       NpmPath path,
       String repositoryBaseUrl,
       boolean headOnly) {
+    return dispatch(member, path, repositoryBaseUrl, headOnly, NpmPackumentVariant.FULL);
+  }
+
+  private MavenResponse dispatch(
+      RepositoryRuntime member,
+      NpmPath path,
+      String repositoryBaseUrl,
+      boolean headOnly,
+      NpmPackumentVariant variant) {
     return switch (member.type()) {
-      case HOSTED -> hosted.get(member, path, repositoryBaseUrl, headOnly);
-      case PROXY -> proxy.get(member, path, repositoryBaseUrl, headOnly);
-      case GROUP -> get(member, path, repositoryBaseUrl, headOnly);
+      case HOSTED -> variant == NpmPackumentVariant.FULL
+          ? hosted.get(member, path, repositoryBaseUrl, headOnly)
+          : hosted.get(member, path, repositoryBaseUrl, headOnly, variant);
+      case PROXY -> variant == NpmPackumentVariant.FULL
+          ? proxy.get(member, path, repositoryBaseUrl, headOnly)
+          : proxy.get(member, path, repositoryBaseUrl, headOnly, variant);
+      case GROUP -> variant == NpmPackumentVariant.FULL
+          ? get(member, path, repositoryBaseUrl, headOnly)
+          : get(member, path, repositoryBaseUrl, headOnly, variant);
     };
   }
 
@@ -316,7 +353,15 @@ public class NpmGroupService {
     return runtime.blobStoreId();
   }
 
-  private record MergedPackageRoot(Map<String, Object> packageRoot, byte[] bytes) {}
+  private record MergedPackageRoot(
+      Map<String, Object> packageRoot,
+      byte[] bytes,
+      Instant minimumReleaseAgeValidUntil) {
+  }
 
-  private record PackageRootContent(Map<String, Object> packageRoot, Instant lastModified) {}
+  private record PackageRootContent(
+      Map<String, Object> packageRoot,
+      Instant lastModified,
+      Instant minimumReleaseAgeValidUntil) {
+  }
 }

--- a/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmHostedService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmHostedService.java
@@ -271,6 +271,24 @@ public class NpmHostedService {
     return loadPackageRootMap(runtime, packageId);
   }
 
+  /** Reads a package root from an already resolved hot-path metadata snapshot without more SQL. */
+  Optional<Map<String, Object>> packageRoot(CachedAssetMetadata metadata) {
+    if (metadata == null || metadata.blob() == null) {
+      return Optional.empty();
+    }
+    AssetBlobRecord blob = metadata.toBlobRecord();
+    BlobStorage storage = blobStorageRegistry.forBlobStoreId(blob.blobStoreId());
+    try (InputStream in = storage.get(BlobReferenceCodec.reference(
+        blob.blobRef(), blob.objectKey(), blob.sha256(), blob.size())).orElse(null)) {
+      if (in == null) {
+        return Optional.empty();
+      }
+      return Optional.of(mapper.readValue(in, MAP_TYPE));
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to read npm package root " + metadata.path(), e);
+    }
+  }
+
   MavenResponse getPackage(RepositoryRuntime runtime, NpmPackageId packageId, String repositoryBaseUrl, boolean headOnly) {
     return getPackage(runtime, packageId, repositoryBaseUrl, headOnly, NpmPackumentVariant.FULL);
   }
@@ -283,12 +301,8 @@ public class NpmHostedService {
       NpmPackumentVariant variant) {
     Map<String, Object> packageRoot = loadPackageRootMap(runtime, packageId)
         .orElseThrow(() -> new NpmExceptions.NpmNotFoundException("Package '" + packageId.id() + "' not found"));
-    Map<String, Object> copy = NpmMetadata.deepCopy(packageRoot);
-    NpmMetadata.rewriteTarballUrls(copy, packageId, repositoryBaseUrl);
-    if (variant.abbreviated()) {
-      copy = NpmMetadata.abbreviatePackageRoot(copy);
-    }
-    byte[] bytes = NpmResponseSupport.write(mapper, copy);
+    byte[] bytes = NpmPackumentResponseWriter.write(
+        mapper, packageRoot, null, null, variant, packageId, repositoryBaseUrl);
     AssetRecord asset = assetDao.findAssetByPath(runtime.id(), packageId.id()).orElse(null);
     Instant lastModified = asset == null ? Instant.now() : asset.lastUpdatedAt();
     if (headOnly) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmPackumentResponseWriter.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmPackumentResponseWriter.java
@@ -1,0 +1,166 @@
+package com.github.klboke.kkrepo.server.npm;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.util.ByteArrayBuilder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.klboke.kkrepo.protocol.npm.NpmMetadata;
+import com.github.klboke.kkrepo.protocol.npm.NpmMinimumReleaseAge;
+import com.github.klboke.kkrepo.protocol.npm.NpmPackageId;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Writes a filtered npm packument without allocating a second full object tree. */
+final class NpmPackumentResponseWriter {
+  private NpmPackumentResponseWriter() {
+  }
+
+  static byte[] write(
+      ObjectMapper mapper,
+      Map<String, Object> packageRoot,
+      NpmMinimumReleaseAge.Analysis analysis,
+      Instant evaluatedAt,
+      NpmPackumentVariant variant,
+      NpmPackageId packageId,
+      String repositoryBaseUrl) {
+    Map<String, Object> versions = NpmMetadata.versions(packageRoot);
+    List<String> visibleVersions = analysis == null
+        ? List.copyOf(versions.keySet())
+        : analysis.visibleVersions(evaluatedAt);
+    Map<String, Object> distTags = analysis == null
+        ? new LinkedHashMap<>(NpmMetadata.distTags(packageRoot))
+        : analysis.filteredDistTags(packageRoot, evaluatedAt, visibleVersions);
+
+    try (ByteArrayBuilder output = new ByteArrayBuilder();
+         JsonGenerator generator = mapper.getFactory().createGenerator(output)) {
+      generator.writeStartObject();
+      for (Map.Entry<String, Object> field : packageRoot.entrySet()) {
+        if (variant.abbreviated() && !NpmMetadata.isAbbreviatedRootField(field.getKey())) {
+          continue;
+        }
+        generator.writeFieldName(field.getKey());
+        if (NpmMetadata.VERSIONS.equals(field.getKey())) {
+          writeVersions(
+              mapper, generator, versions, visibleVersions, variant, packageId, repositoryBaseUrl);
+        } else if (NpmMetadata.DIST_TAGS.equals(field.getKey())) {
+          mapper.writeValue(generator, distTags);
+        } else {
+          mapper.writeValue(generator, field.getValue());
+        }
+      }
+      generator.writeEndObject();
+      generator.flush();
+      return output.toByteArray();
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to serialize npm packument", e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void writeVersions(
+      ObjectMapper mapper,
+      JsonGenerator generator,
+      Map<String, Object> versions,
+      List<String> visibleVersions,
+      NpmPackumentVariant variant,
+      NpmPackageId packageId,
+      String repositoryBaseUrl) throws IOException {
+    generator.writeStartObject();
+    for (String version : visibleVersions) {
+      if (!versions.containsKey(version)) {
+        continue;
+      }
+      generator.writeFieldName(version);
+      Object rawVersion = versions.get(version);
+      if (!(rawVersion instanceof Map<?, ?> versionMap)) {
+        mapper.writeValue(generator, rawVersion);
+        continue;
+      }
+      writeVersion(
+          mapper,
+          generator,
+          (Map<String, Object>) versionMap,
+          variant,
+          packageId,
+          repositoryBaseUrl);
+    }
+    generator.writeEndObject();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void writeVersion(
+      ObjectMapper mapper,
+      JsonGenerator generator,
+      Map<String, Object> version,
+      NpmPackumentVariant variant,
+      NpmPackageId packageId,
+      String repositoryBaseUrl) throws IOException {
+    generator.writeStartObject();
+    boolean hasInstallScriptField = false;
+    for (Map.Entry<String, Object> field : version.entrySet()) {
+      if (variant.abbreviated() && !NpmMetadata.isAbbreviatedVersionField(field.getKey())) {
+        continue;
+      }
+      hasInstallScriptField |= "hasInstallScript".equals(field.getKey());
+      generator.writeFieldName(field.getKey());
+      if (NpmMetadata.DIST.equals(field.getKey()) && field.getValue() instanceof Map<?, ?> dist) {
+        writeDist(
+            mapper,
+            generator,
+            (Map<String, Object>) dist,
+            packageId,
+            repositoryBaseUrl);
+      } else {
+        mapper.writeValue(generator, field.getValue());
+      }
+    }
+    if (variant.abbreviated() && !hasInstallScriptField
+        && NpmMetadata.hasInstallScript(version.get("scripts"))) {
+      generator.writeBooleanField("hasInstallScript", true);
+    }
+    generator.writeEndObject();
+  }
+
+  private static void writeDist(
+      ObjectMapper mapper,
+      JsonGenerator generator,
+      Map<String, Object> dist,
+      NpmPackageId packageId,
+      String repositoryBaseUrl) throws IOException {
+    generator.writeStartObject();
+    for (Map.Entry<String, Object> field : dist.entrySet()) {
+      generator.writeFieldName(field.getKey());
+      if (NpmMetadata.TARBALL.equals(field.getKey())) {
+        String rewritten = rewrittenTarballUrl(
+            field.getValue(), packageId, repositoryBaseUrl);
+        if (rewritten == null) {
+          mapper.writeValue(generator, field.getValue());
+        } else {
+          generator.writeString(rewritten);
+        }
+      } else {
+        mapper.writeValue(generator, field.getValue());
+      }
+    }
+    generator.writeEndObject();
+  }
+
+  private static String rewrittenTarballUrl(
+      Object rawTarball,
+      NpmPackageId packageId,
+      String repositoryBaseUrl) {
+    if (rawTarball == null || repositoryBaseUrl == null || repositoryBaseUrl.isBlank()) {
+      return null;
+    }
+    String tarballName = NpmMetadata.extractTarballName(rawTarball.toString());
+    if (tarballName == null || tarballName.isBlank()) {
+      return null;
+    }
+    String base = repositoryBaseUrl.endsWith("/")
+        ? repositoryBaseUrl.substring(0, repositoryBaseUrl.length() - 1)
+        : repositoryBaseUrl;
+    return base + "/" + packageId.tarballPath(tarballName);
+  }
+}

--- a/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmPackumentResponseWriter.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmPackumentResponseWriter.java
@@ -32,6 +32,9 @@ final class NpmPackumentResponseWriter {
     Map<String, Object> distTags = analysis == null
         ? new LinkedHashMap<>(NpmMetadata.distTags(packageRoot))
         : analysis.filteredDistTags(packageRoot, evaluatedAt, visibleVersions);
+    Map<String, Object> time = analysis == null
+        ? null
+        : analysis.filteredTime(packageRoot, visibleVersions);
 
     try (ByteArrayBuilder output = new ByteArrayBuilder();
          JsonGenerator generator = mapper.getFactory().createGenerator(output)) {
@@ -46,6 +49,8 @@ final class NpmPackumentResponseWriter {
               mapper, generator, versions, visibleVersions, variant, packageId, repositoryBaseUrl);
         } else if (NpmMetadata.DIST_TAGS.equals(field.getKey())) {
           mapper.writeValue(generator, distTags);
+        } else if (NpmMetadata.TIME.equals(field.getKey()) && time != null) {
+          mapper.writeValue(generator, time);
         } else {
           mapper.writeValue(generator, field.getValue());
         }

--- a/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmProxyService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmProxyService.java
@@ -475,24 +475,53 @@ public class NpmProxyService {
     }
     PolicyPackage resolved = resolvePolicyPackage(runtime, packageId, now);
     List<String> versions = resolved.analysis().versionsForTarball(tarballName);
+    enforceTarballVersions(
+        packageId,
+        tarballName,
+        resolved.analysis(),
+        resolved.evaluatedAt(),
+        versions);
+  }
+
+  private void enforceTarballVersions(
+      NpmPackageId packageId,
+      String tarballName,
+      NpmMinimumReleaseAge.Analysis analysis,
+      Instant evaluatedAt,
+      List<String> versions) {
     if (versions.isEmpty()) {
       throw new NpmExceptions.ReleaseAgeDenied(
           "Tarball '" + tarballName + "' is blocked by minimumReleaseAge because its version "
               + "cannot be verified from upstream package metadata");
     }
+    String blockedVersion = null;
+    NpmMinimumReleaseAge.Eligibility blocked = null;
     for (String version : versions) {
-      NpmMinimumReleaseAge.Eligibility eligibility = resolved.analysis().eligibility(
-          version, resolved.evaluatedAt());
+      NpmMinimumReleaseAge.Eligibility eligibility = analysis.eligibility(version, evaluatedAt);
       if (eligibility.eligible()) {
-        continue;
+        // The local tarball URL is exposed by this visible version. Other hidden versions may
+        // legally reuse the same filename, so they must not make the shared URL unavailable.
+        return;
       }
-      String available = eligibility.availableAt() == null
-          ? "unknown (missing or invalid publish time)"
-          : eligibility.availableAt().toString();
-      throw new NpmExceptions.ReleaseAgeDenied(
-          "Tarball '" + tarballName + "' for " + packageId.id() + "@" + version
-              + " is blocked by minimumReleaseAge until " + available);
+      if (blocked == null || earlierAvailability(eligibility, blocked)) {
+        blockedVersion = version;
+        blocked = eligibility;
+      }
     }
+    String available = blocked == null || blocked.availableAt() == null
+        ? "unknown (missing or invalid publish time)"
+        : blocked.availableAt().toString();
+    throw new NpmExceptions.ReleaseAgeDenied(
+        "Tarball '" + tarballName + "' for " + packageId.id() + "@" + blockedVersion
+            + " is blocked by minimumReleaseAge until " + available);
+  }
+
+  private static boolean earlierAvailability(
+      NpmMinimumReleaseAge.Eligibility candidate,
+      NpmMinimumReleaseAge.Eligibility current) {
+    return candidate.availableAt() != null
+        && (current.availableAt() == null
+            || candidate.availableAt().isBefore(current.availableAt()));
   }
 
   private boolean tryEnforceIndexedTarballReleaseAge(
@@ -578,19 +607,12 @@ public class NpmProxyService {
     }
     NpmMinimumReleaseAge.Analysis analysis = NpmMinimumReleaseAge.analyze(
         toReleaseIndex(rows), runtime.minimumReleaseAgeMinutesOrDefault());
-    for (NpmReleaseIndexDao.Release row : rows) {
-      NpmMinimumReleaseAge.Eligibility eligibility = analysis.eligibility(
-          row.version(), evaluatedAt);
-      if (eligibility.eligible()) {
-        continue;
-      }
-      String available = eligibility.availableAt() == null
-          ? "unknown (missing or invalid publish time)"
-          : eligibility.availableAt().toString();
-      throw new NpmExceptions.ReleaseAgeDenied(
-          "Tarball '" + tarballName + "' for " + packageId.id() + "@" + row.version()
-              + " is blocked by minimumReleaseAge until " + available);
-    }
+    enforceTarballVersions(
+        packageId,
+        tarballName,
+        analysis,
+        evaluatedAt,
+        rows.stream().map(NpmReleaseIndexDao.Release::version).toList());
   }
 
   Optional<Instant> nextPolicyTransition(

--- a/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmProxyService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmProxyService.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.klboke.kkrepo.core.BlobStorage;
 import com.github.klboke.kkrepo.persistence.jdbc.api.AssetDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.NpmReleaseIndexDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.ProxyStateDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.AssetRecord;
+import com.github.klboke.kkrepo.protocol.npm.NpmMinimumReleaseAge;
 import com.github.klboke.kkrepo.protocol.npm.NpmMetadata;
 import com.github.klboke.kkrepo.protocol.npm.NpmPackageId;
 import com.github.klboke.kkrepo.protocol.npm.NpmPath;
@@ -23,20 +25,29 @@ import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import com.github.klboke.kkrepo.server.maven.UpstreamBodyReadException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.DateTimeException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class NpmProxyService {
   private static final long[] BACKOFF_SECONDS = {30, 60, 120, 300, 600, 1800};
   private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+  private static final String FULL_METADATA_ATTRIBUTE = "npmFullMetadata";
+  private static final String COMPLETE_PUBLISH_TIMES_ATTRIBUTE = "npmCompletePublishTimes";
+  static final String POLICY_VALID_UNTIL_CONTEXT = "npm.minimumReleaseAgeValidUntil";
 
   private final AssetDao assetDao;
   private final BlobStorageRegistry blobStorageRegistry;
@@ -48,7 +59,11 @@ public class NpmProxyService {
   private final ProxyNegativeCache negativeCache;
   private final AssetMetadataCache assetMetadataCache;
   private final NexusLikeCacheController cacheController;
+  private final NpmReleaseAgeCache releaseAgeCache;
+  private final NpmReleaseIndexDao releaseIndexDao;
+  private final Clock clock;
 
+  @Autowired
   public NpmProxyService(
       AssetDao assetDao,
       BlobStorageRegistry blobStorageRegistry,
@@ -59,7 +74,80 @@ public class NpmProxyService {
       ObjectMapper mapper,
       ProxyNegativeCache negativeCache,
       AssetMetadataCache assetMetadataCache,
+      NexusLikeCacheController cacheController,
+      NpmReleaseAgeCache releaseAgeCache,
+      NpmReleaseIndexDao releaseIndexDao) {
+    this(assetDao, blobStorageRegistry, writer, proxyStateDao, fetcher, hosted, mapper,
+        negativeCache, assetMetadataCache, cacheController, releaseAgeCache, releaseIndexDao,
+        Clock.systemUTC());
+  }
+
+  /** Compatibility constructor for focused tests and subclasses that never enable the policy. */
+  NpmProxyService(
+      AssetDao assetDao,
+      BlobStorageRegistry blobStorageRegistry,
+      NpmAssetWriter writer,
+      ProxyStateDao proxyStateDao,
+      HttpRemoteFetcher fetcher,
+      NpmHostedService hosted,
+      ObjectMapper mapper,
+      ProxyNegativeCache negativeCache,
+      AssetMetadataCache assetMetadataCache,
       NexusLikeCacheController cacheController) {
+    this(assetDao, blobStorageRegistry, writer, proxyStateDao, fetcher, hosted, mapper,
+        negativeCache, assetMetadataCache, cacheController,
+        new NpmReleaseAgeCache(10000, 16L * 1024 * 1024, 30), null,
+        Clock.systemUTC());
+  }
+
+  NpmProxyService(
+      AssetDao assetDao,
+      BlobStorageRegistry blobStorageRegistry,
+      NpmAssetWriter writer,
+      ProxyStateDao proxyStateDao,
+      HttpRemoteFetcher fetcher,
+      NpmHostedService hosted,
+      ObjectMapper mapper,
+      ProxyNegativeCache negativeCache,
+      AssetMetadataCache assetMetadataCache,
+      NexusLikeCacheController cacheController,
+      Clock clock) {
+    this(assetDao, blobStorageRegistry, writer, proxyStateDao, fetcher, hosted, mapper,
+        negativeCache, assetMetadataCache, cacheController,
+        new NpmReleaseAgeCache(10000, 16L * 1024 * 1024, 30), null, clock);
+  }
+
+  NpmProxyService(
+      AssetDao assetDao,
+      BlobStorageRegistry blobStorageRegistry,
+      NpmAssetWriter writer,
+      ProxyStateDao proxyStateDao,
+      HttpRemoteFetcher fetcher,
+      NpmHostedService hosted,
+      ObjectMapper mapper,
+      ProxyNegativeCache negativeCache,
+      AssetMetadataCache assetMetadataCache,
+      NexusLikeCacheController cacheController,
+      NpmReleaseAgeCache releaseAgeCache,
+      Clock clock) {
+    this(assetDao, blobStorageRegistry, writer, proxyStateDao, fetcher, hosted, mapper,
+        negativeCache, assetMetadataCache, cacheController, releaseAgeCache, null, clock);
+  }
+
+  NpmProxyService(
+      AssetDao assetDao,
+      BlobStorageRegistry blobStorageRegistry,
+      NpmAssetWriter writer,
+      ProxyStateDao proxyStateDao,
+      HttpRemoteFetcher fetcher,
+      NpmHostedService hosted,
+      ObjectMapper mapper,
+      ProxyNegativeCache negativeCache,
+      AssetMetadataCache assetMetadataCache,
+      NexusLikeCacheController cacheController,
+      NpmReleaseAgeCache releaseAgeCache,
+      NpmReleaseIndexDao releaseIndexDao,
+      Clock clock) {
     this.assetDao = assetDao;
     this.blobStorageRegistry = blobStorageRegistry;
     this.writer = writer;
@@ -70,6 +158,11 @@ public class NpmProxyService {
     this.negativeCache = negativeCache;
     this.assetMetadataCache = assetMetadataCache;
     this.cacheController = cacheController;
+    this.releaseAgeCache = releaseAgeCache == null
+        ? new NpmReleaseAgeCache(10000, 16L * 1024 * 1024, 30)
+        : releaseAgeCache;
+    this.releaseIndexDao = releaseIndexDao;
+    this.clock = clock == null ? Clock.systemUTC() : clock;
   }
 
   public MavenResponse get(RepositoryRuntime runtime, NpmPath path, String repositoryBaseUrl, boolean headOnly) {
@@ -103,7 +196,7 @@ public class NpmProxyService {
         "-/v1/search",
         "text=" + URLEncoder.encode(text, StandardCharsets.UTF_8)
             + "&size=" + Math.max(1, limit));
-    Instant now = Instant.now();
+    Instant now = clock.instant();
     HttpRemoteFetcher.Request req = new HttpRemoteFetcher.Request(
         url, null, null, null, false)
         .withTimeoutProfile(HttpRemoteFetcher.TimeoutProfile.SEARCH)
@@ -138,9 +231,13 @@ public class NpmProxyService {
       String repositoryBaseUrl,
       boolean headOnly,
       NpmPackumentVariant variant) {
+    if (runtime.minimumReleaseAgeEnabled()) {
+      PolicyPackage resolved = resolvePolicyPackage(runtime, packageId, clock.instant());
+      return policyPackageResponse(runtime, packageId, repositoryBaseUrl, resolved, headOnly, variant);
+    }
     String path = packageId.id();
     Optional<CachedAssetMetadata> cached = lookupCached(runtime, path);
-    Instant now = Instant.now();
+    Instant now = clock.instant();
     if (cached.isPresent()
         && isFresh(runtime, cached.get(), runtime.metadataMaxAgeMinutesOrDefault(), now, NexusCacheType.METADATA)) {
       return hosted.getPackage(runtime, packageId, repositoryBaseUrl, headOnly, variant);
@@ -157,6 +254,26 @@ public class NpmProxyService {
   }
 
   public MavenResponse getDistTags(RepositoryRuntime runtime, NpmPackageId packageId, boolean headOnly) {
+    if (runtime.minimumReleaseAgeEnabled()) {
+      PolicyPackage resolved = resolvePolicyPackage(runtime, packageId, clock.instant());
+      byte[] bytes = releaseAgeCache.response(
+          resolved.metadata(),
+          runtime.minimumReleaseAgeMinutesOrDefault(),
+          resolved.analysis(),
+          resolved.evaluatedAt(),
+          "dist-tags",
+          "",
+          () -> NpmResponseSupport.write(
+              mapper,
+              resolved.analysis().filteredDistTags(
+                  resolved.root().get(), resolved.evaluatedAt())));
+      if (headOnly) {
+        return MavenResponse.noBody(
+            200, bytes.length, NpmResponseSupport.JSON, null, resolved.lastModified());
+      }
+      return MavenResponse.ok(new ByteArrayInputStream(bytes), bytes.length,
+          NpmResponseSupport.JSON, null, resolved.lastModified());
+    }
     getPackage(runtime, packageId, runtime.name(), true);
     return hosted.getDistTags(runtime, packageId, headOnly);
   }
@@ -166,9 +283,12 @@ public class NpmProxyService {
       NpmPackageId packageId,
       String tarballName,
       boolean headOnly) {
+    if (runtime.minimumReleaseAgeEnabled()) {
+      enforceTarballReleaseAge(runtime, packageId, tarballName, clock.instant());
+    }
     String path = packageId.tarballPath(tarballName);
     Optional<CachedAssetMetadata> cached = lookupCached(runtime, path);
-    Instant now = Instant.now();
+    Instant now = clock.instant();
     if (cached.isPresent()
         && isFresh(runtime, cached.get(), runtime.contentMaxAgeMinutesOrDefault(), now, NexusCacheType.CONTENT)) {
       return hosted.getTarball(runtime, packageId, tarballName, headOnly);
@@ -186,6 +306,412 @@ public class NpmProxyService {
       return tarballResponseFromStored(stored, headOnly);
     }
     return hosted.getTarball(runtime, packageId, tarballName, headOnly);
+  }
+
+  private PolicyPackage resolvePolicyPackage(
+      RepositoryRuntime runtime,
+      NpmPackageId packageId,
+      Instant now) {
+    String path = packageId.id();
+    Optional<CachedAssetMetadata> cached = lookupCached(runtime, path);
+    int minimumAge = runtime.minimumReleaseAgeMinutesOrDefault();
+    Instant lastVerifiedAt = cached.map(CachedAssetMetadata::lastUpdatedAt).orElse(null);
+    Instant cachedEvaluationTime = safeEvaluationTime(lastVerifiedAt, now);
+
+    PolicyPackage cachedPolicy = null;
+    if (cached.isPresent()
+        && isFresh(runtime, cached.get(), runtime.metadataMaxAgeMinutesOrDefault(), now,
+            NexusCacheType.METADATA)) {
+      cachedPolicy = cachedPolicy(cached.get(), minimumAge, cachedEvaluationTime);
+      boolean verifiedFull = isFullMetadataVerified(cached.get())
+          || cachedPolicy.analysis().hasCompletePublishTimes();
+      if (verifiedFull
+          && !cachedPolicy.analysis().crossedMaturityBoundary(lastVerifiedAt, now)) {
+        return cachedPolicy;
+      }
+    }
+
+    if (negativeCache.isNotFoundCached(runtime, path)) {
+      throw new NpmExceptions.NpmNotFoundException("Package '" + packageId.id() + "' not found");
+    }
+    if (proxyStateDao.isBlocked(runtime.id(), now)) {
+      if (cached.isPresent()) {
+        return cachedPolicy == null
+            ? cachedPolicy(cached.get(), minimumAge, cachedEvaluationTime)
+            : cachedPolicy;
+      }
+      throw new NpmExceptions.BadUpstreamException(
+          "Upstream temporarily blocked: " + runtime.proxyRemoteUrl());
+    }
+    return fetchPolicyPackage(runtime, packageId, cached, cachedPolicy, now);
+  }
+
+  private PolicyPackage fetchPolicyPackage(
+      RepositoryRuntime runtime,
+      NpmPackageId packageId,
+      Optional<CachedAssetMetadata> cached,
+      PolicyPackage alreadyLoadedPolicy,
+      Instant now) {
+    String url = buildRemoteUrl(runtime.proxyRemoteUrl(), remotePackagePath(packageId));
+    boolean requestFullMetadata = cached.isEmpty()
+        || !(isFullMetadataVerified(cached.get())
+            || (alreadyLoadedPolicy != null
+                && alreadyLoadedPolicy.analysis().hasCompletePublishTimes()));
+    Conditional conditional = requestFullMetadata
+        ? new Conditional(null, null)
+        : conditional(cached);
+    HttpRemoteFetcher.Request req = new HttpRemoteFetcher.Request(
+        url, conditional.etag(), conditional.lastModified(), null, false)
+        .withTimeoutProfile(HttpRemoteFetcher.TimeoutProfile.METADATA)
+        .withAccept("application/json")
+        .withRepository(runtime);
+    Instant priorVerification = cached.map(CachedAssetMetadata::lastUpdatedAt).orElse(null);
+    Instant priorEvaluationTime = safeEvaluationTime(priorVerification, now);
+    int minimumAge = runtime.minimumReleaseAgeMinutesOrDefault();
+    try {
+      return fetcher.fetchWithBodyRetry(req, packageId.id(), result -> {
+        int status = result.status();
+        if (status == 304 && cached.isPresent()) {
+          Map<String, Object> attributes = refreshedAttributes(
+              runtime, cached.get(), NexusCacheType.METADATA, now);
+          if (attributes == null) {
+            assetDao.touchAssetLastUpdated(cached.get().assetId(), now);
+          } else {
+            assetDao.touchAssetLastUpdatedAndAttributes(cached.get().assetId(), now, attributes);
+          }
+          assetMetadataCache.touchVerified(runtime.id(), packageId.id(), now, attributes);
+          proxyStateDao.recordSuccess(runtime.id(), now);
+          negativeCache.invalidate(runtime, packageId.id());
+          PolicyPackage policy = alreadyLoadedPolicy == null
+              ? cachedPolicy(cached.get(), minimumAge, priorEvaluationTime)
+              : alreadyLoadedPolicy;
+          CachedAssetMetadata refreshed = attributes == null
+              ? cached.get().withLastUpdatedAt(now)
+              : cached.get().withLastUpdatedAtAndAttributes(now, attributes);
+          return new PolicyPackage(
+              refreshed, policy.root(), policy.analysis(), now, now);
+        }
+        if (status >= 200 && status < 300) {
+          negativeCache.invalidate(runtime, packageId.id());
+          CachedPackage stored = persistPackage(runtime, packageId, result, now, minimumAge);
+          return new PolicyPackage(
+              stored.metadata(),
+              PackageRootHolder.loaded(stored.packageRoot()),
+              stored.analysis(),
+              stored.lastModified(),
+              now);
+        }
+        if (status == 404 || status == 410) {
+          proxyStateDao.recordSuccess(runtime.id(), now);
+          if (cached.isPresent()) {
+            return alreadyLoadedPolicy == null
+                ? cachedPolicy(cached.get(), minimumAge, priorEvaluationTime)
+                : alreadyLoadedPolicy;
+          }
+          if (status == 404) {
+            negativeCache.rememberNotFound(runtime, packageId.id());
+          }
+          throw new NpmExceptions.NpmNotFoundException(
+              "Package '" + packageId.id() + "' not found");
+        }
+        handleFailure(runtime, cached, "Upstream returned " + status, now);
+        if (cached.isPresent()) {
+          return alreadyLoadedPolicy == null
+              ? cachedPolicy(cached.get(), minimumAge, priorEvaluationTime)
+              : alreadyLoadedPolicy;
+        }
+        throw new NpmExceptions.BadUpstreamException("Upstream returned " + status);
+      });
+    } catch (IOException e) {
+      handleFailure(runtime, cached, "Upstream IO error: " + e.getMessage(), now);
+      if (cached.isPresent()) {
+        return alreadyLoadedPolicy == null
+            ? cachedPolicy(cached.get(), minimumAge, priorEvaluationTime)
+            : alreadyLoadedPolicy;
+      }
+      throw new NpmExceptions.BadUpstreamException("Upstream IO error: " + e.getMessage());
+    }
+  }
+
+  private MavenResponse policyPackageResponse(
+      RepositoryRuntime runtime,
+      NpmPackageId packageId,
+      String repositoryBaseUrl,
+      PolicyPackage resolved,
+      boolean headOnly,
+      NpmPackumentVariant variant) {
+    byte[] bytes = releaseAgeCache.response(
+        resolved.metadata(),
+        runtime.minimumReleaseAgeMinutesOrDefault(),
+        resolved.analysis(),
+        resolved.evaluatedAt(),
+        "package-" + variant.name(),
+        repositoryBaseUrl,
+        () -> NpmPackumentResponseWriter.write(
+            mapper,
+            resolved.root().get(),
+            resolved.analysis(),
+            resolved.evaluatedAt(),
+            variant,
+            packageId,
+            repositoryBaseUrl));
+    MavenResponse response = headOnly
+        ? MavenResponse.noBody(
+            200, bytes.length, NpmResponseSupport.JSON, null, resolved.lastModified())
+        : MavenResponse.ok(new ByteArrayInputStream(bytes), bytes.length,
+            NpmResponseSupport.JSON, null, resolved.lastModified());
+    return response.withInternalAttribute(
+        POLICY_VALID_UNTIL_CONTEXT,
+        resolved.analysis().nextMaturityAfter(resolved.evaluatedAt()).orElse(null));
+  }
+
+  private void enforceTarballReleaseAge(
+      RepositoryRuntime runtime,
+      NpmPackageId packageId,
+      String tarballName,
+      Instant now) {
+    if (tryEnforceIndexedTarballReleaseAge(runtime, packageId, tarballName, now)) {
+      return;
+    }
+    PolicyPackage resolved = resolvePolicyPackage(runtime, packageId, now);
+    List<String> versions = resolved.analysis().versionsForTarball(tarballName);
+    if (versions.isEmpty()) {
+      throw new NpmExceptions.ReleaseAgeDenied(
+          "Tarball '" + tarballName + "' is blocked by minimumReleaseAge because its version "
+              + "cannot be verified from upstream package metadata");
+    }
+    for (String version : versions) {
+      NpmMinimumReleaseAge.Eligibility eligibility = resolved.analysis().eligibility(
+          version, resolved.evaluatedAt());
+      if (eligibility.eligible()) {
+        continue;
+      }
+      String available = eligibility.availableAt() == null
+          ? "unknown (missing or invalid publish time)"
+          : eligibility.availableAt().toString();
+      throw new NpmExceptions.ReleaseAgeDenied(
+          "Tarball '" + tarballName + "' for " + packageId.id() + "@" + version
+              + " is blocked by minimumReleaseAge until " + available);
+    }
+  }
+
+  private boolean tryEnforceIndexedTarballReleaseAge(
+      RepositoryRuntime runtime,
+      NpmPackageId packageId,
+      String tarballName,
+      Instant now) {
+    if (releaseIndexDao == null) {
+      return false;
+    }
+    Optional<CachedAssetMetadata> cached = lookupCached(runtime, packageId.id());
+    if (cached.isEmpty() || cached.get().blob() == null
+        || !isFresh(runtime, cached.get(), runtime.metadataMaxAgeMinutesOrDefault(), now,
+            NexusCacheType.METADATA)) {
+      return false;
+    }
+
+    CachedAssetMetadata metadata = cached.get();
+    Instant publishedAfterExclusive = null;
+    Instant publishedAtOrBefore = null;
+    if (metadata.lastUpdatedAt() != null && now != null && now.isAfter(metadata.lastUpdatedAt())) {
+      try {
+        Duration minimumAge = Duration.ofMinutes(runtime.minimumReleaseAgeMinutesOrDefault());
+        publishedAfterExclusive = metadata.lastUpdatedAt().minus(minimumAge);
+        publishedAtOrBefore = now.minus(minimumAge);
+      } catch (ArithmeticException | DateTimeException e) {
+        return false;
+      }
+    }
+
+    Optional<NpmReleaseIndexDao.TarballPolicy> indexed = releaseIndexDao.findTarballPolicy(
+        metadata.assetId(),
+        metadata.blob().id(),
+        tarballName,
+        publishedAfterExclusive,
+        publishedAtOrBefore);
+    if (indexed.isEmpty()) {
+      // One-time upgrade path for package roots written before the durable index existed.
+      backfillLegacyReleaseIndex(metadata, runtime.minimumReleaseAgeMinutesOrDefault());
+      indexed = releaseIndexDao.findTarballPolicy(
+          metadata.assetId(),
+          metadata.blob().id(),
+          tarballName,
+          publishedAfterExclusive,
+          publishedAtOrBefore);
+    }
+    if (indexed.isEmpty() || !(isFullMetadataVerified(metadata)
+        || indexed.get().status().completePublishTimes())) {
+      return false;
+    }
+    if (indexed.get().maturityBoundaryCrossed()) {
+      return false;
+    }
+    enforceIndexedTarballRows(
+        runtime,
+        packageId,
+        tarballName,
+        safeEvaluationTime(metadata.lastUpdatedAt(), now),
+        indexed.get().releases());
+    return true;
+  }
+
+  private void backfillLegacyReleaseIndex(CachedAssetMetadata metadata, int minimumAge) {
+    Map<String, Object> packageRoot = hosted.packageRoot(metadata)
+        .orElseThrow(() -> new IllegalStateException(
+            "Cached npm package root blob is missing for " + metadata.path()));
+    NpmMinimumReleaseAge.ReleaseIndex releaseIndex = NpmMinimumReleaseAge.index(packageRoot);
+    backfillReleaseIndex(metadata, releaseIndex);
+    releaseAgeCache.remember(
+        metadata, minimumAge, NpmMinimumReleaseAge.analyze(releaseIndex, minimumAge));
+  }
+
+  private void enforceIndexedTarballRows(
+      RepositoryRuntime runtime,
+      NpmPackageId packageId,
+      String tarballName,
+      Instant evaluatedAt,
+      List<NpmReleaseIndexDao.Release> rows) {
+    if (rows.isEmpty()) {
+      throw new NpmExceptions.ReleaseAgeDenied(
+          "Tarball '" + tarballName + "' is blocked by minimumReleaseAge because its version "
+              + "cannot be verified from upstream package metadata");
+    }
+    NpmMinimumReleaseAge.Analysis analysis = NpmMinimumReleaseAge.analyze(
+        toReleaseIndex(rows), runtime.minimumReleaseAgeMinutesOrDefault());
+    for (NpmReleaseIndexDao.Release row : rows) {
+      NpmMinimumReleaseAge.Eligibility eligibility = analysis.eligibility(
+          row.version(), evaluatedAt);
+      if (eligibility.eligible()) {
+        continue;
+      }
+      String available = eligibility.availableAt() == null
+          ? "unknown (missing or invalid publish time)"
+          : eligibility.availableAt().toString();
+      throw new NpmExceptions.ReleaseAgeDenied(
+          "Tarball '" + tarballName + "' for " + packageId.id() + "@" + row.version()
+              + " is blocked by minimumReleaseAge until " + available);
+    }
+  }
+
+  Optional<Instant> nextPolicyTransition(
+      RepositoryRuntime runtime,
+      NpmPackageId packageId,
+      Instant now) {
+    if (!runtime.minimumReleaseAgeEnabled()) {
+      return Optional.empty();
+    }
+    PolicyPackage resolved = resolvePolicyPackage(runtime, packageId, now);
+    return resolved.analysis().nextMaturityAfter(resolved.evaluatedAt());
+  }
+
+  private PolicyPackage cachedPolicy(
+      CachedAssetMetadata metadata,
+      int minimumAge,
+      Instant evaluatedAt) {
+    PackageRootHolder root = new PackageRootHolder(() -> hosted.packageRoot(metadata)
+        .orElseThrow(() -> new IllegalStateException(
+            "Cached npm package root blob is missing for " + metadata.path())));
+    NpmMinimumReleaseAge.Analysis analysis = releaseAgeCache.analysis(
+        metadata, minimumAge, () -> loadIndexedAnalysis(metadata, minimumAge, root));
+    return new PolicyPackage(metadata, root, analysis, metadata.lastUpdatedAt(), evaluatedAt);
+  }
+
+  private NpmMinimumReleaseAge.Analysis loadIndexedAnalysis(
+      CachedAssetMetadata metadata,
+      int minimumAge,
+      PackageRootHolder root) {
+    if (releaseIndexDao != null && metadata.blob() != null) {
+      Optional<NpmReleaseIndexDao.Snapshot> snapshot = releaseIndexDao.findSnapshot(
+          metadata.assetId(), metadata.blob().id());
+      if (snapshot.isPresent()) {
+        return NpmMinimumReleaseAge.analyze(toReleaseIndex(snapshot.get().releases()), minimumAge);
+      }
+    }
+
+    NpmMinimumReleaseAge.ReleaseIndex releaseIndex = NpmMinimumReleaseAge.index(root.get());
+    backfillReleaseIndex(metadata, releaseIndex);
+    return NpmMinimumReleaseAge.analyze(releaseIndex, minimumAge);
+  }
+
+  private void backfillReleaseIndex(
+      CachedAssetMetadata metadata,
+      NpmMinimumReleaseAge.ReleaseIndex releaseIndex) {
+    if (releaseIndexDao == null || metadata == null || metadata.blob() == null) {
+      return;
+    }
+    releaseIndexDao.replaceIfCurrent(
+        metadata.assetId(),
+        metadata.blob().id(),
+        releaseIndex.releases().stream()
+            .allMatch(release -> release.invalidReason() == null),
+        toReleaseRows(releaseIndex),
+        clock.instant());
+  }
+
+  private static NpmMinimumReleaseAge.ReleaseIndex toReleaseIndex(
+      List<NpmReleaseIndexDao.Release> rows) {
+    return new NpmMinimumReleaseAge.ReleaseIndex(rows.stream()
+        .map(row -> new NpmMinimumReleaseAge.IndexedRelease(
+            row.version(), row.publishedAt(), row.invalidReason(), row.tarballName()))
+        .toList());
+  }
+
+  private static List<NpmReleaseIndexDao.Release> toReleaseRows(
+      NpmMinimumReleaseAge.ReleaseIndex releaseIndex) {
+    java.util.ArrayList<NpmReleaseIndexDao.Release> rows = new java.util.ArrayList<>();
+    int ordinal = 0;
+    for (NpmMinimumReleaseAge.IndexedRelease release : releaseIndex.releases()) {
+      rows.add(new NpmReleaseIndexDao.Release(
+          ordinal++, release.version(), release.publishedAt(), release.invalidReason(),
+          release.tarballName()));
+    }
+    return List.copyOf(rows);
+  }
+
+  private static boolean isFullMetadataVerified(CachedAssetMetadata metadata) {
+    if (metadata == null || metadata.blob() == null || metadata.blob().attributes() == null) {
+      return false;
+    }
+    Object value = metadata.blob().attributes().get(FULL_METADATA_ATTRIBUTE);
+    return value != null && Boolean.parseBoolean(value.toString());
+  }
+
+  private static Instant safeEvaluationTime(Instant lastVerifiedAt, Instant now) {
+    if (lastVerifiedAt == null || now == null) {
+      return null;
+    }
+    return lastVerifiedAt.isBefore(now) ? lastVerifiedAt : now;
+  }
+
+  private record PolicyPackage(
+      CachedAssetMetadata metadata,
+      PackageRootHolder root,
+      NpmMinimumReleaseAge.Analysis analysis,
+      Instant lastModified,
+      Instant evaluatedAt) {
+  }
+
+  private static final class PackageRootHolder {
+    private Supplier<Map<String, Object>> loader;
+    private Map<String, Object> value;
+
+    private PackageRootHolder(Supplier<Map<String, Object>> loader) {
+      this.loader = loader;
+    }
+
+    static PackageRootHolder loaded(Map<String, Object> value) {
+      PackageRootHolder holder = new PackageRootHolder(null);
+      holder.value = Objects.requireNonNull(value, "value");
+      return holder;
+    }
+
+    synchronized Map<String, Object> get() {
+      if (value == null) {
+        value = Objects.requireNonNull(loader.get(), "package root loader returned null");
+        loader = null;
+      }
+      return value;
+    }
   }
 
   private MavenResponse tarballResponseFromStored(NpmAssetWriter.Stored stored, boolean headOnly) {
@@ -259,20 +785,48 @@ public class NpmProxyService {
       NpmPackageId packageId,
       HttpRemoteFetcher.Result result,
       Instant now) throws IOException {
+    return persistPackage(runtime, packageId, result, now, null);
+  }
+
+  private CachedPackage persistPackage(
+      RepositoryRuntime runtime,
+      NpmPackageId packageId,
+      HttpRemoteFetcher.Result result,
+      Instant now,
+      Integer minimumReleaseAgeMinutes) throws IOException {
     String contentType = result.contentType();
     if (contentType != null && contentType.toLowerCase(Locale.ROOT).startsWith("text/html")) {
       throw new NpmExceptions.NpmNotFoundException("Package '" + packageId.id() + "' not found");
     }
-    Map<String, Object> packageRoot = mapper.readValue(
-        UpstreamBodyReadException.readAllBytes(result.body()), MAP_TYPE);
+    byte[] packageBytes = UpstreamBodyReadException.readAllBytes(result.body());
+    Map<String, Object> packageRoot = mapper.readValue(packageBytes, MAP_TYPE);
     long blobStoreId = requireBlobStore(runtime);
     BlobStorage storage = blobStorageRegistry.forBlobStoreId(blobStoreId);
     Map<String, String> extras = remoteAttributes(result);
-    NpmAssetWriter.Stored stored = writer.writePackageRoot(runtime, storage, blobStoreId, packageId,
-        NpmResponseSupport.write(mapper, packageRoot), "proxy", runtime.proxyRemoteUrl(), extras);
+    NpmMinimumReleaseAge.ReleaseIndex releaseIndex = minimumReleaseAgeMinutes == null
+        ? null
+        : NpmMinimumReleaseAge.index(packageRoot);
+    NpmMinimumReleaseAge.Analysis analysis = releaseIndex == null
+        ? null
+        : NpmMinimumReleaseAge.analyze(releaseIndex, minimumReleaseAgeMinutes);
+    if (analysis != null) {
+      extras.put(FULL_METADATA_ATTRIBUTE, Boolean.TRUE.toString());
+      extras.put(
+          COMPLETE_PUBLISH_TIMES_ATTRIBUTE,
+          Boolean.toString(analysis.hasCompletePublishTimes()));
+    }
+    NpmAssetWriter.Stored stored = releaseIndex == null
+        ? writer.writePackageRoot(runtime, storage, blobStoreId, packageId,
+            packageBytes, "proxy", runtime.proxyRemoteUrl(), extras)
+        : writer.writePackageRoot(runtime, storage, blobStoreId, packageId,
+            packageBytes, "proxy", runtime.proxyRemoteUrl(), extras, releaseIndex);
     updateCacheInfo(runtime, stored.asset(), NexusCacheType.METADATA, now);
     proxyStateDao.recordSuccess(runtime.id(), now);
-    return new CachedPackage(packageRoot, stored.asset().lastUpdatedAt());
+    CachedAssetMetadata metadata = CachedAssetMetadata.of(stored.asset(), stored.blob());
+    if (analysis != null) {
+      releaseAgeCache.remember(metadata, minimumReleaseAgeMinutes, analysis);
+    }
+    return new CachedPackage(packageRoot, stored.asset().lastUpdatedAt(), metadata, analysis);
   }
 
   private MavenResponse packageResponse(
@@ -281,12 +835,14 @@ public class NpmProxyService {
       CachedPackage stored,
       boolean headOnly,
       NpmPackumentVariant variant) {
-    Map<String, Object> copy = NpmMetadata.deepCopy(stored.packageRoot());
-    NpmMetadata.rewriteTarballUrls(copy, packageId, repositoryBaseUrl);
-    if (variant.abbreviated()) {
-      copy = NpmMetadata.abbreviatePackageRoot(copy);
-    }
-    byte[] bytes = NpmResponseSupport.write(mapper, copy);
+    byte[] bytes = NpmPackumentResponseWriter.write(
+        mapper,
+        stored.packageRoot(),
+        null,
+        null,
+        variant,
+        packageId,
+        repositoryBaseUrl);
     if (headOnly) {
       return MavenResponse.noBody(200, bytes.length, NpmResponseSupport.JSON, null, stored.lastModified());
     }
@@ -294,7 +850,15 @@ public class NpmProxyService {
         NpmResponseSupport.JSON, null, stored.lastModified());
   }
 
-  private record CachedPackage(Map<String, Object> packageRoot, Instant lastModified) {}
+  private record CachedPackage(
+      Map<String, Object> packageRoot,
+      Instant lastModified,
+      CachedAssetMetadata metadata,
+      NpmMinimumReleaseAge.Analysis analysis) {
+    private CachedPackage(Map<String, Object> packageRoot, Instant lastModified) {
+      this(packageRoot, lastModified, null, null);
+    }
+  }
 
   private NpmAssetWriter.Stored fetchAndCacheTarball(
       RepositoryRuntime runtime,

--- a/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmReleaseAgeCache.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmReleaseAgeCache.java
@@ -1,0 +1,116 @@
+package com.github.klboke.kkrepo.server.npm;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.klboke.kkrepo.protocol.npm.NpmMinimumReleaseAge;
+import com.github.klboke.kkrepo.server.cache.CachedAssetMetadata;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.function.Supplier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * Node-local, bounded cache for state derived from an immutable npm packument blob revision.
+ *
+ * <p>The raw packument in shared blob storage remains the source of truth. Keys include the durable
+ * blob identity and the configured policy, so losing this cache only costs a rebuild and stale
+ * entries cannot be selected after another replica stores a new packument revision. Caffeine's
+ * atomic {@code get(key, mappingFunction)} also gives each replica per-key single-flight loading.
+ */
+@Service
+public class NpmReleaseAgeCache {
+  private final Cache<AnalysisKey, NpmMinimumReleaseAge.Analysis> analyses;
+  private final Cache<ResponseKey, byte[]> responses;
+
+  public NpmReleaseAgeCache(
+      @Value("${kkrepo.cache.npm-release-age.maximum-version-entries:100000}")
+      long maximumVersionEntries,
+      @Value("${kkrepo.cache.npm-release-age.response-maximum-bytes:33554432}")
+      long responseMaximumBytes,
+      @Value("${kkrepo.cache.npm-release-age.expire-after-access-minutes:30}")
+      long expireAfterAccessMinutes) {
+    Duration expiry = Duration.ofMinutes(Math.max(1, expireAfterAccessMinutes));
+    this.analyses = Caffeine.newBuilder()
+        .maximumWeight(Math.max(1, maximumVersionEntries))
+        .weigher((AnalysisKey ignored, NpmMinimumReleaseAge.Analysis analysis) ->
+            analysis.cacheWeight())
+        .expireAfterAccess(expiry)
+        .build();
+    this.responses = Caffeine.newBuilder()
+        .maximumWeight(Math.max(1, responseMaximumBytes))
+        .weigher((ResponseKey ignored, byte[] bytes) -> Math.max(1, bytes.length))
+        .expireAfterAccess(expiry)
+        .build();
+  }
+
+  public NpmMinimumReleaseAge.Analysis analysis(
+      CachedAssetMetadata metadata,
+      int minimumReleaseAgeMinutes,
+      Supplier<NpmMinimumReleaseAge.Analysis> analysisLoader) {
+    AnalysisKey key = analysisKey(metadata, minimumReleaseAgeMinutes);
+    return analyses.get(key, ignored -> Objects.requireNonNull(
+        analysisLoader.get(), "analysisLoader returned null"));
+  }
+
+  public void remember(
+      CachedAssetMetadata metadata,
+      int minimumReleaseAgeMinutes,
+      NpmMinimumReleaseAge.Analysis analysis) {
+    analyses.put(
+        analysisKey(metadata, minimumReleaseAgeMinutes),
+        Objects.requireNonNull(analysis, "analysis"));
+  }
+
+  public byte[] response(
+      CachedAssetMetadata metadata,
+      int minimumReleaseAgeMinutes,
+      NpmMinimumReleaseAge.Analysis analysis,
+      Instant evaluatedAt,
+      String kind,
+      String scope,
+      Supplier<byte[]> responseBuilder) {
+    AnalysisKey analysisKey = analysisKey(metadata, minimumReleaseAgeMinutes);
+    ResponseKey key = new ResponseKey(
+        analysisKey,
+        analysis.visibilityGeneration(evaluatedAt),
+        normalize(kind),
+        normalize(scope));
+    return responses.get(key, ignored -> Objects.requireNonNull(
+        responseBuilder.get(), "responseBuilder returned null"));
+  }
+
+  private static AnalysisKey analysisKey(
+      CachedAssetMetadata metadata,
+      int minimumReleaseAgeMinutes) {
+    Objects.requireNonNull(metadata, "metadata");
+    CachedAssetMetadata.CachedBlob blob = Objects.requireNonNull(
+        metadata.blob(), "npm package-root metadata has no blob");
+    return new AnalysisKey(
+        metadata.repositoryId(),
+        normalize(metadata.path()),
+        blob.id(),
+        normalize(blob.sha256()),
+        minimumReleaseAgeMinutes);
+  }
+
+  private static String normalize(String value) {
+    return value == null ? "" : value;
+  }
+
+  private record AnalysisKey(
+      long repositoryId,
+      String path,
+      long blobId,
+      String sha256,
+      int minimumReleaseAgeMinutes) {
+  }
+
+  private record ResponseKey(
+      AnalysisKey analysisKey,
+      int visibilityGeneration,
+      String kind,
+      String scope) {
+  }
+}

--- a/server/src/main/java/com/github/klboke/kkrepo/server/repositories/RepositoryCommands.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/repositories/RepositoryCommands.java
@@ -57,7 +57,33 @@ public final class RepositoryCommands {
       Integer outboundProxyPort,
       String outboundProxyUsername,
       String outboundProxyPassword,
-      Boolean outboundProxyPasswordConfigured) {
+      Boolean outboundProxyPasswordConfigured,
+      Integer minimumReleaseAgeMinutes) {
+    /** Compatibility constructor for callers that predate npm release-age protection. */
+    public ProxySettings(
+        String remoteUrl,
+        Integer contentMaxAgeMinutes,
+        Integer metadataMaxAgeMinutes,
+        Boolean autoBlock,
+        String remoteUsername,
+        String remotePassword,
+        Boolean remotePasswordConfigured,
+        String remoteBearerToken,
+        Boolean remoteBearerTokenConfigured,
+        String outboundProxyType,
+        String outboundProxyHost,
+        Integer outboundProxyPort,
+        String outboundProxyUsername,
+        String outboundProxyPassword,
+        Boolean outboundProxyPasswordConfigured) {
+      this(remoteUrl, contentMaxAgeMinutes, metadataMaxAgeMinutes, autoBlock,
+          remoteUsername, remotePassword, remotePasswordConfigured,
+          remoteBearerToken, remoteBearerTokenConfigured,
+          outboundProxyType, outboundProxyHost, outboundProxyPort,
+          outboundProxyUsername, outboundProxyPassword, outboundProxyPasswordConfigured,
+          null);
+    }
+
     public ProxySettings(
         String remoteUrl,
         Integer contentMaxAgeMinutes,
@@ -93,6 +119,17 @@ public final class RepositoryCommands {
         Boolean autoBlock) {
       this(remoteUrl, contentMaxAgeMinutes, metadataMaxAgeMinutes, autoBlock,
           null, null, null, null, null, null, null, null, null, null, null);
+    }
+
+    public ProxySettings(
+        String remoteUrl,
+        Integer contentMaxAgeMinutes,
+        Integer metadataMaxAgeMinutes,
+        Boolean autoBlock,
+        Integer minimumReleaseAgeMinutes) {
+      this(remoteUrl, contentMaxAgeMinutes, metadataMaxAgeMinutes, autoBlock,
+          null, null, null, null, null, null, null, null, null, null, null,
+          minimumReleaseAgeMinutes);
     }
   }
 

--- a/server/src/main/java/com/github/klboke/kkrepo/server/repositories/RepositoryService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/repositories/RepositoryService.java
@@ -926,7 +926,8 @@ public class RepositoryService {
         settings.outboundProxyPort(),
         settings.outboundProxyUsername(),
         settings.outboundProxyPassword(),
-        settings.outboundProxyPasswordConfigured());
+        settings.outboundProxyPasswordConfigured(),
+        settings.minimumReleaseAgeMinutes());
   }
 
   private static String defaultRemoteUrl(RepositoryFormat format) {
@@ -960,7 +961,8 @@ public class RepositoryService {
         settings.outboundProxyPort(),
         settings.outboundProxyUsername(),
         settings.outboundProxyPassword(),
-        settings.outboundProxyPasswordConfigured());
+        settings.outboundProxyPasswordConfigured(),
+        settings.minimumReleaseAgeMinutes());
   }
 
   private void validateProxy(ProxySettings settings, RepositoryFormat format) {
@@ -977,6 +979,16 @@ public class RepositoryService {
       throw new RepositoryValidationException(e.getMessage());
     }
     validateOutboundProxy(settings);
+    int minimumReleaseAge = settings.minimumReleaseAgeMinutes() == null
+        ? 0
+        : settings.minimumReleaseAgeMinutes();
+    if (minimumReleaseAge < 0) {
+      throw new RepositoryValidationException("proxy.minimumReleaseAgeMinutes must be at least 0");
+    }
+    if (minimumReleaseAge > 0 && format != RepositoryFormat.NPM) {
+      throw new RepositoryValidationException(
+          "proxy.minimumReleaseAgeMinutes is only supported for npm proxy repositories");
+    }
     if (format == RepositoryFormat.SWIFT) {
       normalizeSwiftRemoteUrl(settings.remoteUrl());
     }
@@ -1089,7 +1101,10 @@ public class RepositoryService {
         mergedOutboundProxyPort,
         mergedOutboundProxyUsername,
         mergedOutboundProxyPassword,
-        null);
+        null,
+        incoming.minimumReleaseAgeMinutes() == null
+            ? base.minimumReleaseAgeMinutes()
+            : incoming.minimumReleaseAgeMinutes());
   }
 
   private static String mergedOutboundProxyPassword(ProxySettings base, ProxySettings incoming) {
@@ -1127,6 +1142,9 @@ public class RepositoryService {
     map.put("remoteUrl", proxy.remoteUrl());
     if (proxy.contentMaxAgeMinutes() != null) map.put("contentMaxAgeMinutes", proxy.contentMaxAgeMinutes());
     if (proxy.metadataMaxAgeMinutes() != null) map.put("metadataMaxAgeMinutes", proxy.metadataMaxAgeMinutes());
+    if (proxy.minimumReleaseAgeMinutes() != null) {
+      map.put("minimumReleaseAgeMinutes", proxy.minimumReleaseAgeMinutes());
+    }
     if (proxy.autoBlock() != null) map.put("autoBlock", proxy.autoBlock());
     if (proxy.remoteUsername() != null && !proxy.remoteUsername().isBlank()) {
       map.put("remoteUsername", proxy.remoteUsername());
@@ -1203,7 +1221,8 @@ public class RepositoryService {
         intValue(proxyMap.get("outboundProxyPort")),
         blankToNull(stringOrNull(proxyMap.get("outboundProxyUsername"))),
         blankToNull(stringOrNull(proxyMap.get("outboundProxyPassword"))),
-        null);
+        null,
+        intValue(proxyMap.get("minimumReleaseAgeMinutes")));
   }
 
   private static ProxySettings readProxyAttributesOrDefaults(RepositoryRecord record) {
@@ -1227,7 +1246,8 @@ public class RepositoryService {
         effective.outboundProxyPort(),
         effective.outboundProxyUsername(),
         null,
-        outboundPassword != null && !outboundPassword.isBlank());
+        outboundPassword != null && !outboundPassword.isBlank(),
+        effective.minimumReleaseAgeMinutes() == null ? 0 : effective.minimumReleaseAgeMinutes());
   }
 
   private static String stringOrNull(Object value) {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcherProxyTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcherProxyTest.java
@@ -128,7 +128,8 @@ class HttpRemoteFetcherProxyTest {
           "localhost",
           "Basic cm9ib3Q6c2VjcmV0",
           Set.of(),
-          proxyConfig(proxy.port(), null, null));
+          proxyConfig(proxy.port(), null, null))
+          .withAccept("application/json");
 
       try (HttpRemoteFetcher.Result result = fetcher.fetch(request)) {
         assertEquals(200, result.status());
@@ -137,6 +138,8 @@ class HttpRemoteFetcherProxyTest {
       assertEquals(2, proxy.requests().size());
       assertPinnedLocalhostTarget(proxy.requests().get(1), "/moved/lib-1.0.jar");
       assertEquals("Basic cm9ib3Q6c2VjcmV0", proxy.requests().get(1).header("Authorization"));
+      assertEquals("application/json", proxy.requests().get(0).header("Accept"));
+      assertEquals("application/json", proxy.requests().get(1).header("Accept"));
     }
   }
 

--- a/server/src/test/java/com/github/klboke/kkrepo/server/maven/MavenErrorAdviceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/maven/MavenErrorAdviceTest.java
@@ -4,13 +4,28 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.github.klboke.kkrepo.server.cargo.CargoExceptions;
 import com.github.klboke.kkrepo.protocol.pub.PubContentTypes;
+import com.github.klboke.kkrepo.server.npm.NpmExceptions;
 import com.github.klboke.kkrepo.server.pub.PubExceptions;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 class MavenErrorAdviceTest {
+
+  @Test
+  void npmMinimumReleaseAgeDenialIsNotFoundAndNotCacheable() {
+    MavenErrorAdvice advice = new MavenErrorAdvice();
+
+    ResponseEntity<Map<String, Object>> response = advice.npmReleaseAgeDenied(
+        new NpmExceptions.ReleaseAgeDenied("release is too new"));
+
+    assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    assertEquals("no-store", response.getHeaders().getFirst(HttpHeaders.CACHE_CONTROL));
+    assertEquals(false, response.getBody().get("success"));
+    assertEquals("release is too new", response.getBody().get("error"));
+  }
 
   @Test
   void notFoundBodyIncludesHttpStatus() {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/maven/RepositoryRuntimeRegistryTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/maven/RepositoryRuntimeRegistryTest.java
@@ -89,6 +89,35 @@ class RepositoryRuntimeRegistryTest {
   }
 
   @Test
+  void resolveReadsNpmMinimumReleaseAge() {
+    FakeRepositoryDao dao = new FakeRepositoryDao();
+    dao.add(new RepositoryRecord(
+        10L,
+        "npm-proxy",
+        RepositoryFormat.NPM,
+        RepositoryType.PROXY,
+        "npm-proxy",
+        true,
+        1L,
+        null,
+        "https://registry.npmjs.org/",
+        null,
+        null,
+        "ALLOW",
+        true,
+        Map.of("proxy", Map.of(
+            "remoteUrl", "https://registry.npmjs.org/",
+            "minimumReleaseAgeMinutes", 120))), List.of());
+
+    RepositoryRuntime runtime = new RepositoryRuntimeRegistry(dao, 0)
+        .resolve("npm-proxy")
+        .orElseThrow();
+
+    assertEquals(120, runtime.minimumReleaseAgeMinutesOrDefault());
+    assertTrue(runtime.minimumReleaseAgeEnabled());
+  }
+
+  @Test
   void runtimeWithProxyBearerTokenIsNotWrittenToSharedCache() {
     FakeRepositoryDao dao = new FakeRepositoryDao();
     dao.add(cargoProxyRepo(6, "cargo-private-proxy", "upstream-token"), List.of());

--- a/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmAssetWriterReleaseIndexTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmAssetWriterReleaseIndexTest.java
@@ -1,0 +1,156 @@
+package com.github.klboke.kkrepo.server.npm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.core.BlobReference;
+import com.github.klboke.kkrepo.core.BlobStorage;
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.jdbc.api.AssetDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.BrowseNodeDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.ComponentDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.NpmReleaseIndexDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.model.AssetBlobRecord;
+import com.github.klboke.kkrepo.protocol.npm.NpmMinimumReleaseAge;
+import com.github.klboke.kkrepo.protocol.npm.NpmPackageId;
+import com.github.klboke.kkrepo.server.cache.AssetMetadataCache;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class NpmAssetWriterReleaseIndexTest {
+  private static final NpmPackageId PACKAGE = NpmPackageId.parse("demo");
+
+  @Test
+  void packageRootOverloadsPersistOrderedReleaseIndexRows() {
+    Fixture fixture = fixture(true);
+    NpmMinimumReleaseAge.ReleaseIndex index = new NpmMinimumReleaseAge.ReleaseIndex(List.of(
+        new NpmMinimumReleaseAge.IndexedRelease(
+            "1.0.0", Instant.parse("2026-07-19T10:00:00Z"), null, "demo-1.0.0.tgz"),
+        new NpmMinimumReleaseAge.IndexedRelease(
+            "broken", null, "missing-publish-time", "demo-broken.tgz")));
+
+    NpmAssetWriter.Stored indexed = fixture.writer.writePackageRoot(
+        runtime(), fixture.storage, 1L, PACKAGE, json(), "proxy", "upstream", Map.of(), index);
+    fixture.writer.writePackageRoot(
+        runtime(), fixture.storage, 1L, PACKAGE, json(), "proxy", "upstream", Map.of());
+    fixture.writer.writePackageRoot(
+        runtime(), fixture.storage, 1L, PACKAGE, json(), "proxy", "upstream",
+        Map.of(), Map.of("cache", "fresh"), false);
+
+    assertEquals("demo", indexed.asset().path());
+    assertEquals(null, indexed.responseFile());
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<NpmReleaseIndexDao.Release>> rows = ArgumentCaptor.forClass(List.class);
+    verify(fixture.releaseIndexDao).replaceIfCurrent(
+        eq(70L), eq(50L), eq(false), rows.capture(), any(Instant.class));
+    assertEquals(List.of(
+        new NpmReleaseIndexDao.Release(
+            0, "1.0.0", Instant.parse("2026-07-19T10:00:00Z"), null, "demo-1.0.0.tgz"),
+        new NpmReleaseIndexDao.Release(
+            1, "broken", null, "missing-publish-time", "demo-broken.tgz")), rows.getValue());
+  }
+
+  @Test
+  void releaseIndexRevisionMismatchFailsThePackageRootWrite() {
+    Fixture fixture = fixture(false);
+    NpmMinimumReleaseAge.ReleaseIndex index = new NpmMinimumReleaseAge.ReleaseIndex(List.of(
+        new NpmMinimumReleaseAge.IndexedRelease(
+            "1.0.0", Instant.parse("2026-07-19T10:00:00Z"), null, "demo-1.0.0.tgz")));
+
+    IllegalStateException error = assertThrows(IllegalStateException.class,
+        () -> fixture.writer.writePackageRoot(
+            runtime(), fixture.storage, 1L, PACKAGE, json(), "proxy", "upstream", Map.of(), index));
+
+    assertEquals(
+        "npm release index revision no longer matches package root npm-proxy/demo",
+        error.getMessage());
+  }
+
+  @Test
+  void tarballWriteCanRetainItsResponseFile() {
+    Fixture fixture = fixture(true);
+
+    NpmAssetWriter.Stored stored = fixture.writer.writeTarball(
+        runtime(), fixture.storage, 1L, PACKAGE, "1.0.0", "demo-1.0.0.tgz",
+        new ByteArrayInputStream("tarball".getBytes(StandardCharsets.UTF_8)),
+        "application/octet-stream", "proxy", "upstream", Map.of(), true);
+
+    assertNotNull(stored.responseFile());
+    assertFalse(stored.responseFile().toFile().isDirectory());
+    stored.discardBody();
+  }
+
+  private static Fixture fixture(boolean indexAccepted) {
+    AssetDao assetDao = mock(AssetDao.class);
+    ComponentDao componentDao = mock(ComponentDao.class);
+    BrowseNodeDao browseNodeDao = mock(BrowseNodeDao.class);
+    AssetMetadataCache metadataCache = mock(AssetMetadataCache.class);
+    NpmReleaseIndexDao releaseIndexDao = mock(NpmReleaseIndexDao.class);
+    BlobStorage storage = mock(BlobStorage.class);
+    BlobReference reference = new BlobReference("default", "objects/npm-test", "sha256", 7L);
+
+    when(storage.putFile(anyString(), anyString(), any(Path.class), anyString()))
+        .thenReturn(reference);
+    when(assetDao.findAssetByPath(anyLong(), anyString())).thenReturn(Optional.empty());
+    when(assetDao.findReusableBlobBySha256(anyLong(), anyString(), anyLong()))
+        .thenReturn(Optional.empty());
+    when(assetDao.recoverDeletedBlobBySha256(anyLong(), anyString(), anyLong()))
+        .thenReturn(Optional.empty());
+    when(assetDao.insertBlobOrFindExisting(any(AssetBlobRecord.class)))
+        .thenAnswer(invocation -> withId(invocation.getArgument(0), 50L));
+    when(assetDao.tryInsertAsset(any())).thenReturn(OptionalLong.of(70L));
+    when(componentDao.upsertReturningId(any())).thenReturn(80L);
+    when(releaseIndexDao.replaceIfCurrent(
+        anyLong(), anyLong(), any(Boolean.class), any(), any(Instant.class)))
+        .thenReturn(indexAccepted);
+
+    NpmAssetWriter writer = new NpmAssetWriter(
+        assetDao, componentDao, browseNodeDao, null, metadataCache,
+        null, null, releaseIndexDao);
+    return new Fixture(writer, storage, releaseIndexDao);
+  }
+
+  private static AssetBlobRecord withId(AssetBlobRecord record, long id) {
+    return new AssetBlobRecord(
+        id, record.blobStoreId(), record.blobRef(), record.blobRefHash(), record.objectKey(),
+        record.objectKeyHash(), record.sha1(), record.sha256(), record.md5(), record.size(),
+        record.contentType(), record.createdBy(), record.createdByIp(), record.blobCreatedAt(),
+        record.blobUpdatedAt(), record.attributes());
+  }
+
+  private static byte[] json() {
+    return "{\"name\":\"demo\",\"versions\":{}}".getBytes(StandardCharsets.UTF_8);
+  }
+
+  private static RepositoryRuntime runtime() {
+    return new RepositoryRuntime(
+        10L, "npm-proxy", RepositoryFormat.NPM, RepositoryType.PROXY, "npm-proxy", true,
+        1L, null, "MIXED", "PERMISSIVE", true, "https://registry.npmjs.org",
+        1440, 1440, true, null, List.of());
+  }
+
+  private record Fixture(
+      NpmAssetWriter writer,
+      BlobStorage storage,
+      NpmReleaseIndexDao releaseIndexDao) {
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmGroupPackumentCacheTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmGroupPackumentCacheTest.java
@@ -14,6 +14,7 @@ import com.github.klboke.kkrepo.persistence.jdbc.api.model.AssetRecord;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.RepositoryRecord;
 import com.github.klboke.kkrepo.protocol.npm.NpmPackageId;
 import com.github.klboke.kkrepo.server.cache.AssetMetadataCache;
+import com.github.klboke.kkrepo.server.cache.CachedAssetMetadata;
 import com.github.klboke.kkrepo.server.cache.NexusCacheType;
 import com.github.klboke.kkrepo.server.cache.NexusLikeCacheController;
 import com.github.klboke.kkrepo.server.cache.NexusLikeCacheInfo;
@@ -152,6 +153,27 @@ class NpmGroupPackumentCacheTest {
     assertTrue(fixture.cache.findFresh(group, PACKAGE_ID, NOW).isEmpty());
     assertEquals(Map.of("packageId", PACKAGE_ID.id()),
         fixture.assets.asset(group.id(), PACKAGE_ID.id()).attributes());
+  }
+
+  @Test
+  void minimumReleaseAgeValidityAttributeIsParsedDefensively() {
+    Fixture fixture = fixture(true);
+
+    assertEquals(null, fixture.cache.minimumReleaseAgeValidUntil(null));
+    assertEquals(null, fixture.cache.minimumReleaseAgeValidUntil(metadata(null)));
+    assertEquals(null, fixture.cache.minimumReleaseAgeValidUntil(metadata(Map.of())));
+    assertEquals(null, fixture.cache.minimumReleaseAgeValidUntil(metadata(Map.of(
+        "minimumReleaseAgeValidUntil", " "))));
+    assertEquals(null, fixture.cache.minimumReleaseAgeValidUntil(metadata(Map.of(
+        "minimumReleaseAgeValidUntil", "not-an-instant"))));
+    assertEquals(NOW.plusSeconds(30), fixture.cache.minimumReleaseAgeValidUntil(metadata(Map.of(
+        "minimumReleaseAgeValidUntil", NOW.plusSeconds(30).toString()))));
+  }
+
+  private static CachedAssetMetadata metadata(Map<String, Object> attributes) {
+    return new CachedAssetMetadata(
+        1L, 99L, null, null, RepositoryFormat.NPM, PACKAGE_ID.id(), PACKAGE_ID.id(),
+        "package-root", NpmResponseSupport.JSON, 1L, NOW, attributes, null);
   }
 
   private static Fixture fixture(boolean enabled) {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmGroupServiceCacheTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmGroupServiceCacheTest.java
@@ -4,6 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.klboke.kkrepo.core.BlobObjectMetadata;
@@ -22,6 +26,8 @@ import com.github.klboke.kkrepo.persistence.jdbc.api.model.RepositoryRecord;
 import com.github.klboke.kkrepo.protocol.npm.NpmPackageId;
 import com.github.klboke.kkrepo.protocol.npm.NpmPath;
 import com.github.klboke.kkrepo.server.cache.AssetMetadataCache;
+import com.github.klboke.kkrepo.server.cache.GroupMemberAssetCache;
+import com.github.klboke.kkrepo.server.cache.NexusCacheType;
 import com.github.klboke.kkrepo.server.cache.NexusLikeCacheController;
 import com.github.klboke.kkrepo.server.maven.BlobStorageRegistry;
 import com.github.klboke.kkrepo.server.maven.MavenResponse;
@@ -228,6 +234,101 @@ class NpmGroupServiceCacheTest {
     assertEquals("release is too new", denied.getMessage());
   }
 
+  @Test
+  void packageAndDistTagHeadResponsesUseMergedPackument() throws Exception {
+    Fixture fixture = fixture();
+    NpmGroupService groupService = fixture.groupService();
+    RepositoryRuntime member = runtime(101L, "npm-hosted", RepositoryType.HOSTED, List.of());
+    RepositoryRuntime group = runtime(999L, "npm-group", RepositoryType.GROUP, List.of(member));
+    NpmPackageId packageId = NpmPackageId.parse("@example/demo");
+    NpmPath packagePath = new NpmPath(
+        NpmPath.Kind.PACKAGE_ROOT, packageId.id(), packageId, null, null, null, null);
+    NpmPath tagsPath = new NpmPath(
+        NpmPath.Kind.DIST_TAGS, packageId.id(), packageId, null, null, null, null);
+
+    MavenResponse packageHead = groupService.get(group, packagePath, "base", true);
+    MavenResponse tagsHead = groupService.get(group, tagsPath, "base", true);
+    MavenResponse tagsBody = groupService.get(group, tagsPath, "base", false);
+
+    assertEquals(null, packageHead.body());
+    assertEquals(null, tagsHead.body());
+    assertTrue(body(tagsBody).contains("{}"));
+  }
+
+  @Test
+  void cachedTarballMemberDenialIsEvictedBeforeGroupRetries() {
+    Fixture fixture = fixture();
+    GroupMemberAssetCache memberCache = mock(GroupMemberAssetCache.class);
+    NpmProxyService proxy = new ReleaseAgeNpmProxyService();
+    NpmGroupService groupService = new NpmGroupService(
+        fixture.hosted, proxy, fixture.mapper, fixture.packumentCache, memberCache,
+        fixture.registry, fixture.writer);
+    NpmPackageId packageId = NpmPackageId.parse("@example/demo");
+    String tarballName = "demo-2.0.0.tgz";
+    String cachePath = packageId.tarballPath(tarballName);
+    NpmPath path = new NpmPath(
+        NpmPath.Kind.TARBALL, cachePath, packageId, null, tarballName, null, null);
+    RepositoryRuntime proxyRuntime = runtime(
+        101L, "npm-proxy", RepositoryType.PROXY, List.of(), 60);
+    RepositoryRuntime group = runtime(
+        999L, "npm-group", RepositoryType.GROUP, List.of(proxyRuntime));
+    when(memberCache.get(group, cachePath, NexusCacheType.CONTENT))
+        .thenReturn(Optional.of(proxyRuntime.id()));
+
+    assertThrows(NpmExceptions.ReleaseAgeDenied.class,
+        () -> groupService.get(group, path, "base", false));
+
+    verify(memberCache).evict(group, cachePath, NexusCacheType.CONTENT);
+  }
+
+  @Test
+  void nestedGroupsAndProxyInstallVariantUseVariantAwareDispatch() throws Exception {
+    Fixture fixture = fixture();
+    RecordingNpmProxyService proxyService = new RecordingNpmProxyService();
+    NpmGroupService groupService = fixture.groupServiceWithProxy(proxyService);
+    NpmPackageId packageId = NpmPackageId.parse("@example/demo");
+    NpmPath path = new NpmPath(
+        NpmPath.Kind.PACKAGE_ROOT, packageId.id(), packageId, null, null, null, null);
+    RepositoryRuntime proxy = runtime(101L, "npm-proxy", RepositoryType.PROXY, List.of(), 60);
+    RepositoryRuntime proxyGroup = runtime(
+        999L, "proxy-group", RepositoryType.GROUP, List.of(proxy));
+
+    assertTrue(body(groupService.get(
+        proxyGroup, path, "base", false, NpmPackumentVariant.INSTALL_V1))
+        .contains("1.0.0"));
+
+    RepositoryRuntime hosted = runtime(201L, "npm-hosted", RepositoryType.HOSTED, List.of());
+    RepositoryRuntime inner = runtime(202L, "inner", RepositoryType.GROUP, List.of(hosted));
+    RepositoryRuntime outer = runtime(203L, "outer", RepositoryType.GROUP, List.of(inner));
+    assertTrue(body(groupService.get(outer, path, "base", false)).contains("1.0.0"));
+    assertTrue(body(groupService.get(
+        outer, path, "base", false, NpmPackumentVariant.INSTALL_V1)).contains("1.0.0"));
+  }
+
+  @Test
+  void groupUsesEarliestPolicyTransitionAcrossProxyMembers() {
+    Fixture fixture = fixture();
+    PerMemberTransitionProxyService proxy = new PerMemberTransitionProxyService();
+    NpmGroupService groupService = fixture.groupServiceWithProxy(proxy);
+    NpmPackageId packageId = NpmPackageId.parse("@example/demo");
+    NpmPath path = new NpmPath(
+        NpmPath.Kind.PACKAGE_ROOT, packageId.id(), packageId, null, null, null, null);
+    RepositoryRuntime first = runtime(101L, "first", RepositoryType.PROXY, List.of(), 60);
+    RepositoryRuntime second = runtime(102L, "second", RepositoryType.PROXY, List.of(), 60);
+    RepositoryRuntime later = runtime(103L, "later", RepositoryType.PROXY, List.of(), 60);
+    RepositoryRuntime noDeadline = runtime(
+        104L, "no-deadline", RepositoryType.PROXY, List.of(), 60);
+    RepositoryRuntime group = runtime(
+        999L, "npm-group", RepositoryType.GROUP,
+        List.of(first, second, later, noDeadline));
+
+    MavenResponse response = groupService.get(group, path, "base", false);
+
+    assertEquals(
+        proxy.base.plusSeconds(300),
+        response.internalAttribute(NpmProxyService.POLICY_VALID_UNTIL_CONTEXT));
+  }
+
   private static Fixture fixture() {
     ObjectMapper mapper = new ObjectMapper();
     StubRepositoryDao repositories = new StubRepositoryDao();
@@ -384,6 +485,40 @@ class NpmGroupServiceCacheTest {
           NpmResponseSupport.JSON, null, Instant.now())
           .withInternalAttribute(
               NpmProxyService.POLICY_VALID_UNTIL_CONTEXT, nextTransition);
+    }
+
+    @Override
+    public MavenResponse get(
+        RepositoryRuntime runtime,
+        NpmPath path,
+        String repositoryBaseUrl,
+        boolean headOnly,
+        NpmPackumentVariant variant) {
+      return get(runtime, path, repositoryBaseUrl, headOnly);
+    }
+  }
+
+  private static class PerMemberTransitionProxyService extends NpmProxyService {
+    final Instant base = Instant.parse("2026-07-19T12:00:00Z");
+
+    PerMemberTransitionProxyService() {
+      super(null, null, null, null, null, null, null, null, null, null);
+    }
+
+    @Override
+    public MavenResponse get(
+        RepositoryRuntime runtime, NpmPath path, String repositoryBaseUrl, boolean headOnly) {
+      byte[] bytes = "{\"name\":\"@example/demo\",\"versions\":{}}"
+          .getBytes(StandardCharsets.UTF_8);
+      Object transition = switch ((int) runtime.id()) {
+        case 101 -> base.plusSeconds(600);
+        case 102 -> base.plusSeconds(300);
+        case 103 -> base.plusSeconds(900);
+        default -> "not-an-instant";
+      };
+      return MavenResponse.ok(new ByteArrayInputStream(bytes), bytes.length,
+              NpmResponseSupport.JSON, null, base)
+          .withInternalAttribute(NpmProxyService.POLICY_VALID_UNTIL_CONTEXT, transition);
     }
   }
 

--- a/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmGroupServiceCacheTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmGroupServiceCacheTest.java
@@ -111,10 +111,12 @@ class NpmGroupServiceCacheTest {
         group, path, "http://nexus/group", false, NpmPackumentVariant.INSTALL_V1));
     String installBodySecond = body(groupService.get(
         group, path, "http://nexus/group", false, NpmPackumentVariant.INSTALL_V1));
+    assertTrue(fixture.assets.findAssetByPath(group.id(), packageId.id()).isEmpty(),
+        "install-v1 should no longer build an intermediate full group packument");
     String fullBody = body(groupService.get(group, path, "http://nexus/group", false));
 
-    assertEquals(1, fixture.hosted.calls.get(),
-        "install-v1 and full reads should reuse the cached merged full packument");
+    assertEquals(2, fixture.hosted.calls.get(),
+        "install-v1 and full variants should each fan out once without an intermediate full build");
     assertEquals(2, fixture.storage.puts.get(),
         "first install-v1 read should store one full blob and one abbreviated blob");
     assertTrue(fixture.assets.findAssetByPath(group.id(), packageId.id()).isPresent());
@@ -168,6 +170,64 @@ class NpmGroupServiceCacheTest {
     assertEquals(packageId.tarballPath("forge-tokens-0.2.0.tgz"), error.getMessage());
   }
 
+  @Test
+  void groupPackumentCacheExpiresAtNextMinimumReleaseAgeTransition() {
+    Fixture fixture = fixture();
+    RecordingNpmProxyService proxyService = new RecordingNpmProxyService();
+    NpmGroupService groupService = fixture.groupServiceWithProxy(proxyService);
+    NpmPackageId packageId = NpmPackageId.parse("@example/demo");
+    NpmPath path = new NpmPath(
+        NpmPath.Kind.PACKAGE_ROOT, packageId.id(), packageId, null, null, null, null);
+    RepositoryRuntime proxy = runtime(
+        101L, "npm-proxy", RepositoryType.PROXY, List.of(), 60);
+    RepositoryRuntime group = runtime(
+        999L, "npm-group", RepositoryType.GROUP, List.of(proxy));
+
+    groupService.get(group, path, "http://nexus/group", false);
+    groupService.get(group, path, "http://nexus/group", false);
+
+    assertEquals(1, proxyService.calls.get(),
+        "the group cache may be reused before the member's next maturity transition");
+    assertEquals(1, fixture.storage.puts.get(),
+        "the filtered group packument should be persisted with an exact policy deadline");
+    assertTrue(fixture.packumentCache.findFresh(
+        group,
+        packageId,
+        NpmPackumentVariant.FULL,
+        proxyService.nextTransition.minusNanos(1)).isPresent());
+    assertTrue(fixture.packumentCache.findFresh(
+        group,
+        packageId,
+        NpmPackumentVariant.FULL,
+        proxyService.nextTransition).isEmpty(),
+        "the cached group packument must expire exactly when a version becomes mature");
+  }
+
+  @Test
+  void groupReturnsReleaseAgeDenialWhenNoMemberCanServeTarball() {
+    Fixture fixture = fixture();
+    NpmGroupService groupService = fixture.groupServiceWithProxy(new ReleaseAgeNpmProxyService());
+    NpmPackageId packageId = NpmPackageId.parse("@example/demo");
+    NpmPath path = new NpmPath(
+        NpmPath.Kind.TARBALL,
+        packageId.tarballPath("demo-2.0.0.tgz"),
+        packageId,
+        null,
+        "demo-2.0.0.tgz",
+        null,
+        null);
+    RepositoryRuntime proxy = runtime(
+        101L, "npm-proxy", RepositoryType.PROXY, List.of(), 60);
+    RepositoryRuntime group = runtime(
+        999L, "npm-group", RepositoryType.GROUP, List.of(proxy));
+
+    NpmExceptions.ReleaseAgeDenied denied = assertThrows(
+        NpmExceptions.ReleaseAgeDenied.class,
+        () -> groupService.get(group, path, "http://nexus/group", false));
+
+    assertEquals("release is too new", denied.getMessage());
+  }
+
   private static Fixture fixture() {
     ObjectMapper mapper = new ObjectMapper();
     StubRepositoryDao repositories = new StubRepositoryDao();
@@ -198,10 +258,19 @@ class NpmGroupServiceCacheTest {
 
   private static RepositoryRuntime runtime(
       long id, String name, RepositoryType type, List<RepositoryRuntime> members) {
+    return runtime(id, name, type, members, 0);
+  }
+
+  private static RepositoryRuntime runtime(
+      long id,
+      String name,
+      RepositoryType type,
+      List<RepositoryRuntime> members,
+      int minimumReleaseAgeMinutes) {
     return new RepositoryRuntime(
         id, name, RepositoryFormat.NPM, type, "npm-" + type.name().toLowerCase(),
         true, 1L, "ALLOW", null, null, true, null, null, 60,
-        null, null, members);
+        null, null, members, minimumReleaseAgeMinutes);
   }
 
   private static RepositoryRecord record(long id, String name) {
@@ -287,6 +356,49 @@ class NpmGroupServiceCacheTest {
     public MavenResponse get(
         RepositoryRuntime runtime, NpmPath path, String repositoryBaseUrl, boolean headOnly) {
       throw new NpmExceptions.BadUpstreamException("Upstream returned 502");
+    }
+  }
+
+  private static class RecordingNpmProxyService extends NpmProxyService {
+    final AtomicInteger calls = new AtomicInteger();
+    final Instant nextTransition = Instant.now().plusSeconds(600);
+
+    RecordingNpmProxyService() {
+      super(null, null, null, null, null, null, null, null, null, null);
+    }
+
+    @Override
+    public MavenResponse get(
+        RepositoryRuntime runtime,
+        NpmPath path,
+        String repositoryBaseUrl,
+        boolean headOnly) {
+      calls.incrementAndGet();
+      byte[] body = """
+          {"name":"@example/demo","dist-tags":{"latest":"1.0.0"},"versions":{
+            "1.0.0":{"name":"@example/demo","version":"1.0.0",
+              "dist":{"tarball":"https://upstream.example/demo-1.0.0.tgz"}}
+          }}
+          """.getBytes(StandardCharsets.UTF_8);
+      return MavenResponse.ok(new ByteArrayInputStream(body), body.length,
+          NpmResponseSupport.JSON, null, Instant.now())
+          .withInternalAttribute(
+              NpmProxyService.POLICY_VALID_UNTIL_CONTEXT, nextTransition);
+    }
+  }
+
+  private static class ReleaseAgeNpmProxyService extends NpmProxyService {
+    ReleaseAgeNpmProxyService() {
+      super(null, null, null, null, null, null, null, null, null, null);
+    }
+
+    @Override
+    public MavenResponse get(
+        RepositoryRuntime runtime,
+        NpmPath path,
+        String repositoryBaseUrl,
+        boolean headOnly) {
+      throw new NpmExceptions.ReleaseAgeDenied("release is too new");
     }
   }
 

--- a/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmHostedServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmHostedServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -22,10 +23,13 @@ import com.github.klboke.kkrepo.persistence.jdbc.api.model.AssetBlobRecord;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.AssetRecord;
 import com.github.klboke.kkrepo.protocol.npm.NpmPackageId;
 import com.github.klboke.kkrepo.server.cache.AssetMetadataCache;
+import com.github.klboke.kkrepo.server.cache.CachedAssetMetadata;
 import com.github.klboke.kkrepo.server.maven.BlobStorageRegistry;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Base64;
@@ -258,11 +262,60 @@ class NpmHostedServiceTest {
     assertEquals(Map.of("stable", "1.0.0"), map(stored.get("dist-tags")));
   }
 
+  @Test
+  void readsPackageRootFromResolvedSnapshotAndRewritesServedTarballUrl() throws Exception {
+    Fixture fixture = fixture();
+    String json = """
+        {"name":"demo","dist-tags":{"latest":"1.0.0"},"versions":{
+          "1.0.0":{"name":"demo","version":"1.0.0",
+            "dist":{"tarball":"https://registry.npmjs.org/demo/-/demo-1.0.0.tgz"}}
+        }}
+        """;
+    CachedAssetMetadata snapshot = packageSnapshot(json);
+    when(fixture.storage.get(any())).thenReturn(Optional.of(
+        new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))));
+
+    assertEquals("demo", fixture.service.packageRoot(snapshot).orElseThrow().get("name"));
+
+    stubPackageRoot(fixture, json);
+    String served = new String(fixture.service.getPackage(
+        runtime("ALLOW", 7L), PACKAGE, "https://packages.example/npm", false)
+        .body().readAllBytes(), StandardCharsets.UTF_8);
+    assertEquals(true, served.contains(
+        "https://packages.example/npm/demo/-/demo-1.0.0.tgz"));
+  }
+
+  @Test
+  void snapshotPackageRootHandlesMissingMetadataBlobAndBody() {
+    Fixture fixture = fixture();
+    CachedAssetMetadata withoutBlob = CachedAssetMetadata.of(
+        packageAsset(3L, 1L), null);
+
+    assertEquals(Optional.empty(), fixture.service.packageRoot((CachedAssetMetadata) null));
+    assertEquals(Optional.empty(), fixture.service.packageRoot(withoutBlob));
+
+    CachedAssetMetadata snapshot = packageSnapshot("{}");
+    when(fixture.storage.get(any())).thenReturn(Optional.empty());
+    assertEquals(Optional.empty(), fixture.service.packageRoot(snapshot));
+  }
+
+  @Test
+  void snapshotPackageRootWrapsBlobReadFailure() throws Exception {
+    Fixture fixture = fixture();
+    InputStream broken = mock(InputStream.class);
+    when(broken.read(any(byte[].class), anyInt(), anyInt()))
+        .thenThrow(new IOException("broken blob"));
+    when(fixture.storage.get(any())).thenReturn(Optional.of(broken));
+
+    IllegalStateException error = assertThrows(
+        IllegalStateException.class,
+        () -> fixture.service.packageRoot(packageSnapshot("{}")));
+
+    assertEquals(true, error.getMessage().contains("Failed to read npm package root demo"));
+  }
+
   private static void stubPackageRoot(Fixture fixture, String json) {
-    AssetRecord asset = new AssetRecord(
-        1L, 10L, 2L, 3L, RepositoryFormat.NPM, "demo", null,
-        "demo", "package-root", "application/json", (long) json.length(),
-        null, Instant.EPOCH, Map.of());
+    AssetRecord asset = packageAsset(3L, (long) json.length());
     AssetBlobRecord blob = new AssetBlobRecord(
         3L, 7L, "blob://bucket/demo", null, "demo", null,
         "sha1", "sha256", "md5", (long) json.length(), "application/json",
@@ -271,6 +324,21 @@ class NpmHostedServiceTest {
     when(fixture.assetDao.findBlobById(3L)).thenReturn(Optional.of(blob));
     when(fixture.storage.get(any())).thenAnswer(invocation -> Optional.of(
         new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))));
+  }
+
+  private static CachedAssetMetadata packageSnapshot(String json) {
+    AssetBlobRecord blob = new AssetBlobRecord(
+        3L, 7L, "blob://bucket/demo", null, "demo", null,
+        "sha1", "sha256", "md5", (long) json.length(), "application/json",
+        "alice", null, Instant.EPOCH, Instant.EPOCH, Map.of());
+    return CachedAssetMetadata.of(packageAsset(3L, (long) json.length()), blob);
+  }
+
+  private static AssetRecord packageAsset(Long blobId, Long size) {
+    return new AssetRecord(
+        1L, 10L, 2L, blobId, RepositoryFormat.NPM, "demo", null,
+        "demo", "package-root", "application/json", size,
+        null, Instant.EPOCH, Map.of());
   }
 
   @SuppressWarnings("unchecked")

--- a/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmPackumentResponseWriterTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmPackumentResponseWriterTest.java
@@ -1,6 +1,7 @@
 package com.github.klboke.kkrepo.server.npm;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -27,9 +28,12 @@ class NpmPackumentResponseWriterTest {
 
     byte[] bytes = NpmPackumentResponseWriter.write(
         mapper, root, analysis, NOW, NpmPackumentVariant.FULL, PACKAGE, BASE);
+    Map<?, ?> response = mapper.readValue(bytes, Map.class);
 
-    assertEquals(expected, mapper.readValue(bytes, Map.class));
+    assertEquals(expected, response);
+    assertFalse(((Map<?, ?>) response.get("time")).containsKey("1.1.0"));
     assertTrue(NpmMetadata.versions(root).containsKey("1.1.0"));
+    assertTrue(((Map<?, ?>) root.get("time")).containsKey("1.1.0"));
     assertEquals(
         "https://registry.npmjs.org/demo/-/demo-1.0.0.tgz",
         tarball(NpmMetadata.versions(root).get("1.0.0")));

--- a/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmPackumentResponseWriterTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmPackumentResponseWriterTest.java
@@ -2,12 +2,19 @@ package com.github.klboke.kkrepo.server.npm;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.klboke.kkrepo.protocol.npm.NpmMetadata;
 import com.github.klboke.kkrepo.protocol.npm.NpmMinimumReleaseAge;
 import com.github.klboke.kkrepo.protocol.npm.NpmPackageId;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -53,6 +60,88 @@ class NpmPackumentResponseWriterTest {
     assertEquals(expected, mapper.readValue(bytes, Map.class));
   }
 
+  @Test
+  void writesUnfilteredAndNonStandardVersionShapesWithoutPolicy() throws Exception {
+    Map<String, Object> root = new LinkedHashMap<>();
+    root.put("name", "demo");
+    root.put("dist-tags", new LinkedHashMap<>(Map.of("latest", "1.0.0")));
+    root.put("time", new LinkedHashMap<>(Map.of("1.0.0", "not-a-timestamp")));
+    Map<String, Object> versions = new LinkedHashMap<>();
+    versions.put("1.0.0", "legacy-version-shape");
+    versions.put("2.0.0", new LinkedHashMap<>(Map.of(
+        "name", "demo",
+        "version", "2.0.0",
+        "dist", "legacy-dist-shape")));
+    root.put("versions", versions);
+
+    byte[] bytes = NpmPackumentResponseWriter.write(
+        mapper, root, null, NOW, NpmPackumentVariant.FULL, PACKAGE, BASE);
+
+    assertEquals(root, mapper.readValue(bytes, Map.class));
+  }
+
+  @Test
+  void preservesUnrewritableTarballsAndReusesExistingInstallFlag() throws Exception {
+    Map<String, Object> root = new LinkedHashMap<>();
+    root.put("name", "demo");
+    root.put("dist-tags", Map.of());
+    Map<String, Object> versions = new LinkedHashMap<>();
+    versions.put("null-tarball", versionWithTarball(null));
+    versions.put("empty-tarball", versionWithTarball(""));
+    versions.put("blank-base", versionWithTarball(
+        "https://registry.npmjs.org/demo/-/demo-blank-base.tgz"));
+    Map<String, Object> flagged = versionWithTarball(
+        "https://registry.npmjs.org/demo/-/demo-flagged.tgz");
+    flagged.put("hasInstallScript", false);
+    flagged.put("scripts", Map.of("install", "node install.js"));
+    versions.put("flagged", flagged);
+    root.put("versions", versions);
+
+    Map<?, ?> response = mapper.readValue(NpmPackumentResponseWriter.write(
+        mapper, root, null, NOW, NpmPackumentVariant.INSTALL_V1, PACKAGE, " "), Map.class);
+    Map<?, ?> writtenVersions = (Map<?, ?>) response.get("versions");
+
+    assertEquals(null, tarball(writtenVersions.get("null-tarball")));
+    assertEquals("", tarball(writtenVersions.get("empty-tarball")));
+    assertEquals(
+        "https://registry.npmjs.org/demo/-/demo-blank-base.tgz",
+        tarball(writtenVersions.get("blank-base")));
+    assertEquals(false, ((Map<?, ?>) writtenVersions.get("flagged")).get("hasInstallScript"));
+  }
+
+  @Test
+  void handlesNullBaseAndRemovesOneTrailingSlashWhenRewriting() throws Exception {
+    Map<String, Object> root = packument();
+
+    Map<?, ?> unchanged = mapper.readValue(NpmPackumentResponseWriter.write(
+        mapper, root, null, NOW, NpmPackumentVariant.FULL, PACKAGE, null), Map.class);
+    Map<?, ?> rewritten = mapper.readValue(NpmPackumentResponseWriter.write(
+        mapper, root, null, NOW, NpmPackumentVariant.FULL, PACKAGE, BASE + "/"), Map.class);
+
+    assertEquals(
+        "https://registry.npmjs.org/demo/-/demo-1.0.0.tgz",
+        tarball(((Map<?, ?>) unchanged.get("versions")).get("1.0.0")));
+    assertEquals(
+        BASE + "/demo/-/demo-1.0.0.tgz",
+        tarball(((Map<?, ?>) rewritten.get("versions")).get("1.0.0")));
+  }
+
+  @Test
+  void wrapsJsonGeneratorCreationFailure() throws Exception {
+    ObjectMapper brokenMapper = mock(ObjectMapper.class);
+    JsonFactory factory = mock(JsonFactory.class);
+    when(brokenMapper.getFactory()).thenReturn(factory);
+    when(factory.createGenerator(any(OutputStream.class)))
+        .thenThrow(new IOException("generator unavailable"));
+
+    IllegalStateException error = assertThrows(IllegalStateException.class,
+        () -> NpmPackumentResponseWriter.write(
+            brokenMapper, packument(), null, NOW, NpmPackumentVariant.FULL, PACKAGE, BASE));
+
+    assertEquals("Failed to serialize npm packument", error.getMessage());
+    assertTrue(error.getCause() instanceof IOException);
+  }
+
   private static Map<String, Object> packument() {
     Map<String, Object> root = new LinkedHashMap<>();
     root.put("name", "demo");
@@ -81,9 +170,21 @@ class NpmPackumentResponseWriterTest {
     return document;
   }
 
+  private static Map<String, Object> versionWithTarball(Object tarball) {
+    Map<String, Object> document = new LinkedHashMap<>();
+    document.put("name", "demo");
+    document.put("version", "1.0.0");
+    Map<String, Object> dist = new LinkedHashMap<>();
+    dist.put("tarball", tarball);
+    dist.put("shasum", "0".repeat(40));
+    document.put("dist", dist);
+    return document;
+  }
+
   @SuppressWarnings("unchecked")
   private static String tarball(Object rawVersion) {
     Map<String, Object> version = (Map<String, Object>) rawVersion;
-    return ((Map<String, Object>) version.get("dist")).get("tarball").toString();
+    Object tarball = ((Map<String, Object>) version.get("dist")).get("tarball");
+    return tarball == null ? null : tarball.toString();
   }
 }

--- a/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmPackumentResponseWriterTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmPackumentResponseWriterTest.java
@@ -1,0 +1,85 @@
+package com.github.klboke.kkrepo.server.npm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.klboke.kkrepo.protocol.npm.NpmMetadata;
+import com.github.klboke.kkrepo.protocol.npm.NpmMinimumReleaseAge;
+import com.github.klboke.kkrepo.protocol.npm.NpmPackageId;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class NpmPackumentResponseWriterTest {
+  private static final Instant NOW = Instant.parse("2026-07-19T12:00:00Z");
+  private static final NpmPackageId PACKAGE = NpmPackageId.parse("demo");
+  private static final String BASE = "https://packages.example/repository/npm";
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void fullProjectionMatchesCopyFilterAndRewriteWithoutMutatingSource() throws Exception {
+    Map<String, Object> root = packument();
+    NpmMinimumReleaseAge.Analysis analysis = NpmMinimumReleaseAge.analyze(root, 60);
+    Map<String, Object> expected = analysis.filter(root, NOW);
+    NpmMetadata.rewriteTarballUrls(expected, PACKAGE, BASE);
+
+    byte[] bytes = NpmPackumentResponseWriter.write(
+        mapper, root, analysis, NOW, NpmPackumentVariant.FULL, PACKAGE, BASE);
+
+    assertEquals(expected, mapper.readValue(bytes, Map.class));
+    assertTrue(NpmMetadata.versions(root).containsKey("1.1.0"));
+    assertEquals(
+        "https://registry.npmjs.org/demo/-/demo-1.0.0.tgz",
+        tarball(NpmMetadata.versions(root).get("1.0.0")));
+  }
+
+  @Test
+  void installProjectionMatchesExistingAbbreviatedSemanticsInOneWritePass() throws Exception {
+    Map<String, Object> root = packument();
+    NpmMinimumReleaseAge.Analysis analysis = NpmMinimumReleaseAge.analyze(root, 60);
+    Map<String, Object> expected = NpmMetadata.abbreviatePackageRoot(root);
+    analysis.filterPreparedCopy(expected, NOW);
+    NpmMetadata.rewriteTarballUrls(expected, PACKAGE, BASE);
+
+    byte[] bytes = NpmPackumentResponseWriter.write(
+        mapper, root, analysis, NOW, NpmPackumentVariant.INSTALL_V1, PACKAGE, BASE);
+
+    assertEquals(expected, mapper.readValue(bytes, Map.class));
+  }
+
+  private static Map<String, Object> packument() {
+    Map<String, Object> root = new LinkedHashMap<>();
+    root.put("name", "demo");
+    root.put("readme", "large root readme");
+    root.put("dist-tags", new LinkedHashMap<>(Map.of("latest", "1.1.0")));
+    root.put("time", new LinkedHashMap<>(Map.of(
+        "1.0.0", "2026-07-18T12:00:00Z",
+        "1.1.0", "2026-07-19T11:30:01Z")));
+    Map<String, Object> versions = new LinkedHashMap<>();
+    versions.put("1.0.0", version("1.0.0"));
+    versions.put("1.1.0", version("1.1.0"));
+    root.put("versions", versions);
+    return root;
+  }
+
+  private static Map<String, Object> version(String version) {
+    Map<String, Object> document = new LinkedHashMap<>();
+    document.put("name", "demo");
+    document.put("version", version);
+    document.put("readme", "large version readme");
+    document.put("scripts", Map.of("install", "node install.js"));
+    document.put("dependencies", Map.of("left-pad", "^1.3.0"));
+    document.put("dist", new LinkedHashMap<>(Map.of(
+        "tarball", "https://registry.npmjs.org/demo/-/demo-" + version + ".tgz",
+        "shasum", "0".repeat(40))));
+    return document;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static String tarball(Object rawVersion) {
+    Map<String, Object> version = (Map<String, Object>) rawVersion;
+    return ((Map<String, Object>) version.get("dist")).get("tarball").toString();
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmProxyRuntimeTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmProxyRuntimeTest.java
@@ -202,6 +202,67 @@ class NpmProxyRuntimeTest {
   }
 
   @Test
+  void minimumReleaseAgeAllowsSharedTarballWhenAnyIndexedVersionIsEligible() throws Exception {
+    Instant now = Instant.parse("2026-07-19T12:00:00Z");
+    Fixture fixture = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    RepositoryRuntime runtime = runtime(60, 7L, 60);
+    CachedAssetMetadata packageSnapshot = snapshot(
+        "demo", now, "package-root", Map.of("npmFullMetadata", "true"));
+    CachedAssetMetadata tarballSnapshot = snapshot(TARBALL_PATH, now, "tarball", Map.of());
+    when(fixture.cache.find(eq(10L), anyString(), any())).thenAnswer(invocation ->
+        Optional.of("demo".equals(invocation.getArgument(1))
+            ? packageSnapshot
+            : tarballSnapshot));
+    NpmReleaseIndexDao.TarballPolicy indexed = new NpmReleaseIndexDao.TarballPolicy(
+        new NpmReleaseIndexDao.Status(1L, 2L, true, 2, now),
+        false,
+        List.of(
+            new NpmReleaseIndexDao.Release(
+                0, "1.0.0", Instant.parse("2026-07-19T10:00:00Z"), null, TARBALL),
+            new NpmReleaseIndexDao.Release(
+                1, "1.1.0", Instant.parse("2026-07-19T11:30:01Z"), null, TARBALL)));
+    when(fixture.releaseIndexDao.findTarballPolicy(1L, 2L, TARBALL, null, null))
+        .thenReturn(Optional.of(indexed));
+    MavenResponse expected = MavenResponse.noBody(200);
+    when(fixture.hosted.getTarball(runtime, PACKAGE, TARBALL, false)).thenReturn(expected);
+
+    assertSame(expected, fixture.service.getTarball(runtime, PACKAGE, TARBALL, false));
+
+    verify(fixture.hosted, never()).packageRoot(any(CachedAssetMetadata.class));
+    verify(fixture.fetcher, never()).fetchWithBodyRetry(any(), anyString(), any());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void minimumReleaseAgeAllowsSharedTarballOnPackumentFallback() throws Exception {
+    Instant now = Instant.parse("2026-07-19T12:00:00Z");
+    Fixture fixture = fixtureWithoutReleaseIndex(Clock.fixed(now, ZoneOffset.UTC));
+    RepositoryRuntime runtime = runtime(60, 7L, 60);
+    CachedAssetMetadata packageSnapshot = snapshot(
+        "demo", now, "package-root", Map.of("npmFullMetadata", "true"));
+    CachedAssetMetadata tarballSnapshot = snapshot(TARBALL_PATH, now, "tarball", Map.of());
+    when(fixture.cache.find(eq(10L), anyString(), any())).thenAnswer(invocation ->
+        Optional.of("demo".equals(invocation.getArgument(1))
+            ? packageSnapshot
+            : tarballSnapshot));
+    Map<String, Object> root = new ObjectMapper().readValue("""
+        {"name":"demo","dist-tags":{"latest":"1.1.0"},
+         "time":{"1.0.0":"2026-07-19T10:00:00Z","1.1.0":"2026-07-19T11:30:01Z"},
+         "versions":{
+           "1.0.0":{"name":"demo","version":"1.0.0","dist":{"tarball":"https://registry.npmjs.org/demo/-/demo-1.0.0.tgz"}},
+           "1.1.0":{"name":"demo","version":"1.1.0","dist":{"tarball":"https://registry.npmjs.org/demo/-/demo-1.0.0.tgz"}}
+         }}
+        """, Map.class);
+    when(fixture.hosted.packageRoot(packageSnapshot)).thenReturn(Optional.of(root));
+    MavenResponse expected = MavenResponse.noBody(200);
+    when(fixture.hosted.getTarball(runtime, PACKAGE, TARBALL, false)).thenReturn(expected);
+
+    assertSame(expected, fixture.service.getTarball(runtime, PACKAGE, TARBALL, false));
+
+    verify(fixture.fetcher, never()).fetchWithBodyRetry(any(), anyString(), any());
+  }
+
+  @Test
   void minimumReleaseAgeUsesTargetedIndexWithoutLoadingPackumentBlob() throws Exception {
     Instant now = Instant.parse("2026-07-19T12:00:00Z");
     Instant lastVerified = Instant.parse("2026-07-19T11:59:00Z");
@@ -419,6 +480,14 @@ class NpmProxyRuntimeTest {
   }
 
   private static Fixture fixture(Clock clock) {
+    return fixture(clock, true);
+  }
+
+  private static Fixture fixtureWithoutReleaseIndex(Clock clock) {
+    return fixture(clock, false);
+  }
+
+  private static Fixture fixture(Clock clock, boolean releaseIndexEnabled) {
     AssetDao assetDao = mock(AssetDao.class);
     BlobStorageRegistry registry = mock(BlobStorageRegistry.class);
     NpmAssetWriter writer = mock(NpmAssetWriter.class);
@@ -427,7 +496,9 @@ class NpmProxyRuntimeTest {
     NpmHostedService hosted = mock(NpmHostedService.class);
     ProxyNegativeCache negativeCache = mock(ProxyNegativeCache.class);
     AssetMetadataCache cache = mock(AssetMetadataCache.class);
-    NpmReleaseIndexDao releaseIndexDao = mock(NpmReleaseIndexDao.class);
+    NpmReleaseIndexDao releaseIndexDao = releaseIndexEnabled
+        ? mock(NpmReleaseIndexDao.class)
+        : null;
     BlobStorage storage = mock(BlobStorage.class);
     return new Fixture(
         assetDao, registry, writer, proxyStateDao, fetcher, hosted, negativeCache, cache,

--- a/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmProxyRuntimeTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmProxyRuntimeTest.java
@@ -132,10 +132,13 @@ class NpmProxyRuntimeTest {
     Map<?, ?> body = new ObjectMapper().readValue(response.body(), Map.class);
     Map<?, ?> versions = (Map<?, ?>) body.get("versions");
     Map<?, ?> tags = (Map<?, ?>) body.get("dist-tags");
+    Map<?, ?> time = (Map<?, ?>) body.get("time");
 
     assertTrue(versions.containsKey("1.0.0"));
     assertFalse(versions.containsKey("1.1.0"));
     assertEquals("1.0.0", tags.get("latest"));
+    assertTrue(time.containsKey("1.0.0"));
+    assertFalse(time.containsKey("1.1.0"));
     ArgumentCaptor<HttpRemoteFetcher.Request> request =
         ArgumentCaptor.forClass(HttpRemoteFetcher.Request.class);
     verify(fixture.fetcher).fetchWithBodyRetry(request.capture(), eq("demo"), any());

--- a/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmProxyRuntimeTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmProxyRuntimeTest.java
@@ -469,6 +469,353 @@ class NpmProxyRuntimeTest {
         () -> noStore.service.getPackage(runtime(1, null), PACKAGE, "base", false));
   }
 
+  @Test
+  void compatibilityConstructorsDefaultReleaseAgeCollaborators() {
+    Fixture fixture = fixture();
+    NpmProxyService withClock = new NpmProxyService(
+        fixture.assetDao, fixture.registry, fixture.writer, fixture.proxyStateDao,
+        fixture.fetcher, fixture.hosted, new ObjectMapper(), fixture.negativeCache,
+        fixture.cache, null, Clock.systemUTC());
+    NpmProxyService withReleaseAgeCache = new NpmProxyService(
+        fixture.assetDao, fixture.registry, fixture.writer, fixture.proxyStateDao,
+        fixture.fetcher, fixture.hosted, new ObjectMapper(), fixture.negativeCache,
+        fixture.cache, null, new NpmReleaseAgeCache(16, 1024, 1), Clock.systemUTC());
+    NpmProxyService withDefaults = new NpmProxyService(
+        fixture.assetDao, fixture.registry, fixture.writer, fixture.proxyStateDao,
+        fixture.fetcher, fixture.hosted, new ObjectMapper(), fixture.negativeCache,
+        fixture.cache, null, null, fixture.releaseIndexDao, null);
+
+    assertTrue(withClock != null);
+    assertTrue(withReleaseAgeCache != null);
+    assertTrue(withDefaults != null);
+  }
+
+  @Test
+  void dispatchesEverySupportedGetKindAndRejectsUnknownPaths() {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(60, 7L);
+    CachedAssetMetadata packageRoot = snapshot("demo", Instant.now(), "package-root", Map.of());
+    CachedAssetMetadata tarball = snapshot(TARBALL_PATH, Instant.now(), "tarball", Map.of());
+    when(fixture.cache.find(eq(10L), anyString(), any())).thenAnswer(invocation ->
+        Optional.of(TARBALL_PATH.equals(invocation.getArgument(1)) ? tarball : packageRoot));
+    MavenResponse packageResponse = MavenResponse.noBody(200);
+    MavenResponse tarballResponse = MavenResponse.noBody(200);
+    MavenResponse tagsResponse = MavenResponse.noBody(200);
+    when(fixture.hosted.getPackage(
+        runtime, PACKAGE, "base", false, NpmPackumentVariant.FULL)).thenReturn(packageResponse);
+    when(fixture.hosted.getPackage(
+        runtime, PACKAGE, runtime.name(), true, NpmPackumentVariant.FULL))
+        .thenReturn(packageResponse);
+    when(fixture.hosted.getTarball(runtime, PACKAGE, TARBALL, false)).thenReturn(tarballResponse);
+    when(fixture.hosted.getDistTags(runtime, PACKAGE, false)).thenReturn(tagsResponse);
+
+    assertSame(packageResponse, fixture.service.get(runtime,
+        path(NpmPath.Kind.PACKAGE_ROOT, null), "base", false));
+    assertSame(packageResponse, fixture.service.get(runtime,
+        path(NpmPath.Kind.PACKAGE_VERSION, null), "base", false));
+    assertSame(tarballResponse, fixture.service.get(runtime,
+        path(NpmPath.Kind.TARBALL, TARBALL), "base", false));
+    assertSame(tagsResponse, fixture.service.get(runtime,
+        path(NpmPath.Kind.DIST_TAGS, null), "base", false));
+    assertThrows(NpmExceptions.NpmNotFoundException.class, () -> fixture.service.get(
+        runtime, path(NpmPath.Kind.UNKNOWN, null), "base", false));
+  }
+
+  @Test
+  void searchReturnsEmptyResultOnRemoteFailureOrIoAndValidatesRuntime() throws Exception {
+    RepositoryRuntime runtime = runtime(60, 7L);
+    Fixture failed = fixture();
+    respond(failed.fetcher, new HttpRemoteFetcher.Result(
+        503, Map.of(), new ByteArrayInputStream(new byte[0])));
+
+    assertThrows(NpmExceptions.BadUpstreamException.class,
+        () -> failed.service.search(runtime, null, 0));
+    verify(failed.proxyStateDao).recordFailure(eq(10L), eq(30L), anyString(), any());
+
+    Fixture io = fixture();
+    failWithIo(io.fetcher, "search unavailable");
+    assertThrows(NpmExceptions.BadUpstreamException.class,
+        () -> io.service.search(runtime, "demo", 10));
+    verify(io.proxyStateDao).recordFailure(eq(10L), eq(30L), anyString(), any());
+
+    assertThrows(IllegalStateException.class,
+        () -> io.service.search(hostedRuntime(), "demo", 10));
+  }
+
+  @Test
+  void nonPolicyRequestsHonorNegativeCacheAndBlockedUpstreamFallbacks() throws Exception {
+    RepositoryRuntime runtime = runtime(60, 7L);
+
+    Fixture negative = fixture();
+    when(negative.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.empty());
+    when(negative.negativeCache.isNotFoundCached(runtime, "demo")).thenReturn(true);
+    assertThrows(NpmExceptions.NpmNotFoundException.class,
+        () -> negative.service.getPackage(runtime, PACKAGE, "base", false));
+
+    Fixture blockedMiss = fixture();
+    when(blockedMiss.cache.find(eq(10L), anyString(), any())).thenReturn(Optional.empty());
+    when(blockedMiss.proxyStateDao.isBlocked(eq(10L), any())).thenReturn(true);
+    assertThrows(NpmExceptions.BadUpstreamException.class,
+        () -> blockedMiss.service.getPackage(runtime, PACKAGE, "base", false));
+    assertThrows(NpmExceptions.BadUpstreamException.class,
+        () -> blockedMiss.service.getTarball(runtime, PACKAGE, TARBALL, false));
+
+    Fixture blockedCached = fixture();
+    CachedAssetMetadata stalePackage = snapshot("demo", Instant.EPOCH, "package-root", Map.of());
+    CachedAssetMetadata staleTarball = snapshot(TARBALL_PATH, Instant.EPOCH, "tarball", Map.of());
+    when(blockedCached.cache.find(eq(10L), anyString(), any())).thenAnswer(invocation ->
+        Optional.of(TARBALL_PATH.equals(invocation.getArgument(1)) ? staleTarball : stalePackage));
+    when(blockedCached.proxyStateDao.isBlocked(eq(10L), any())).thenReturn(true);
+    MavenResponse packageResponse = MavenResponse.noBody(200);
+    MavenResponse tarballResponse = MavenResponse.noBody(200);
+    when(blockedCached.hosted.getPackage(
+        runtime, PACKAGE, "base", false, NpmPackumentVariant.FULL)).thenReturn(packageResponse);
+    when(blockedCached.hosted.getTarball(runtime, PACKAGE, TARBALL, false))
+        .thenReturn(tarballResponse);
+
+    assertSame(packageResponse,
+        blockedCached.service.getPackage(runtime, PACKAGE, "base", false));
+    assertSame(tarballResponse,
+        blockedCached.service.getTarball(runtime, PACKAGE, TARBALL, false));
+  }
+
+  @Test
+  void policyHeadResponsesAndTransitionLookupUseCachedFullMetadata() throws Exception {
+    Instant now = Instant.parse("2026-07-19T12:00:00Z");
+    Fixture fixture = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    RepositoryRuntime policyRuntime = runtime(60, 7L, 60);
+    CachedAssetMetadata snapshot = snapshot(
+        "demo", now, "package-root", Map.of("npmFullMetadata", "true"));
+    when(fixture.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.of(snapshot));
+    when(fixture.hosted.packageRoot(snapshot)).thenReturn(Optional.of(packument(
+        "1.0.0", "2026-07-19T11:30:00Z")));
+
+    MavenResponse packageHead = fixture.service.getPackage(
+        policyRuntime, PACKAGE, "base", true);
+    MavenResponse tagsHead = fixture.service.getDistTags(policyRuntime, PACKAGE, true);
+
+    assertEquals(200, packageHead.status());
+    assertEquals(null, packageHead.body());
+    assertEquals(200, tagsHead.status());
+    assertEquals(
+        Instant.parse("2026-07-19T12:30:00Z"),
+        fixture.service.nextPolicyTransition(policyRuntime, PACKAGE, now).orElseThrow());
+    assertTrue(fixture.service.nextPolicyTransition(runtime(60, 7L), PACKAGE, now).isEmpty());
+  }
+
+  @Test
+  void policyResolutionHonorsNegativeCacheAndBothBlockedCacheStates() throws Exception {
+    Instant now = Instant.parse("2026-07-19T12:00:00Z");
+    RepositoryRuntime runtime = runtime(60, 7L, 60);
+
+    Fixture negative = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    when(negative.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.empty());
+    when(negative.negativeCache.isNotFoundCached(runtime, "demo")).thenReturn(true);
+    assertThrows(NpmExceptions.NpmNotFoundException.class,
+        () -> negative.service.getPackage(runtime, PACKAGE, "base", false));
+
+    Fixture blockedMiss = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    when(blockedMiss.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.empty());
+    when(blockedMiss.proxyStateDao.isBlocked(10L, now)).thenReturn(true);
+    assertThrows(NpmExceptions.BadUpstreamException.class,
+        () -> blockedMiss.service.getPackage(runtime, PACKAGE, "base", false));
+
+    Fixture blockedStale = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    CachedAssetMetadata stale = snapshot(
+        "demo", Instant.EPOCH, "package-root", Map.of("npmFullMetadata", "true"));
+    when(blockedStale.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.of(stale));
+    when(blockedStale.proxyStateDao.isBlocked(10L, now)).thenReturn(true);
+    when(blockedStale.hosted.packageRoot(stale)).thenReturn(Optional.of(packument(
+        "1.0.0", "2026-07-19T10:00:00Z")));
+    assertEquals(200, blockedStale.service.getPackage(runtime, PACKAGE, "base", false).status());
+
+    Fixture blockedLoaded = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    CachedAssetMetadata fresh = snapshot("demo", now, "package-root", Map.of());
+    Map<String, Object> incomplete = packument("1.0.0", "2026-07-19T10:00:00Z");
+    incomplete.remove("time");
+    when(blockedLoaded.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.of(fresh));
+    when(blockedLoaded.hosted.packageRoot(fresh)).thenReturn(Optional.of(incomplete));
+    when(blockedLoaded.proxyStateDao.isBlocked(10L, now)).thenReturn(true);
+    assertEquals(200, blockedLoaded.service.getPackage(runtime, PACKAGE, "base", false).status());
+  }
+
+  @Test
+  void policyRemoteNotModifiedAndErrorStatusesUseSafeFallbacks() throws Exception {
+    Instant now = Instant.parse("2026-07-19T12:00:00Z");
+    RepositoryRuntime runtime = runtime(1, 7L, 60);
+    CachedAssetMetadata stale = snapshot(
+        "demo", Instant.EPOCH, "package-root", Map.of("npmFullMetadata", "true"));
+
+    Fixture notModified = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    when(notModified.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.of(stale));
+    when(notModified.hosted.packageRoot(stale)).thenReturn(Optional.of(packument(
+        "1.0.0", "2026-07-19T10:00:00Z")));
+    respond(notModified.fetcher, new HttpRemoteFetcher.Result(
+        304, Map.of(), new ByteArrayInputStream(new byte[0])));
+    assertEquals(200, notModified.service.getPackage(runtime, PACKAGE, "base", false).status());
+    verify(notModified.assetDao).touchAssetLastUpdated(1L, now);
+
+    Fixture removedCached = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    when(removedCached.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.of(stale));
+    when(removedCached.hosted.packageRoot(stale)).thenReturn(Optional.of(packument(
+        "1.0.0", "2026-07-19T10:00:00Z")));
+    respond(removedCached.fetcher, new HttpRemoteFetcher.Result(
+        404, Map.of(), new ByteArrayInputStream(new byte[0])));
+    assertEquals(200, removedCached.service.getPackage(runtime, PACKAGE, "base", false).status());
+
+    Fixture gone = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    when(gone.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.empty());
+    respond(gone.fetcher, new HttpRemoteFetcher.Result(
+        410, Map.of(), new ByteArrayInputStream(new byte[0])));
+    assertThrows(NpmExceptions.NpmNotFoundException.class,
+        () -> gone.service.getPackage(runtime, PACKAGE, "base", false));
+
+    Fixture unavailable = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    when(unavailable.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.empty());
+    respond(unavailable.fetcher, new HttpRemoteFetcher.Result(
+        503, Map.of(), new ByteArrayInputStream(new byte[0])));
+    assertThrows(NpmExceptions.BadUpstreamException.class,
+        () -> unavailable.service.getPackage(runtime, PACKAGE, "base", false));
+  }
+
+  @Test
+  void policyRemoteIoFallsBackOnlyWhenCachedMetadataExists() throws Exception {
+    Instant now = Instant.parse("2026-07-19T12:00:00Z");
+    RepositoryRuntime runtime = runtime(1, 7L, 60);
+    CachedAssetMetadata stale = snapshot(
+        "demo", Instant.EPOCH, "package-root", Map.of("npmFullMetadata", "true"));
+
+    Fixture cached = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    when(cached.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.of(stale));
+    when(cached.hosted.packageRoot(stale)).thenReturn(Optional.of(packument(
+        "1.0.0", "2026-07-19T10:00:00Z")));
+    failWithIo(cached.fetcher, "metadata unavailable");
+    assertEquals(200, cached.service.getPackage(runtime, PACKAGE, "base", false).status());
+
+    Fixture miss = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    when(miss.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.empty());
+    failWithIo(miss.fetcher, "metadata unavailable");
+    assertThrows(NpmExceptions.BadUpstreamException.class,
+        () -> miss.service.getPackage(runtime, PACKAGE, "base", false));
+  }
+
+  @Test
+  void indexedTarballPolicyRejectsUnknownRowsAndFallsBackWhenIncomplete() {
+    Instant now = Instant.parse("2026-07-19T12:00:00Z");
+    RepositoryRuntime runtime = runtime(60, 7L, 60);
+
+    Fixture emptyRows = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    CachedAssetMetadata verified = snapshot(
+        "demo", now, "package-root", Map.of("npmFullMetadata", "true"));
+    when(emptyRows.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.of(verified));
+    when(emptyRows.releaseIndexDao.findTarballPolicy(1L, 2L, TARBALL, null, null))
+        .thenReturn(Optional.of(new NpmReleaseIndexDao.TarballPolicy(
+            new NpmReleaseIndexDao.Status(1L, 2L, true, 0, now), false, List.of())));
+    assertThrows(NpmExceptions.ReleaseAgeDenied.class,
+        () -> emptyRows.service.getTarball(runtime, PACKAGE, TARBALL, false));
+
+    Fixture incomplete = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    CachedAssetMetadata unverified = snapshot("demo", now, "package-root", Map.of());
+    when(incomplete.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.of(unverified));
+    when(incomplete.releaseIndexDao.findTarballPolicy(1L, 2L, TARBALL, null, null))
+        .thenReturn(Optional.of(new NpmReleaseIndexDao.TarballPolicy(
+            new NpmReleaseIndexDao.Status(1L, 2L, false, 0, now), false, List.of())));
+    when(incomplete.hosted.packageRoot(unverified)).thenReturn(Optional.of(new LinkedHashMap<>(Map.of(
+        "name", "demo", "versions", new LinkedHashMap<>()))));
+    when(incomplete.proxyStateDao.isBlocked(10L, now)).thenReturn(true);
+    assertThrows(NpmExceptions.ReleaseAgeDenied.class,
+        () -> incomplete.service.getTarball(runtime, PACKAGE, TARBALL, false));
+  }
+
+  @Test
+  void indexedSnapshotAvoidsRebuildingAnalysisButStillWritesPackumentBody() throws Exception {
+    Instant now = Instant.parse("2026-07-19T12:00:00Z");
+    Fixture fixture = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    RepositoryRuntime runtime = runtime(60, 7L, 60);
+    CachedAssetMetadata metadata = snapshot(
+        "demo", now, "package-root", Map.of("npmFullMetadata", "true"));
+    when(fixture.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.of(metadata));
+    when(fixture.releaseIndexDao.findSnapshot(1L, 2L)).thenReturn(Optional.of(
+        new NpmReleaseIndexDao.Snapshot(
+            new NpmReleaseIndexDao.Status(1L, 2L, true, 1, now),
+            List.of(new NpmReleaseIndexDao.Release(
+                0, "1.0.0", Instant.parse("2026-07-19T10:00:00Z"), null, TARBALL)))));
+    when(fixture.hosted.packageRoot(metadata)).thenReturn(Optional.of(packument(
+        "1.0.0", "2026-07-19T10:00:00Z")));
+
+    assertEquals(200, fixture.service.getPackage(runtime, PACKAGE, "base", false).status());
+    verify(fixture.releaseIndexDao, never()).replaceIfCurrent(
+        eq(1L), eq(2L), any(Boolean.class), any(), any());
+  }
+
+  @Test
+  void indexedTarballDenialReportsEarliestKnownAvailabilityOrUnknownTime() {
+    Instant now = Instant.parse("2026-07-19T12:00:00Z");
+    RepositoryRuntime runtime = runtime(60, 7L, 60);
+    CachedAssetMetadata metadata = snapshot(
+        "demo", now, "package-root", Map.of("npmFullMetadata", "true"));
+
+    Fixture ordered = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    when(ordered.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.of(metadata));
+    when(ordered.releaseIndexDao.findTarballPolicy(1L, 2L, TARBALL, null, null))
+        .thenReturn(Optional.of(new NpmReleaseIndexDao.TarballPolicy(
+            new NpmReleaseIndexDao.Status(1L, 2L, true, 3, now),
+            false,
+            List.of(
+                new NpmReleaseIndexDao.Release(
+                    0, "unknown", null, "missing-publish-time", TARBALL),
+                new NpmReleaseIndexDao.Release(
+                    1, "1.0.0", Instant.parse("2026-07-19T11:30:00Z"), null, TARBALL),
+                new NpmReleaseIndexDao.Release(
+                    2, "2.0.0", Instant.parse("2026-07-19T11:45:00Z"), null, TARBALL)))));
+
+    NpmExceptions.ReleaseAgeDenied known = assertThrows(
+        NpmExceptions.ReleaseAgeDenied.class,
+        () -> ordered.service.getTarball(runtime, PACKAGE, TARBALL, false));
+    assertTrue(known.getMessage().contains("until 2026-07-19T12:30:00Z"));
+
+    Fixture unknown = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    when(unknown.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.of(metadata));
+    when(unknown.releaseIndexDao.findTarballPolicy(1L, 2L, TARBALL, null, null))
+        .thenReturn(Optional.of(new NpmReleaseIndexDao.TarballPolicy(
+            new NpmReleaseIndexDao.Status(1L, 2L, true, 1, now),
+            false,
+            List.of(new NpmReleaseIndexDao.Release(
+                0, "unknown", null, "missing-publish-time", TARBALL)))));
+
+    NpmExceptions.ReleaseAgeDenied missing = assertThrows(
+        NpmExceptions.ReleaseAgeDenied.class,
+        () -> unknown.service.getTarball(runtime, PACKAGE, TARBALL, false));
+    assertTrue(missing.getMessage().contains("unknown (missing or invalid publish time)"));
+  }
+
+  @Test
+  void legacyIndexBackfillAndCachedAnalysisFailWhenPackageBlobIsMissing() {
+    Instant now = Instant.parse("2026-07-19T12:00:00Z");
+    RepositoryRuntime runtime = runtime(60, 7L, 60);
+    CachedAssetMetadata metadata = snapshot(
+        "demo", now, "package-root", Map.of("npmFullMetadata", "true"));
+
+    Fixture backfill = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    when(backfill.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.of(metadata));
+    when(backfill.releaseIndexDao.findTarballPolicy(1L, 2L, TARBALL, null, null))
+        .thenReturn(Optional.empty());
+    when(backfill.hosted.packageRoot(metadata)).thenReturn(Optional.empty());
+    IllegalStateException backfillError = assertThrows(
+        IllegalStateException.class,
+        () -> backfill.service.getTarball(runtime, PACKAGE, TARBALL, false));
+    assertTrue(backfillError.getMessage().contains("Cached npm package root blob is missing"));
+
+    Fixture analysis = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    when(analysis.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.of(metadata));
+    when(analysis.releaseIndexDao.findSnapshot(1L, 2L)).thenReturn(Optional.empty());
+    when(analysis.hosted.packageRoot(metadata)).thenReturn(Optional.empty());
+    IllegalStateException analysisError = assertThrows(
+        IllegalStateException.class,
+        () -> analysis.service.getPackage(runtime, PACKAGE, "base", false));
+    assertTrue(analysisError.getMessage().contains("Cached npm package root blob is missing"));
+  }
+
   private static void respond(HttpRemoteFetcher fetcher, HttpRemoteFetcher.Result result)
       throws IOException {
     doAnswer(invocation -> {
@@ -476,6 +823,16 @@ class NpmProxyRuntimeTest {
       HttpRemoteFetcher.ResultHandler<Object> handler = invocation.getArgument(2);
       return handler.handle(result);
     }).when(fetcher).fetchWithBodyRetry(any(), anyString(), any());
+  }
+
+  private static void failWithIo(HttpRemoteFetcher fetcher, String message) throws IOException {
+    doAnswer(invocation -> {
+      throw new IOException(message);
+    }).when(fetcher).fetchWithBodyRetry(any(), anyString(), any());
+  }
+
+  private static NpmPath path(NpmPath.Kind kind, String tarballName) {
+    return new NpmPath(kind, "demo", PACKAGE, null, tarballName, null, null);
   }
 
   private static Fixture fixture() {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmProxyRuntimeTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmProxyRuntimeTest.java
@@ -1,6 +1,7 @@
 package com.github.klboke.kkrepo.server.npm;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -18,10 +19,12 @@ import com.github.klboke.kkrepo.core.BlobStorage;
 import com.github.klboke.kkrepo.core.RepositoryFormat;
 import com.github.klboke.kkrepo.core.RepositoryType;
 import com.github.klboke.kkrepo.persistence.jdbc.api.AssetDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.NpmReleaseIndexDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.ProxyStateDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.AssetBlobRecord;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.AssetRecord;
 import com.github.klboke.kkrepo.protocol.npm.NpmPackageId;
+import com.github.klboke.kkrepo.protocol.npm.NpmMinimumReleaseAge;
 import com.github.klboke.kkrepo.protocol.npm.NpmPath;
 import com.github.klboke.kkrepo.server.cache.AssetMetadataCache;
 import com.github.klboke.kkrepo.server.cache.CachedAssetMetadata;
@@ -33,11 +36,15 @@ import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class NpmProxyRuntimeTest {
   private static final NpmPackageId PACKAGE = NpmPackageId.parse("demo");
@@ -95,6 +102,219 @@ class NpmProxyRuntimeTest {
     assertEquals("application/json", response.contentType());
     verify(fixture.proxyStateDao).recordSuccess(eq(10L), any());
     verify(fixture.negativeCache).invalidate(runtime, "demo");
+  }
+
+  @Test
+  void minimumReleaseAgeFiltersPackumentRewindsLatestAndRequestsFullMetadata() throws Exception {
+    Instant now = Instant.parse("2026-07-19T12:00:00Z");
+    Fixture fixture = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    RepositoryRuntime runtime = runtime(1, 7L, 60);
+    when(fixture.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.empty());
+    when(fixture.registry.forBlobStoreId(7L)).thenReturn(fixture.storage);
+    respond(fixture.fetcher, new HttpRemoteFetcher.Result(
+        200, Map.of("Content-Type", "application/json"),
+        new ByteArrayInputStream("""
+            {"name":"demo","dist-tags":{"latest":"1.1.0"},
+             "time":{"1.0.0":"2026-07-18T12:00:00Z","1.1.0":"2026-07-19T11:30:01Z"},
+             "versions":{
+               "1.0.0":{"name":"demo","version":"1.0.0","dist":{"tarball":"https://registry.npmjs.org/demo/-/demo-1.0.0.tgz"}},
+               "1.1.0":{"name":"demo","version":"1.1.0","dist":{"tarball":"https://registry.npmjs.org/demo/-/demo-1.1.0.tgz"}}
+             }}
+            """.getBytes(StandardCharsets.UTF_8))));
+    when(fixture.writer.writePackageRoot(
+        eq(runtime), eq(fixture.storage), eq(7L), eq(PACKAGE), any(),
+        eq("proxy"), eq(runtime.proxyRemoteUrl()), any(),
+        any(NpmMinimumReleaseAge.ReleaseIndex.class)))
+        .thenAnswer(invocation -> stored(
+            "demo", "package-root", "application/json", invocation.getArgument(7)));
+
+    MavenResponse response = fixture.service.getPackage(runtime, PACKAGE, "base", false);
+    Map<?, ?> body = new ObjectMapper().readValue(response.body(), Map.class);
+    Map<?, ?> versions = (Map<?, ?>) body.get("versions");
+    Map<?, ?> tags = (Map<?, ?>) body.get("dist-tags");
+
+    assertTrue(versions.containsKey("1.0.0"));
+    assertFalse(versions.containsKey("1.1.0"));
+    assertEquals("1.0.0", tags.get("latest"));
+    ArgumentCaptor<HttpRemoteFetcher.Request> request =
+        ArgumentCaptor.forClass(HttpRemoteFetcher.Request.class);
+    verify(fixture.fetcher).fetchWithBodyRetry(request.capture(), eq("demo"), any());
+    assertEquals("application/json", request.getValue().accept());
+  }
+
+  @Test
+  void minimumReleaseAgeBlocksDirectCachedTarballRequests() {
+    Instant now = Instant.parse("2026-07-19T12:00:00Z");
+    Fixture fixture = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    RepositoryRuntime runtime = runtime(60, 7L, 60);
+    CachedAssetMetadata packageSnapshot = snapshot("demo", now, "package-root", Map.of());
+    when(fixture.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.of(packageSnapshot));
+    when(fixture.hosted.packageRoot(packageSnapshot)).thenReturn(Optional.of(packument(
+        "1.0.0", "2026-07-19T11:30:01Z")));
+    NpmReleaseIndexDao.TarballPolicy indexed = new NpmReleaseIndexDao.TarballPolicy(
+        new NpmReleaseIndexDao.Status(1L, 2L, true, 1, now),
+        false,
+        List.of(new NpmReleaseIndexDao.Release(
+            0, "1.0.0", Instant.parse("2026-07-19T11:30:01Z"), null, TARBALL)));
+    when(fixture.releaseIndexDao.findTarballPolicy(1L, 2L, TARBALL, null, null))
+        .thenReturn(Optional.empty(), Optional.of(indexed), Optional.of(indexed));
+
+    NpmExceptions.ReleaseAgeDenied denied = null;
+    for (int attempt = 0; attempt < 2; attempt++) {
+      denied = assertThrows(
+          NpmExceptions.ReleaseAgeDenied.class,
+          () -> fixture.service.getTarball(runtime, PACKAGE, TARBALL, false));
+    }
+
+    assertTrue(denied.getMessage().contains("until 2026-07-19T12:30:01Z"));
+    verify(fixture.hosted).packageRoot(packageSnapshot);
+    verify(fixture.hosted, never()).getTarball(runtime, PACKAGE, TARBALL, false);
+  }
+
+  @Test
+  void minimumReleaseAgeAllowsRepeatedCachedTarballWithoutReloadingPackument() throws Exception {
+    Instant now = Instant.parse("2026-07-19T12:00:00Z");
+    Fixture fixture = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    RepositoryRuntime runtime = runtime(60, 7L, 60);
+    CachedAssetMetadata packageSnapshot = snapshot("demo", now, "package-root", Map.of());
+    CachedAssetMetadata tarballSnapshot = snapshot(TARBALL_PATH, now, "tarball", Map.of());
+    when(fixture.cache.find(eq(10L), anyString(), any())).thenAnswer(invocation ->
+        Optional.of("demo".equals(invocation.getArgument(1))
+            ? packageSnapshot
+            : tarballSnapshot));
+    when(fixture.hosted.packageRoot(packageSnapshot)).thenReturn(Optional.of(packument(
+        "1.0.0", "2026-07-19T10:00:00Z")));
+    NpmReleaseIndexDao.TarballPolicy indexed = new NpmReleaseIndexDao.TarballPolicy(
+        new NpmReleaseIndexDao.Status(1L, 2L, true, 1, now),
+        false,
+        List.of(new NpmReleaseIndexDao.Release(
+            0, "1.0.0", Instant.parse("2026-07-19T10:00:00Z"), null, TARBALL)));
+    when(fixture.releaseIndexDao.findTarballPolicy(1L, 2L, TARBALL, null, null))
+        .thenReturn(Optional.empty(), Optional.of(indexed), Optional.of(indexed));
+    MavenResponse expected = MavenResponse.noBody(200);
+    when(fixture.hosted.getTarball(runtime, PACKAGE, TARBALL, false)).thenReturn(expected);
+
+    assertSame(expected, fixture.service.getTarball(runtime, PACKAGE, TARBALL, false));
+    assertSame(expected, fixture.service.getTarball(runtime, PACKAGE, TARBALL, false));
+
+    verify(fixture.hosted).packageRoot(packageSnapshot);
+    verify(fixture.fetcher, never()).fetchWithBodyRetry(any(), anyString(), any());
+  }
+
+  @Test
+  void minimumReleaseAgeUsesTargetedIndexWithoutLoadingPackumentBlob() throws Exception {
+    Instant now = Instant.parse("2026-07-19T12:00:00Z");
+    Instant lastVerified = Instant.parse("2026-07-19T11:59:00Z");
+    Fixture fixture = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    RepositoryRuntime runtime = runtime(60, 7L, 60);
+    CachedAssetMetadata packageSnapshot = snapshot(
+        "demo", lastVerified, "package-root", Map.of("npmFullMetadata", "true"));
+    CachedAssetMetadata tarballSnapshot = snapshot(TARBALL_PATH, now, "tarball", Map.of());
+    when(fixture.cache.find(eq(10L), anyString(), any())).thenAnswer(invocation ->
+        Optional.of("demo".equals(invocation.getArgument(1))
+            ? packageSnapshot
+            : tarballSnapshot));
+    NpmReleaseIndexDao.Status status =
+        new NpmReleaseIndexDao.Status(1L, 2L, true, 1, lastVerified);
+    List<NpmReleaseIndexDao.Release> releases = List.of(new NpmReleaseIndexDao.Release(
+        0, "1.0.0", Instant.parse("2026-07-19T10:00:00Z"), null, TARBALL));
+    when(fixture.releaseIndexDao.findTarballPolicy(
+        1L, 2L, TARBALL,
+        Instant.parse("2026-07-19T10:59:00Z"),
+        Instant.parse("2026-07-19T11:00:00Z")))
+        .thenReturn(Optional.of(new NpmReleaseIndexDao.TarballPolicy(
+            status, false, releases)));
+    MavenResponse expected = MavenResponse.noBody(200);
+    when(fixture.hosted.getTarball(runtime, PACKAGE, TARBALL, false)).thenReturn(expected);
+
+    assertSame(expected, fixture.service.getTarball(runtime, PACKAGE, TARBALL, false));
+
+    verify(fixture.releaseIndexDao).findTarballPolicy(
+        1L, 2L, TARBALL,
+        Instant.parse("2026-07-19T10:59:00Z"),
+        Instant.parse("2026-07-19T11:00:00Z"));
+    verify(fixture.releaseIndexDao, never()).findStatus(eq(1L), eq(2L));
+    verify(fixture.releaseIndexDao, never()).hasMaturityBoundary(
+        eq(1L), eq(2L), any(), any());
+    verify(fixture.releaseIndexDao, never()).findByTarball(eq(1L), eq(2L), anyString());
+    verify(fixture.releaseIndexDao, never()).findSnapshot(eq(1L), eq(2L));
+    verify(fixture.hosted, never()).packageRoot(any(CachedAssetMetadata.class));
+    verify(fixture.fetcher, never()).fetchWithBodyRetry(any(), anyString(), any());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void minimumReleaseAgeAlsoFiltersDirectDistTagEndpoint() throws Exception {
+    Instant now = Instant.parse("2026-07-19T12:00:00Z");
+    Fixture fixture = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    RepositoryRuntime runtime = runtime(60, 7L, 60);
+    CachedAssetMetadata packageSnapshot = snapshot("demo", now, "package-root", Map.of());
+    Map<String, Object> raw = new ObjectMapper().readValue("""
+        {"name":"demo","dist-tags":{"latest":"2.0.0"},
+         "time":{"1.0.0":"2026-07-18T12:00:00Z","2.0.0":"2026-07-19T11:30:01Z"},
+         "versions":{
+           "1.0.0":{"name":"demo","version":"1.0.0","dist":{"tarball":"https://registry.npmjs.org/demo/-/demo-1.0.0.tgz"}},
+           "2.0.0":{"name":"demo","version":"2.0.0","dist":{"tarball":"https://registry.npmjs.org/demo/-/demo-2.0.0.tgz"}}
+         }}
+        """, Map.class);
+    when(fixture.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.of(packageSnapshot));
+    when(fixture.hosted.packageRoot(packageSnapshot)).thenReturn(Optional.of(raw));
+
+    MavenResponse response = fixture.service.getDistTags(runtime, PACKAGE, false);
+    Map<?, ?> tags = new ObjectMapper().readValue(response.body(), Map.class);
+    MavenResponse repeated = fixture.service.getDistTags(runtime, PACKAGE, false);
+
+    assertEquals("1.0.0", tags.get("latest"));
+    assertEquals(tags, new ObjectMapper().readValue(repeated.body(), Map.class));
+    verify(fixture.hosted).packageRoot(packageSnapshot);
+    verify(fixture.hosted, never()).getDistTags(runtime, PACKAGE, false);
+  }
+
+  @Test
+  void verifiedFullMetadataWithMissingTimesDoesNotForceRefetchOnEveryRequest() throws Exception {
+    Instant now = Instant.parse("2026-07-19T12:00:00Z");
+    Fixture fixture = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    RepositoryRuntime runtime = runtime(60, 7L, 60);
+    CachedAssetMetadata packageSnapshot = snapshot(
+        "demo", now, "package-root",
+        Map.of("npmFullMetadata", "true", "npmCompletePublishTimes", "false"));
+    Map<String, Object> raw = packument("1.0.0", "2026-07-19T10:00:00Z");
+    raw.remove("time");
+    when(fixture.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.of(packageSnapshot));
+    when(fixture.hosted.packageRoot(packageSnapshot)).thenReturn(Optional.of(raw));
+
+    MavenResponse first = fixture.service.getPackage(runtime, PACKAGE, "base", false);
+    MavenResponse second = fixture.service.getPackage(runtime, PACKAGE, "base", false);
+
+    assertTrue(((Map<?, ?>) new ObjectMapper().readValue(first.body(), Map.class)
+        .get("versions")).isEmpty());
+    assertTrue(((Map<?, ?>) new ObjectMapper().readValue(second.body(), Map.class)
+        .get("versions")).isEmpty());
+    verify(fixture.hosted).packageRoot(packageSnapshot);
+    verify(fixture.fetcher, never()).fetchWithBodyRetry(any(), anyString(), any());
+  }
+
+  @Test
+  void maturityBoundaryForcesRevalidationAndFailureDoesNotExposeVersion() throws Exception {
+    Instant now = Instant.parse("2026-07-19T12:01:00Z");
+    Instant lastVerified = Instant.parse("2026-07-19T11:59:00Z");
+    Fixture fixture = fixture(Clock.fixed(now, ZoneOffset.UTC));
+    RepositoryRuntime runtime = runtime(-1, 7L, 60);
+    CachedAssetMetadata packageSnapshot = snapshot(
+        "demo", lastVerified, "package-root", Map.of("remoteEtag", "root"));
+    Map<String, Object> raw = packument("1.0.0", "2026-07-19T11:00:00Z");
+    when(fixture.cache.find(eq(10L), eq("demo"), any())).thenReturn(Optional.of(packageSnapshot));
+    when(fixture.hosted.packageRoot(packageSnapshot)).thenReturn(Optional.of(raw));
+    respond(fixture.fetcher, new HttpRemoteFetcher.Result(
+        503, Map.of(), new ByteArrayInputStream(new byte[0])));
+
+    MavenResponse response = fixture.service.getPackage(runtime, PACKAGE, "base", false);
+    Map<?, ?> body = new ObjectMapper().readValue(response.body(), Map.class);
+
+    assertTrue(((Map<?, ?>) body.get("versions")).isEmpty(),
+        "a failed maturity-boundary revalidation must keep the release hidden");
+    verify(fixture.fetcher).fetchWithBodyRetry(any(), eq("demo"), any());
+    verify(fixture.proxyStateDao).recordFailure(eq(10L), eq(30L), anyString(), eq(now));
   }
 
   @Test
@@ -195,6 +415,10 @@ class NpmProxyRuntimeTest {
   }
 
   private static Fixture fixture() {
+    return fixture(Clock.systemUTC());
+  }
+
+  private static Fixture fixture(Clock clock) {
     AssetDao assetDao = mock(AssetDao.class);
     BlobStorageRegistry registry = mock(BlobStorageRegistry.class);
     NpmAssetWriter writer = mock(NpmAssetWriter.class);
@@ -203,19 +427,26 @@ class NpmProxyRuntimeTest {
     NpmHostedService hosted = mock(NpmHostedService.class);
     ProxyNegativeCache negativeCache = mock(ProxyNegativeCache.class);
     AssetMetadataCache cache = mock(AssetMetadataCache.class);
+    NpmReleaseIndexDao releaseIndexDao = mock(NpmReleaseIndexDao.class);
     BlobStorage storage = mock(BlobStorage.class);
     return new Fixture(
         assetDao, registry, writer, proxyStateDao, fetcher, hosted, negativeCache, cache,
-        storage, new NpmProxyService(
+        releaseIndexDao, storage, new NpmProxyService(
             assetDao, registry, writer, proxyStateDao, fetcher, hosted, new ObjectMapper(),
-            negativeCache, cache, null));
+            negativeCache, cache, null,
+            new NpmReleaseAgeCache(10000, 16L * 1024 * 1024, 30), releaseIndexDao, clock));
   }
 
   private static RepositoryRuntime runtime(int maxAgeMinutes, Long blobStoreId) {
+    return runtime(maxAgeMinutes, blobStoreId, 0);
+  }
+
+  private static RepositoryRuntime runtime(
+      int maxAgeMinutes, Long blobStoreId, int minimumReleaseAgeMinutes) {
     return new RepositoryRuntime(
         10L, "npm", RepositoryFormat.NPM, RepositoryType.PROXY, "npm", true, blobStoreId,
         null, null, null, true, "https://registry.npmjs.org/",
-        maxAgeMinutes, maxAgeMinutes, true, null, List.of());
+        maxAgeMinutes, maxAgeMinutes, true, null, List.of(), minimumReleaseAgeMinutes);
   }
 
   private static RepositoryRuntime hostedRuntime() {
@@ -235,12 +466,21 @@ class NpmProxyRuntimeTest {
   }
 
   private static NpmAssetWriter.Stored stored(String path, String kind, String contentType) {
+    return stored(path, kind, contentType, Map.of());
+  }
+
+  private static NpmAssetWriter.Stored stored(
+      String path,
+      String kind,
+      String contentType,
+      Map<String, Object> blobAttributes) {
     AssetRecord asset = new AssetRecord(
         1L, 10L, 3L, 2L, RepositoryFormat.NPM, path, null,
         path.substring(path.lastIndexOf('/') + 1), kind, contentType,
         7L, null, Instant.now(), Map.of());
     return new NpmAssetWriter.Stored(
-        asset, blob(Map.of()), new NpmAssetWriter.Digests("md5", "sha1", "sha256", "sha512", 7L),
+        asset, blob(blobAttributes),
+        new NpmAssetWriter.Digests("md5", "sha1", "sha256", "sha512", 7L),
         true, null);
   }
 
@@ -249,6 +489,21 @@ class NpmProxyRuntimeTest {
         2L, 7L, "blob://bucket/object", null, "object", null,
         "sha1", "sha256", "md5", 7L, "application/octet-stream",
         "proxy", "upstream", Instant.EPOCH, Instant.EPOCH, attributes);
+  }
+
+  private static Map<String, Object> packument(String version, String publishedAt) {
+    Map<String, Object> root = new LinkedHashMap<>();
+    root.put("name", "demo");
+    root.put("dist-tags", new LinkedHashMap<>(Map.of("latest", version)));
+    root.put("time", new LinkedHashMap<>(Map.of(version, publishedAt)));
+    root.put("versions", new LinkedHashMap<>(Map.of(
+        version,
+        new LinkedHashMap<>(Map.of(
+            "name", "demo",
+            "version", version,
+            "dist", new LinkedHashMap<>(Map.of(
+                "tarball", "https://registry.npmjs.org/demo/-/demo-" + version + ".tgz")))))));
+    return root;
   }
 
   private record Fixture(
@@ -260,6 +515,7 @@ class NpmProxyRuntimeTest {
       NpmHostedService hosted,
       ProxyNegativeCache negativeCache,
       AssetMetadataCache cache,
+      NpmReleaseIndexDao releaseIndexDao,
       BlobStorage storage,
       NpmProxyService service) {
   }

--- a/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmReleaseAgeCacheTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmReleaseAgeCacheTest.java
@@ -1,0 +1,162 @@
+package com.github.klboke.kkrepo.server.npm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.persistence.jdbc.api.model.AssetBlobRecord;
+import com.github.klboke.kkrepo.persistence.jdbc.api.model.AssetRecord;
+import com.github.klboke.kkrepo.protocol.npm.NpmMinimumReleaseAge;
+import com.github.klboke.kkrepo.server.cache.CachedAssetMetadata;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class NpmReleaseAgeCacheTest {
+  private static final Instant NOW = Instant.parse("2026-07-19T12:00:00Z");
+
+  @Test
+  void analysisIsLoadedOnceForConcurrentRequestsOnTheSameBlobRevision() throws Exception {
+    NpmReleaseAgeCache cache = new NpmReleaseAgeCache(10_000, 1024 * 1024, 30);
+    CachedAssetMetadata metadata = snapshot(2L, "sha256-a");
+    Map<String, Object> root = packument();
+    AtomicInteger loads = new AtomicInteger();
+    CountDownLatch start = new CountDownLatch(1);
+    CountDownLatch loaderStarted = new CountDownLatch(1);
+    CountDownLatch releaseLoader = new CountDownLatch(1);
+    ExecutorService executor = Executors.newFixedThreadPool(8);
+    List<Future<NpmMinimumReleaseAge.Analysis>> futures = new ArrayList<>();
+    try {
+      for (int index = 0; index < 20; index++) {
+        futures.add(executor.submit(() -> {
+          await(start);
+          return cache.analysis(metadata, 60, () -> {
+            loads.incrementAndGet();
+            loaderStarted.countDown();
+            await(releaseLoader);
+            return NpmMinimumReleaseAge.analyze(root, 60);
+          });
+        }));
+      }
+      start.countDown();
+      await(loaderStarted);
+      releaseLoader.countDown();
+
+      NpmMinimumReleaseAge.Analysis expected = futures.getFirst().get(5, TimeUnit.SECONDS);
+      for (Future<NpmMinimumReleaseAge.Analysis> future : futures) {
+        assertSame(expected, future.get(5, TimeUnit.SECONDS));
+      }
+      assertEquals(1, loads.get(), "Caffeine get must provide per-key single-flight loading");
+    } finally {
+      releaseLoader.countDown();
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void analysisKeyChangesWithDurableBlobRevisionAndPolicy() {
+    NpmReleaseAgeCache cache = new NpmReleaseAgeCache(10_000, 1024 * 1024, 30);
+    Map<String, Object> root = packument();
+    AtomicInteger loads = new AtomicInteger();
+
+    NpmMinimumReleaseAge.Analysis first = cache.analysis(
+        snapshot(2L, "sha256-a"), 60, () -> loaded(root, loads));
+    assertSame(first, cache.analysis(
+        snapshot(2L, "sha256-a"), 60, () -> loaded(root, loads)));
+    assertNotSame(first, cache.analysis(
+        snapshot(3L, "sha256-b"), 60, () -> loaded(root, loads)));
+    cache.analysis(snapshot(3L, "sha256-b"), 120, () -> loaded(root, loads));
+
+    assertEquals(3, loads.get());
+  }
+
+  @Test
+  void filteredResponseIsRebuiltOnlyWhenVisibilityGenerationChanges() {
+    NpmReleaseAgeCache cache = new NpmReleaseAgeCache(10_000, 1024 * 1024, 30);
+    CachedAssetMetadata metadata = snapshot(2L, "sha256-a");
+    Map<String, Object> root = packument();
+    NpmMinimumReleaseAge.Analysis analysis = cache.analysis(
+        metadata, 60, () -> NpmMinimumReleaseAge.analyze(root, 60));
+    AtomicInteger builds = new AtomicInteger();
+
+    byte[] first = cache.response(
+        metadata, 60, analysis, NOW, "package-FULL", "base",
+        () -> bytes(builds));
+    byte[] sameGeneration = cache.response(
+        metadata, 60, analysis, NOW.plusSeconds(1), "package-FULL", "base",
+        () -> bytes(builds));
+    byte[] afterTransition = cache.response(
+        metadata, 60, analysis, Instant.parse("2026-07-19T12:30:00Z"),
+        "package-FULL", "base", () -> bytes(builds));
+
+    assertSame(first, sameGeneration);
+    assertNotSame(first, afterTransition);
+    assertEquals(2, builds.get());
+  }
+
+  private static NpmMinimumReleaseAge.Analysis loaded(
+      Map<String, Object> root,
+      AtomicInteger loads) {
+    loads.incrementAndGet();
+    return NpmMinimumReleaseAge.analyze(root, 60);
+  }
+
+  private static byte[] bytes(AtomicInteger builds) {
+    return ("body-" + builds.incrementAndGet()).getBytes(StandardCharsets.UTF_8);
+  }
+
+  private static void await(CountDownLatch latch) {
+    try {
+      if (!latch.await(5, TimeUnit.SECONDS)) {
+        throw new AssertionError("timed out waiting for test latch");
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError("interrupted while waiting for test latch", e);
+    }
+  }
+
+  private static CachedAssetMetadata snapshot(long blobId, String sha256) {
+    AssetRecord asset = new AssetRecord(
+        1L, 10L, 3L, blobId, RepositoryFormat.NPM, "demo", null,
+        "demo", "package-root", "application/json", 7L, null, NOW, Map.of());
+    AssetBlobRecord blob = new AssetBlobRecord(
+        blobId, 7L, "blob://bucket/object-" + blobId, null, "object-" + blobId, null,
+        "sha1", sha256, "md5", 7L, "application/json",
+        "proxy", "upstream", NOW, NOW, Map.of());
+    return CachedAssetMetadata.of(asset, blob);
+  }
+
+  private static Map<String, Object> packument() {
+    Map<String, Object> root = new LinkedHashMap<>();
+    root.put("name", "demo");
+    root.put("dist-tags", new LinkedHashMap<>(Map.of("latest", "1.1.0")));
+    root.put("time", new LinkedHashMap<>(Map.of(
+        "1.0.0", "2026-07-19T10:00:00Z",
+        "1.1.0", "2026-07-19T11:30:00Z")));
+    Map<String, Object> versions = new LinkedHashMap<>();
+    versions.put("1.0.0", version("1.0.0"));
+    versions.put("1.1.0", version("1.1.0"));
+    root.put("versions", versions);
+    return root;
+  }
+
+  private static Map<String, Object> version(String version) {
+    return new LinkedHashMap<>(Map.of(
+        "name", "demo",
+        "version", version,
+        "dist", Map.of(
+            "tarball", "https://registry.npmjs.org/demo/-/demo-" + version + ".tgz")));
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmReleaseAgeCacheTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmReleaseAgeCacheTest.java
@@ -99,10 +99,13 @@ class NpmReleaseAgeCacheTest {
     byte[] afterTransition = cache.response(
         metadata, 60, analysis, Instant.parse("2026-07-19T12:30:00Z"),
         "package-FULL", "base", () -> bytes(builds));
+    byte[] normalizedNullKey = cache.response(
+        metadata, 60, analysis, NOW, null, null, () -> bytes(builds));
 
     assertSame(first, sameGeneration);
     assertNotSame(first, afterTransition);
-    assertEquals(2, builds.get());
+    assertNotSame(first, normalizedNullKey);
+    assertEquals(3, builds.get());
   }
 
   private static NpmMinimumReleaseAge.Analysis loaded(

--- a/server/src/test/java/com/github/klboke/kkrepo/server/repositories/RepositoryServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/repositories/RepositoryServiceTest.java
@@ -275,6 +275,61 @@ class RepositoryServiceTest {
   }
 
   @Test
+  void npmProxyMinimumReleaseAgeRoundTripsAndDefaultsToZero() {
+    StubRepositoryDao repositories = new StubRepositoryDao(repository(1L));
+    RepositoryService service = service(repositories);
+
+    RepositoryView created = service.create(new CreateCommand(
+        "npm-proxy",
+        "npm-proxy",
+        true,
+        "default",
+        true,
+        null,
+        new ProxySettings("https://registry.npmjs.org/", 1440, 1440, true, 60),
+        null, null, null, null));
+
+    assertEquals(60, created.proxy().minimumReleaseAgeMinutes());
+    Map<?, ?> proxy = (Map<?, ?>) repositories.repository.attributes().get("proxy");
+    assertEquals(60, proxy.get("minimumReleaseAgeMinutes"));
+
+    StubRepositoryDao defaultRepositories = new StubRepositoryDao(repository(1L));
+    RepositoryView defaulted = service(defaultRepositories).create(new CreateCommand(
+        "npm-proxy-default",
+        "npm-proxy",
+        true,
+        "default",
+        true,
+        null,
+        new ProxySettings("https://registry.npmjs.org/", 1440, 1440, true),
+        null, null, null, null));
+    assertEquals(0, defaulted.proxy().minimumReleaseAgeMinutes());
+  }
+
+  @Test
+  void minimumReleaseAgeRejectsNegativeAndNonNpmValues() {
+    RepositoryService service = service(new StubRepositoryDao(repository(1L)));
+
+    RepositoryValidationException negative = assertThrows(
+        RepositoryValidationException.class,
+        () -> service.create(new CreateCommand(
+            "npm-proxy", "npm-proxy", true, "default", true, null,
+            new ProxySettings("https://registry.npmjs.org/", 1440, 1440, true, -1),
+            null, null, null, null)));
+    assertEquals("proxy.minimumReleaseAgeMinutes must be at least 0", negative.getMessage());
+
+    RepositoryValidationException wrongFormat = assertThrows(
+        RepositoryValidationException.class,
+        () -> service.create(new CreateCommand(
+            "maven-proxy", "maven2-proxy", true, "default", true, null,
+            new ProxySettings("https://repo.maven.apache.org/maven2/", 1440, 1440, true, 60),
+            null, null, null, null)));
+    assertEquals(
+        "proxy.minimumReleaseAgeMinutes is only supported for npm proxy repositories",
+        wrongFormat.getMessage());
+  }
+
+  @Test
   void proxyRemotePasswordIsStoredButMaskedInRepositoryView() {
     StubRepositoryDao repositories = new StubRepositoryDao(dockerProxyRepository());
     RepositoryService service = service(repositories);


### PR DESCRIPTION
## What

- add the npm proxy-only `minimumReleaseAgeMinutes` setting, defaulting to `0` so existing repositories keep their current behavior
- fetch and retain the full upstream packument, filter immature `versions`, and repair affected `dist-tags` in both full and install-v1 responses
- enforce the same policy for cached and uncached direct tarball requests; denied downloads return npm JSON `404` with `Cache-Control: no-store`
- preserve the policy through npm group repositories and revalidate when a release crosses its maturity boundary
- add admin UI configuration, validation, and operational guidance
- persist a compact, rebuildable release index in MySQL/PostgreSQL, fenced to the current package-root blob revision, with automatic backfill for legacy cached packuments
- optimize the hot path with one indexed SQL query, portable chunked multi-row inserts, single-pass packument serialization, and bounded node-local L1 caches

## Why

Metadata/content TTL only controls when kkrepo revalidates cached content. It cannot guarantee that a package version has existed for a minimum amount of time before clients can resolve or download it.

This adds publish-time enforcement for npm proxy repositories to reduce exposure to newly published malicious or compromised versions. While enabled, missing or invalid per-version publish timestamps fail closed.

## Performance

Directional local benchmarks with JaCoCo enabled:

- 4,000-version MySQL tarball-policy lookup P50: `33.09 ms -> 11.44 ms`
- 4,000-version release-index replacement: `5.72 s -> 2.20 s`
- index storage: about `2.42 MB`, or `606 B/version`
- packument response allocation: reduced by about `27%-45%`
- direct tarball JSON/policy work: `26.8-413.8 ms -> 0.003-0.028 ms`; the real MySQL-backed hot path measured `11.44 ms` P50

## Checks

- `mvn -pl server -am test` — all 26 modules successful
- server — 1,317 tests, 0 failures, 0 errors
- MySQL persistence — 59 tests, 0 failures, 0 errors
- PostgreSQL persistence — 33 tests, 0 failures, 0 errors
- `node --check admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js`
- `git diff --check`

Closes #135