### PR TITLE
docs: add Ansible Galaxy to repository roadmap

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -176,9 +176,10 @@ AI agent 和贡献者的开发说明见 [AGENTS.md](AGENTS.md)。
 5. ✅ Terraform Provider / Module Registry - hosted、proxy、group、Provider GPG 签名、Nexus 路径兼容、UI/API 上传、搜索、真实 Terraform CLI E2E、Nexus hosted 数据迁移和显式选择的 proxy cache 迁移已实现（[设计说明](docs/zh/dev/terraform-repository-design.md)）
 6. ✅ Swift Package Registry - hosted、GitHub-backed proxy、group、Registry v1、不可变签名发布、UI/API 上传、Browse/Search、多副本协同、真实 SwiftPM/Xcode E2E 和 shape-gated Nexus 3.92.x-3.94.x 迁移已实现（[设计说明](docs/zh/dev/swift-package-registry-design.md)）
 7. ohpm / HarmonyOS - 规划中，覆盖 hosted、proxy、group、导入和管理端能力（[设计说明](docs/zh/dev/ohpm-repository-design.md)）
-8. APT / Debian
-9. Conan
-10. Conda
+8. Ansible Galaxy
+9. APT / Debian
+10. Conan
+11. Conda
 
 用户和管理端 UI 已暴露的 token 类型包括协议专用 token（`NpmToken`、`CargoToken`、`PubToken`、`NuGetApiKey`、`RubyGemsApiKey`），以及面向 Terraform 服务 URL、CI、脚本和自定义 HTTP 客户端的 `GenericToken`；`GenericToken` 适用于能够发送已配置 API-key header 或 bearer token 的调用方。
 

--- a/README.md
+++ b/README.md
@@ -176,9 +176,10 @@ Repository format roadmap:
 5. ✅ Terraform Provider / Module Registry - Hosted, proxy, group, provider GPG signing, Nexus-compatible paths, UI/API upload, search, real Terraform CLI E2E, Nexus hosted-data migration, and explicitly selected proxy-cache migration implemented ([Chinese design notes](docs/zh/dev/terraform-repository-design.md))
 6. ✅ Swift Package Registry - Hosted, GitHub-backed proxy, group, Registry v1, immutable signed publication, UI/API upload, Browse/Search, multi-replica coordination, real SwiftPM/Xcode E2E, and shape-gated Nexus 3.92.x-3.94.x migration are implemented ([Chinese design notes](docs/zh/dev/swift-package-registry-design.md))
 7. ohpm / HarmonyOS - Planned with hosted, proxy, group, import, and admin capabilities ([Chinese design notes](docs/zh/dev/ohpm-repository-design.md))
-8. APT / Debian
-9. Conan
-10. Conda
+8. Ansible Galaxy
+9. APT / Debian
+10. Conan
+11. Conda
 
 Token types exposed in the user and admin UI include protocol-specific tokens (`NpmToken`, `CargoToken`, `PubToken`, `NuGetApiKey`, `RubyGemsApiKey`) plus `GenericToken` for Terraform service URLs, CI, scripts, and custom HTTP clients that can send the configured API-key header or bearer token.
 


### PR DESCRIPTION
## Summary

- Add Ansible Galaxy to the repository format roadmap.
- Keep the English and Chinese README roadmaps aligned.
- Leave the new item unmarked because it is planned rather than implemented.

## Validation

- [ ] `mvn -pl server -am test` (not applicable; documentation-only change)
- [ ] `mvn -pl compat-test -am -Dtest=MavenMetadataMergeCompatibilityTest,MavenWritePolicyCompatibilityTest,NpmProtocolCompatibilityTest -Dsurefire.failIfNoSpecifiedTests=false test` (not applicable; documentation-only change)
- [x] Live compatibility workflow is not applicable because this PR does not change protocol or admin API behavior.
- [x] Real client E2E is not applicable because this PR does not change package-client behavior.
- [x] Other: `git diff --check`

## Compatibility and design checklist

- [x] This PR does not change protocol behavior.
- [x] Compatibility tests are not required for this documentation-only change.
- [x] This PR does not touch state, cache, locking, session, background tasks, upload/delete, metadata, or permissions.
- [x] This PR does not touch migration behavior.

## Notes for reviewers

- The roadmap uses the official product name, Ansible Galaxy.
