### PR TITLE
fix(docker): honor trusted forwarded headers

### DIFF
--- a/docs/en/nginx-reverse-proxy.md
+++ b/docs/en/nginx-reverse-proxy.md
@@ -4,7 +4,7 @@ This note covers the common deployment shape where Nginx terminates HTTPS and fo
 
 ## Why Forwarded Headers Matter
 
-kkRepo generates some client-visible absolute URLs from the incoming request. For example, npm package metadata rewrites `dist.tarball`, and Composer p2 metadata rewrites `dist.url`; both must use the client-visible public scheme and host.
+kkRepo generates some client-visible absolute URLs from the incoming request. For example, npm package metadata rewrites `dist.tarball`, Composer p2 metadata rewrites `dist.url`, and Docker generates the token challenge `realm` and `service` plus upload response `Location` headers. These values must use the client-visible public scheme, host, and port.
 
 If Nginx receives `https://nexus.example.com` but forwards to kkRepo as plain HTTP, kkRepo must receive trusted forwarded headers. Otherwise generated URLs may use the backend view of the request, such as `http://...` or a backend port.
 
@@ -101,6 +101,14 @@ curl -u alice:"$KKREPO_PASSWORD" \
 ```
 
 The `dist.url` value should start with `https://nexus.example.com/repository/composer-group/`.
+
+For Docker, first inspect the registry challenge:
+
+```bash
+curl -sS -D - -o /dev/null https://nexus.example.com/v2/
+```
+
+The `realm` in `WWW-Authenticate` should start with `https://nexus.example.com/`, and `service` must not contain a backend host or `:8080`. Then run `docker login` and `docker push` against the same public address; upload response `Location` headers should also remain on the public HTTPS address.
 
 If it starts with `http://`, contains `:8080`, or uses an internal host name, check:
 

--- a/docs/zh/nginx-reverse-proxy.md
+++ b/docs/zh/nginx-reverse-proxy.md
@@ -4,7 +4,7 @@
 
 ## 为什么需要 Forwarded Header
 
-kkRepo 会基于当前请求生成部分客户端可见的绝对 URL。例如 npm package metadata 会重写 `dist.tarball`，Composer p2 metadata 会重写 `dist.url`；两者都必须使用客户端可访问的公网 scheme 和 host。
+kkRepo 会基于当前请求生成部分客户端可见的绝对 URL。例如 npm package metadata 会重写 `dist.tarball`，Composer p2 metadata 会重写 `dist.url`；Docker 会生成 token challenge 的 `realm`、`service` 以及上传响应的 `Location`。这些值都必须使用客户端可访问的公网 scheme、host 和 port。
 
 如果 Nginx 对外接收的是 `https://nexus.example.com`，但转发到 kkRepo 时变成后端 HTTP 请求，kkRepo 必须收到可信的 forwarded header。否则生成的 URL 可能会使用后端看到的请求信息，例如 `http://...` 或后端端口。
 
@@ -101,6 +101,14 @@ curl -u alice:"$KKREPO_PASSWORD" \
 ```
 
 其中 `dist.url` 应以 `https://nexus.example.com/repository/composer-group/` 开头。
+
+Docker 应先验证 registry challenge：
+
+```bash
+curl -sS -D - -o /dev/null https://nexus.example.com/v2/
+```
+
+`WWW-Authenticate` 中的 `realm` 应以 `https://nexus.example.com/` 开头，`service` 不应包含后端 host 或 `:8080`。随后使用相同公网地址执行 `docker login` 和 `docker push`；上传响应的 `Location` 也应保持公网 HTTPS 地址。
 
 如果返回值以 `http://` 开头、包含 `:8080`，或使用了内部 host，检查：
 

--- a/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerAuthFilter.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerAuthFilter.java
@@ -11,6 +11,7 @@ import com.github.klboke.kkrepo.protocol.docker.DockerProtocolException;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
 import com.github.klboke.kkrepo.server.security.AuthenticatedSubject;
+import com.github.klboke.kkrepo.server.security.ForwardedHeaderPolicy;
 import com.github.klboke.kkrepo.server.security.SecurityAuthenticationService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -33,17 +34,20 @@ public class DockerAuthFilter extends OncePerRequestFilter {
   private final DockerAuthService authService;
   private final SecurityAuthenticationService authenticationService;
   private final AccessDecisionService accessDecisionService;
+  private final ForwardedHeaderPolicy forwardedHeaderPolicy;
   private final DockerPathParser parser = new DockerPathParser();
 
   public DockerAuthFilter(
       RepositoryRuntimeRegistry registry,
       DockerAuthService authService,
       SecurityAuthenticationService authenticationService,
-      AccessDecisionService accessDecisionService) {
+      AccessDecisionService accessDecisionService,
+      ForwardedHeaderPolicy forwardedHeaderPolicy) {
     this.registry = registry;
     this.authService = authService;
     this.authenticationService = authenticationService;
     this.accessDecisionService = accessDecisionService;
+    this.forwardedHeaderPolicy = forwardedHeaderPolicy;
   }
 
   @Override
@@ -247,20 +251,14 @@ public class DockerAuthFilter extends OncePerRequestFilter {
     return uri;
   }
 
-  private static String tokenRealm(HttpServletRequest request) {
-    return baseUrl(request) + "/service/rest/v1/docker/token";
+  private String tokenRealm(HttpServletRequest request) {
+    return forwardedHeaderPolicy.serverBaseUrl(request) + "/service/rest/v1/docker/token";
   }
 
-  private static String service(HttpServletRequest request) {
-    return request.getServerName() + ":" + request.getServerPort();
-  }
-
-  private static String baseUrl(HttpServletRequest request) {
-    String scheme = request.getScheme();
-    int port = request.getServerPort();
-    boolean defaultPort = ("http".equalsIgnoreCase(scheme) && port == 80)
-        || ("https".equalsIgnoreCase(scheme) && port == 443);
-    return scheme + "://" + request.getServerName() + (defaultPort ? "" : ":" + port);
+  private String service(HttpServletRequest request) {
+    String baseUrl = forwardedHeaderPolicy.serverBaseUrl(request);
+    int schemeSeparator = baseUrl.indexOf("://");
+    return schemeSeparator < 0 ? baseUrl : baseUrl.substring(schemeSeparator + 3);
   }
 
   private record DockerTarget(String repository, DockerPath path, boolean connectorRoute) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerRegistryController.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerRegistryController.java
@@ -13,6 +13,7 @@ import com.github.klboke.kkrepo.protocol.docker.DockerProtocolException;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
 import com.github.klboke.kkrepo.server.security.AuthenticatedSubject;
+import com.github.klboke.kkrepo.server.security.ForwardedHeaderPolicy;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.net.URLDecoder;
@@ -20,7 +21,6 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -46,6 +46,7 @@ public class DockerRegistryController {
   private final DockerGroupService group;
   private final DockerRangeSupport rangeSupport;
   private final AccessDecisionService accessDecisionService;
+  private final ForwardedHeaderPolicy forwardedHeaderPolicy;
   private final DockerPathParser parser = new DockerPathParser();
 
   public DockerRegistryController(
@@ -53,24 +54,16 @@ public class DockerRegistryController {
       DockerHostedService hosted,
       DockerProxyService proxy,
       DockerGroupService group,
-      DockerRangeSupport rangeSupport) {
-    this(registry, hosted, proxy, group, rangeSupport, null);
-  }
-
-  @Autowired
-  public DockerRegistryController(
-      RepositoryRuntimeRegistry registry,
-      DockerHostedService hosted,
-      DockerProxyService proxy,
-      DockerGroupService group,
       DockerRangeSupport rangeSupport,
-      AccessDecisionService accessDecisionService) {
+      AccessDecisionService accessDecisionService,
+      ForwardedHeaderPolicy forwardedHeaderPolicy) {
     this.registry = registry;
     this.hosted = hosted;
     this.proxy = proxy;
     this.group = group;
     this.rangeSupport = rangeSupport;
     this.accessDecisionService = accessDecisionService;
+    this.forwardedHeaderPolicy = forwardedHeaderPolicy;
   }
 
   public ResponseEntity<?> get(
@@ -470,12 +463,12 @@ public class DockerRegistryController {
     }
   }
 
-  private static String uploadLocation(
+  private String uploadLocation(
       HttpServletRequest request, RepositoryRuntime runtime, DockerTarget target, String imageName, String uuid) {
     return registryBaseUrl(request, runtime, target) + registryPath(target, imageName, "blobs/uploads/" + uuid);
   }
 
-  private static String blobLocation(
+  private String blobLocation(
       HttpServletRequest request,
       RepositoryRuntime runtime,
       DockerTarget target,
@@ -484,7 +477,7 @@ public class DockerRegistryController {
     return registryBaseUrl(request, runtime, target) + registryPath(target, imageName, "blobs/" + digest.value());
   }
 
-  private static String manifestLocation(
+  private String manifestLocation(
       HttpServletRequest request,
       RepositoryRuntime runtime,
       DockerTarget target,
@@ -498,22 +491,14 @@ public class DockerRegistryController {
     return prefix + imageName + "/" + suffix;
   }
 
-  private static String registryBaseUrl(
+  private String registryBaseUrl(
       HttpServletRequest request, RepositoryRuntime runtime, DockerTarget target) {
     if (target.connectorRoute()
         && runtime.dockerConnectorPublicUrl() != null
         && !runtime.dockerConnectorPublicUrl().isBlank()) {
       return trimTrailingSlash(runtime.dockerConnectorPublicUrl());
     }
-    return baseUrl(request);
-  }
-
-  private static String baseUrl(HttpServletRequest request) {
-    String scheme = request.getScheme();
-    int port = request.getServerPort();
-    boolean defaultPort = ("http".equalsIgnoreCase(scheme) && port == 80)
-        || ("https".equalsIgnoreCase(scheme) && port == 443);
-    return scheme + "://" + request.getServerName() + (defaultPort ? "" : ":" + port);
+    return forwardedHeaderPolicy.serverBaseUrl(request);
   }
 
   private static String stripContextPath(HttpServletRequest request) {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/docker/DockerAuthFilterTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/docker/DockerAuthFilterTest.java
@@ -20,6 +20,7 @@ import com.github.klboke.kkrepo.protocol.docker.DockerProtocolException;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
 import com.github.klboke.kkrepo.server.security.AuthenticatedSubject;
+import com.github.klboke.kkrepo.server.security.ForwardedHeaderPolicy;
 import com.github.klboke.kkrepo.server.security.SecurityAuthenticationService;
 import java.util.List;
 import java.util.Map;
@@ -39,6 +40,7 @@ class DockerAuthFilterTest {
   private DockerAuthService authService;
   private RepositoryRuntimeRegistry registry;
   private AccessDecisionService accessDecisionService;
+  private ForwardedHeaderPolicy forwardedHeaderPolicy;
 
   @BeforeEach
   void setUp() {
@@ -53,6 +55,7 @@ class DockerAuthFilterTest {
     authService = mock(DockerAuthService.class);
     registry = mock(RepositoryRuntimeRegistry.class);
     accessDecisionService = mock(AccessDecisionService.class);
+    forwardedHeaderPolicy = new ForwardedHeaderPolicy("");
   }
 
   @Test
@@ -67,7 +70,8 @@ class DockerAuthFilterTest {
         registry,
         authService,
         authenticationService,
-        accessDecisionService);
+        accessDecisionService,
+        forwardedHeaderPolicy);
     MockHttpServletRequest request = new MockHttpServletRequest("GET", "/v2/");
     request.setScheme("http");
     request.setServerName("127.0.0.1");
@@ -86,13 +90,72 @@ class DockerAuthFilterTest {
   }
 
   @Test
+  void trustedForwardedHeadersDefinePublicBearerChallenge() throws Exception {
+    when(authService.challenge(
+        "https://registry.example.com/service/rest/v1/docker/token",
+        "registry.example.com"))
+        .thenReturn("public-challenge");
+    SecurityAuthenticationService authenticationService = mock(SecurityAuthenticationService.class);
+    DockerAuthFilter filter = new DockerAuthFilter(
+        registry,
+        authService,
+        authenticationService,
+        accessDecisionService,
+        new ForwardedHeaderPolicy("10.0.0.1"));
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/v2/");
+    request.setScheme("http");
+    request.setServerName("kkrepo.internal");
+    request.setServerPort(8080);
+    request.setRemoteAddr("10.0.0.1");
+    request.addHeader("X-Forwarded-Proto", "https");
+    request.addHeader("X-Forwarded-Host", "registry.example.com");
+    request.addHeader("X-Forwarded-Port", "443");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    filter.doFilter(request, response, new MockFilterChain());
+
+    assertEquals(401, response.getStatus());
+    assertEquals("public-challenge", response.getHeader(HttpHeaders.WWW_AUTHENTICATE));
+  }
+
+  @Test
+  void untrustedForwardedHeadersCannotOverrideBearerChallenge() throws Exception {
+    when(authService.challenge(
+        "http://kkrepo.internal:8080/service/rest/v1/docker/token",
+        "kkrepo.internal:8080"))
+        .thenReturn("internal-challenge");
+    SecurityAuthenticationService authenticationService = mock(SecurityAuthenticationService.class);
+    DockerAuthFilter filter = new DockerAuthFilter(
+        registry,
+        authService,
+        authenticationService,
+        accessDecisionService,
+        new ForwardedHeaderPolicy("10.0.0.1"));
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/v2/");
+    request.setScheme("http");
+    request.setServerName("kkrepo.internal");
+    request.setServerPort(8080);
+    request.setRemoteAddr("203.0.113.10");
+    request.addHeader("X-Forwarded-Proto", "https");
+    request.addHeader("X-Forwarded-Host", "attacker.example.com");
+    request.addHeader("X-Forwarded-Port", "443");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    filter.doFilter(request, response, new MockFilterChain());
+
+    assertEquals(401, response.getStatus());
+    assertEquals("internal-challenge", response.getHeader(HttpHeaders.WWW_AUTHENTICATE));
+  }
+
+  @Test
   void baseProbeAcceptsValidBearerTokenWithoutRepositoryScope() throws Exception {
     when(authService.authenticateBearer("base-token")).thenReturn(Optional.of(subject));
     DockerAuthFilter filter = new DockerAuthFilter(
         registry,
         authService,
         mock(SecurityAuthenticationService.class),
-        accessDecisionService);
+        accessDecisionService,
+        forwardedHeaderPolicy);
     MockHttpServletRequest request = new MockHttpServletRequest("GET", "/v2/");
     request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer base-token");
     MockHttpServletResponse response = new MockHttpServletResponse();
@@ -120,7 +183,7 @@ class DockerAuthFilterTest {
             + "service=\"127.0.0.1:18090\",scope=\"repository:docker-live-proxy/library/alpine:pull\"");
     SecurityAuthenticationService authenticationService = mock(SecurityAuthenticationService.class);
     DockerAuthFilter filter = new DockerAuthFilter(
-        registry, authService, authenticationService, accessDecisionService);
+        registry, authService, authenticationService, accessDecisionService, forwardedHeaderPolicy);
     MockHttpServletRequest request =
         new MockHttpServletRequest("GET", "/v2/docker-live-proxy/library/alpine/manifests/latest");
     request.setScheme("http");
@@ -153,7 +216,8 @@ class DockerAuthFilterTest {
         .thenReturn("Bearer realm=\"http://127.0.0.1:18180/service/rest/v1/docker/token\","
             + "service=\"127.0.0.1:18180\",scope=\"repository:codex/alpine:pull\"");
     DockerAuthFilter filter = new DockerAuthFilter(
-        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService);
+        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService,
+        forwardedHeaderPolicy);
     MockHttpServletRequest request =
         new MockHttpServletRequest("GET", "/v2/codex/alpine/manifests/latest");
     request.setScheme("http");
@@ -181,7 +245,8 @@ class DockerAuthFilterTest {
     when(accessDecisionService.decide(org.mockito.ArgumentMatchers.eq(subject.permissionSubject()), org.mockito.ArgumentMatchers.any()))
         .thenReturn(AccessDecision.allow());
     DockerAuthFilter filter = new DockerAuthFilter(
-        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService);
+        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService,
+        forwardedHeaderPolicy);
     MockHttpServletRequest request =
         new MockHttpServletRequest("GET", "/v2/docker-live-proxy/library/alpine/manifests/latest");
     request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer valid-token");
@@ -206,7 +271,8 @@ class DockerAuthFilterTest {
         org.mockito.ArgumentMatchers.any()))
         .thenReturn(AccessDecision.allow());
     DockerAuthFilter filter = new DockerAuthFilter(
-        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService);
+        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService,
+        forwardedHeaderPolicy);
     MockHttpServletRequest request =
         new MockHttpServletRequest("POST", "/v2/docker-live-proxy/library/alpine/blobs/uploads/");
     request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer valid-token");
@@ -232,7 +298,8 @@ class DockerAuthFilterTest {
     when(accessDecisionService.decide(org.mockito.ArgumentMatchers.eq(permissionSubject), org.mockito.ArgumentMatchers.any()))
         .thenReturn(AccessDecision.allow());
     DockerAuthFilter filter = new DockerAuthFilter(
-        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService);
+        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService,
+        forwardedHeaderPolicy);
     MockHttpServletRequest request =
         new MockHttpServletRequest("POST", "/v2/docker-live-proxy/library/alpine/blobs/uploads/");
     request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer valid-token");
@@ -255,7 +322,8 @@ class DockerAuthFilterTest {
     when(accessDecisionService.decide(org.mockito.ArgumentMatchers.eq(permissionSubject), org.mockito.ArgumentMatchers.any()))
         .thenReturn(AccessDecision.allow());
     DockerAuthFilter filter = new DockerAuthFilter(
-        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService);
+        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService,
+        forwardedHeaderPolicy);
     MockHttpServletRequest request =
         new MockHttpServletRequest("PUT", "/v2/docker-live-proxy/library/alpine/manifests/latest");
     request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer valid-token");
@@ -278,7 +346,8 @@ class DockerAuthFilterTest {
     when(accessDecisionService.decide(org.mockito.ArgumentMatchers.eq(permissionSubject), org.mockito.ArgumentMatchers.any()))
         .thenReturn(AccessDecision.allow());
     DockerAuthFilter filter = new DockerAuthFilter(
-        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService);
+        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService,
+        forwardedHeaderPolicy);
     MockHttpServletRequest request =
         new MockHttpServletRequest("GET", "/v2/docker-live-proxy/_catalog");
     request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer valid-token");
@@ -301,7 +370,8 @@ class DockerAuthFilterTest {
         .thenReturn("Bearer realm=\"http://127.0.0.1:18090/service/rest/v1/docker/token\","
             + "service=\"127.0.0.1:18090\",scope=\"registry:catalog:*\"");
     DockerAuthFilter filter = new DockerAuthFilter(
-        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService);
+        registry, authService, mock(SecurityAuthenticationService.class), accessDecisionService,
+        forwardedHeaderPolicy);
     MockHttpServletRequest request =
         new MockHttpServletRequest("GET", "/v2/docker-live-proxy/_catalog");
     request.setScheme("http");

--- a/server/src/test/java/com/github/klboke/kkrepo/server/docker/DockerRegistryControllerTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/docker/DockerRegistryControllerTest.java
@@ -29,6 +29,7 @@ import com.github.klboke.kkrepo.protocol.docker.DockerProtocolException;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
 import com.github.klboke.kkrepo.server.security.AuthenticatedSubject;
+import com.github.klboke.kkrepo.server.security.ForwardedHeaderPolicy;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -71,6 +72,32 @@ class DockerRegistryControllerTest {
     assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
     assertEquals(
         "http://repo.example.com:8081/v2/docker-hosted/library/alpine/blobs/uploads/upload-1",
+        response.getHeaders().getFirst(HttpHeaders.LOCATION));
+  }
+
+  @Test
+  void trustedForwardedHeadersDefinePublicUploadLocation() {
+    RepositoryRuntime runtime = hosted("docker-hosted", null);
+    DockerHostedService hosted = mock(DockerHostedService.class);
+    when(hosted.startUpload(eq(runtime), eq("library/alpine"), eq(null), eq(null), eq(null), anyString(), anyString()))
+        .thenReturn(new DockerUploadService.UploadStatus("upload-1", 0, 0, false, null));
+    DockerRegistryController controller = controllerWithForwardedHeaders(
+        runtime, hosted, new ForwardedHeaderPolicy("10.0.0.1"));
+    MockHttpServletRequest request =
+        new MockHttpServletRequest("POST", "/v2/docker-hosted/library/alpine/blobs/uploads");
+    request.setScheme("http");
+    request.setServerName("kkrepo.internal");
+    request.setServerPort(8080);
+    request.setRemoteAddr("10.0.0.1");
+    request.addHeader("X-Forwarded-Proto", "https");
+    request.addHeader("X-Forwarded-Host", "registry.example.com");
+    request.addHeader("X-Forwarded-Port", "443");
+
+    ResponseEntity<?> response = controller.post(request, null, null);
+
+    assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
+    assertEquals(
+        "https://registry.example.com/v2/docker-hosted/library/alpine/blobs/uploads/upload-1",
         response.getHeaders().getFirst(HttpHeaders.LOCATION));
   }
 
@@ -495,6 +522,35 @@ class DockerRegistryControllerTest {
       DockerProxyService proxy,
       DockerGroupService group,
       AccessDecisionService accessDecisionService) {
+    return controller(
+        runtimes,
+        hosted,
+        proxy,
+        group,
+        accessDecisionService,
+        new ForwardedHeaderPolicy(""));
+  }
+
+  private static DockerRegistryController controllerWithForwardedHeaders(
+      RepositoryRuntime runtime,
+      DockerHostedService hosted,
+      ForwardedHeaderPolicy forwardedHeaderPolicy) {
+    return controller(
+        List.of(runtime),
+        hosted,
+        mock(DockerProxyService.class),
+        mock(DockerGroupService.class),
+        null,
+        forwardedHeaderPolicy);
+  }
+
+  private static DockerRegistryController controller(
+      List<RepositoryRuntime> runtimes,
+      DockerHostedService hosted,
+      DockerProxyService proxy,
+      DockerGroupService group,
+      AccessDecisionService accessDecisionService,
+      ForwardedHeaderPolicy forwardedHeaderPolicy) {
     RepositoryRuntimeRegistry registry = mock(RepositoryRuntimeRegistry.class);
     for (RepositoryRuntime runtime : runtimes) {
       when(registry.resolve(runtime.name())).thenReturn(Optional.of(runtime));
@@ -505,7 +561,8 @@ class DockerRegistryControllerTest {
         proxy,
         group,
         mock(DockerRangeSupport.class),
-        accessDecisionService);
+        accessDecisionService,
+        forwardedHeaderPolicy);
   }
 
   private static MockMvc dockerWriteMvc(RepositoryRuntime runtime) {


### PR DESCRIPTION
## Summary

- Build Docker Bearer challenge `realm` and `service` values through the shared trusted forwarded-header policy.
- Build Docker upload, blob, and manifest `Location` headers through the same policy while preserving `docker.connector.public-url` precedence.
- Add trusted/untrusted proxy regression coverage and document Docker verification in the English and Chinese Nginx guides.

Fixes #140

## Why

Nginx can terminate public HTTPS and forward to kkRepo over backend HTTP. Docker URL generation read `request.getScheme()`, `request.getServerName()`, and `request.getServerPort()` directly, so it ignored the already-configured `X-Forwarded-Proto`, `X-Forwarded-Host`, and `X-Forwarded-Port` trust policy. This could advertise an internal `http://` token realm or backend port even when the proxy configuration was correct.

## Impact

- Forwarded headers affect Docker client-visible URLs only when the immediate peer matches `KKREPO_TRUSTED_PROXIES`.
- Untrusted callers cannot spoof the public Docker challenge or response locations.
- Direct access behavior and connector `public-url` overrides remain supported.
- No token permission, persistence, cache, locking, or multi-replica behavior changes.

## Validation

- [x] `mvn -pl server -am test` (1302 tests)
- [x] `mvn -pl server -am -Dtest='Docker*Test' -Dsurefire.failIfNoSpecifiedTests=false test` (113 server Docker tests plus protocol and MySQL/PostgreSQL Docker DAO tests)
- [x] `git diff --check`
- [ ] Compatibility suite: not applicable; this changes proxy-aware external URL construction and is covered by focused server tests.
- [ ] Live compatibility workflow: not applicable.
- [ ] Real client E2E: not applicable to permission behavior; the reported remaining `unauthorized` was confirmed to be repository permissions.

## Compatibility and design checklist

- [x] Docker Bearer challenge and OCI response URL shapes remain unchanged; only the externally visible authority is resolved through the existing trusted proxy policy.
- [x] Focused regression tests cover both trusted forwarded headers and rejection of spoofed headers from an untrusted peer.
- [x] This change introduces no shared state or single-JVM correctness dependency.
- [x] No migration changes.

## Notes for reviewers

- npm and Composer URL rewriting already use `ForwardedHeaderPolicy`; this brings the Docker-specific filter/controller paths in line with that behavior.
