### PR TITLE
docs: remove experimental Native labeling

### DIFF
--- a/docs/en/build-deployment-guide.md
+++ b/docs/en/build-deployment-guide.md
@@ -160,7 +160,7 @@ Specify an image tag:
 
 Container deployments should still use an independent MySQL instance and OSS/S3 blob store. Do not use a container-local filesystem as long-term production blob storage.
 
-## GraalVM Native Image (Experimental)
+## GraalVM Native Image
 
 The `native` Maven profile runs Spring AOT processing and then compiles the server with GraalVM Native Image. To build a local executable, install a GraalVM JDK 25 distribution that includes the `native-image` tool, then run:
 
@@ -186,7 +186,7 @@ The Docker image helper exposes the same behavior through an explicit option:
 ./scripts/build-docker-image.sh --native kkrepo:native
 ```
 
-Without `--native`, the helper continues to build the JVM image. Native packaging is currently experimental. Before production adoption, validate the protocols and optional integrations used by your deployment, especially external Apollo configuration and OSS/S3 providers. See the [Native Image or JVM Selection Guide](native-vs-jvm-guide.md) for the measured tradeoffs and current recommendation.
+Without `--native`, the helper continues to build the JVM image. Native packaging has passed the full real-client E2E matrix on both MySQL and PostgreSQL. Before production adoption, validate the optional integrations used by your deployment, especially external Apollo configuration and OSS/S3 providers. See the [Native Image or JVM Selection Guide](native-vs-jvm-guide.md) for the measured tradeoffs and current recommendation.
 
 ## Archive Package Deployment
 

--- a/docs/en/native-vs-jvm-guide.md
+++ b/docs/en/native-vs-jvm-guide.md
@@ -3,7 +3,7 @@
 kkRepo supports two runtime packaging modes:
 
 - **JVM**, the default and recommended production mode, runs the Spring Boot executable jar on Java 25.
-- **Native**, an opt-in experimental mode, applies Spring AOT processing and compiles kkRepo with GraalVM Native Image.
+- **Native**, an opt-in runtime mode, applies Spring AOT processing and compiles kkRepo with GraalVM Native Image.
 
 Native packaging is not enabled implicitly. Docker images and archive distributions remain JVM-based unless `--native` is passed explicitly.
 
@@ -60,16 +60,16 @@ The final end-to-end archive validation also exercised a Buildpacks tool-cache m
 Use the default JVM distribution when:
 
 - kkRepo is a long-running repository service and warmed throughput is the main priority.
-- The deployment uses external Apollo, OSS/S3 providers, uncommon protocol paths, or other integrations that have not yet passed Native client E2E.
+- The deployment relies on optional integrations outside the completed real-client E2E matrix, such as external Apollo or a specific OSS/S3 provider.
 - Operational maturity, diagnostics, profiling, or existing JVM tuning is more important than cold-start speed.
 
 Consider the opt-in Native distribution when:
 
 - Fast readiness is important for autoscaling, scale-to-zero, preview environments, or rapid replacement of failed replicas.
 - The deployment is memory-constrained or runs many small replicas.
-- The exact database, storage provider, authentication integrations, and client protocols have passed the Native client E2E workflow.
+- The deployment has validated its exact database, storage provider, authentication integrations, and client protocols with Native.
 
-For current production deployments, JVM remains the default recommendation. Native remains experimental until real-client, object-storage, external-configuration, upgrade, and representative artifact-transfer coverage is comparable to the JVM path.
+For current production deployments, JVM remains the default recommendation. Native has passed the full real-client E2E matrix on both MySQL and PostgreSQL. Before production adoption, validate any deployment-specific optional integrations that are not represented in that matrix.
 
 ## Build and CI Commands
 

--- a/docs/zh/build-deployment-guide.md
+++ b/docs/zh/build-deployment-guide.md
@@ -160,7 +160,7 @@ docker pull ghcr.io/klboke/kkrepo:latest
 
 容器化部署仍建议使用独立 MySQL 和 OSS/S3 blob store，不建议把容器本地文件系统作为长期生产 blob 存储。
 
-## GraalVM Native Image（实验性）
+## GraalVM Native Image
 
 `native` Maven profile 会先执行 Spring AOT 处理，再使用 GraalVM Native Image 编译服务端。构建本地可执行文件前，需要安装包含 `native-image` 工具的 GraalVM JDK 25，然后执行：
 
@@ -186,7 +186,7 @@ Docker 镜像辅助脚本也提供相同的显式入口：
 ./scripts/build-docker-image.sh --native kkrepo:native
 ```
 
-不传 `--native` 时，脚本仍构建 JVM 镜像。原生打包目前仍为实验性能力。用于生产前，应针对实际使用的协议和可选集成做验证，尤其是外部 Apollo 配置中心及 OSS/S3 存储提供方。实测差异和当前建议见 [Native Image 与 JVM 选型指南](native-vs-jvm-guide.md)。
+不传 `--native` 时，脚本仍构建 JVM 镜像。Native 打包已在 MySQL 和 PostgreSQL 上通过完整真实客户端 E2E 矩阵。用于生产前，应验证实际部署使用的可选集成，尤其是外部 Apollo 配置中心及 OSS/S3 存储提供方。实测差异和当前建议见 [Native Image 与 JVM 选型指南](native-vs-jvm-guide.md)。
 
 ## 压缩包部署
 

--- a/docs/zh/native-vs-jvm-guide.md
+++ b/docs/zh/native-vs-jvm-guide.md
@@ -3,7 +3,7 @@
 kkRepo 支持两种运行时打包方式：
 
 - **JVM**：默认且推荐的生产模式，在 Java 25 上运行 Spring Boot 可执行 jar。
-- **Native**：显式开启的实验性模式，先执行 Spring AOT，再通过 GraalVM Native Image 编译 kkRepo。
+- **Native**：显式开启的运行模式，先执行 Spring AOT，再通过 GraalVM Native Image 编译 kkRepo。
 
 Native 打包不会被隐式开启。Docker 镜像和压缩发行包只有显式传入 `--native` 才会构建 Native 版本；默认始终构建 JVM 版本。
 
@@ -60,16 +60,16 @@ Health 端点会经过共享 MySQL 健康检查路径，两种模式都出现过
 以下情况使用默认 JVM 发行包：
 
 - kkRepo 作为长期运行的仓库服务，充分预热后的吞吐优先级更高。
-- 部署依赖外部 Apollo、OSS/S3 provider、低频协议路径，或其他尚未通过 Native client E2E 的集成。
+- 部署依赖完整真实客户端 E2E 矩阵之外的可选集成，例如外部 Apollo 或特定 OSS/S3 provider。
 - 更重视成熟运维、诊断、性能分析和已有 JVM 调优经验。
 
 以下情况可以考虑显式选择 Native 发行包：
 
 - 弹性扩缩、scale-to-zero、预览环境或故障副本快速替换对 readiness 时间敏感。
 - 节点内存紧张，或需要运行较多小规格副本。
-- 实际使用的数据库、存储 provider、认证集成和客户端协议已经通过 Native client E2E。
+- 已使用 Native 验证实际使用的数据库、存储 provider、认证集成和客户端协议。
 
-当前生产环境仍默认推荐 JVM。Native 在真实客户端、对象存储、外部配置、升级和代表性制品传输覆盖达到 JVM 路径之前保持实验性。
+当前生产环境仍默认推荐 JVM。Native 已在 MySQL 和 PostgreSQL 上通过完整真实客户端 E2E 矩阵。用于生产前，仍应验证该矩阵未覆盖的部署特定可选集成。
 
 ## 构建与 CI 命令
 


### PR DESCRIPTION
## Summary

- remove all experimental-mode labels from the Native runtime documentation
- record that Native passed the full real-client E2E matrix on MySQL and PostgreSQL
- keep JVM as the default package while retaining deployment-specific validation guidance for optional integrations

## Why

Native has completed the full client E2E matrix on both supported database backends, so describing it as experimental is outdated.

## Validation

- `git diff --check`
- repository-wide search confirms no Native or GraalVM experimental labels remain