### PR TITLE
Release kkRepo 0.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,7 @@ jobs:
           bash -n scripts/ci/prepare-swift-e2e-tls.sh
           bash -n scripts/ci/setup-swift-e2e-wrappers.sh
           bash -n scripts/ci/test-e2e-image-artifact.sh
+          bash -n scripts/ci/test-quickstart-runtime.sh
           bash -n scripts/ci/test-swift-e2e-wrappers.sh
           bash -n scripts/ci/test-dist-launcher.sh
           bash -n server/src/dist/bin/start.sh
@@ -158,6 +159,7 @@ jobs:
           bash -n server/src/dist/bin/stop.sh
           scripts/ci/test-dev-jar-deploy.sh
           scripts/ci/test-e2e-image-artifact.sh
+          scripts/ci/test-quickstart-runtime.sh
           scripts/ci/test-swift-e2e-wrappers.sh
           scripts/ci/test-dist-launcher.sh
           test -f .github/deploy/dev/systemd/kkrepo.service

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -1,0 +1,203 @@
+name: Release Packages
+
+run-name: Release packages v${{ inputs.version }} from ${{ github.ref_name }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version without the v prefix
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-packages-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate release source
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Require merged main
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "Release packages must be built from the merged main branch, got $GITHUB_REF" >&2
+            exit 1
+          fi
+          if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Version must use the x.y.z form without a v prefix" >&2
+            exit 1
+          fi
+
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: maven
+
+      - name: Match the project version
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          project_version="$(mvn -q -N -DforceStdout help:evaluate -Dexpression=project.version)"
+          if [[ "$project_version" != "$RELEASE_VERSION" ]]; then
+            echo "Requested version $RELEASE_VERSION does not match project version $project_version" >&2
+            exit 1
+          fi
+
+  build:
+    name: Build ${{ matrix.label }}
+    needs: validate
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: jvm
+            label: JVM archives
+            runner: ubuntu-24.04
+            build-argument: --jvm
+            suffix: ""
+          - id: native-linux-amd64
+            label: Native Linux amd64 archives
+            runner: ubuntu-24.04
+            build-argument: --native
+            suffix: -native-linux-amd64
+          - id: native-linux-arm64
+            label: Native Linux arm64 archives
+            runner: ubuntu-24.04-arm
+            build-argument: --native
+            suffix: -native-linux-arm64
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: maven
+
+      - name: Build distribution
+        env:
+          BUILD_ARGUMENT: ${{ matrix.build-argument }}
+          MAVEN_OPTS: -Xmx3g
+        run: scripts/build-dist.sh "$BUILD_ARGUMENT"
+
+      - name: Verify distribution
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_SUFFIX: ${{ matrix.suffix }}
+          RELEASE_VARIANT: ${{ matrix.id }}
+        run: |
+          archive_base="server/target/kkrepo-${RELEASE_VERSION}${RELEASE_SUFFIX}"
+          tar_archive="${archive_base}.tar.gz"
+          zip_archive="${archive_base}.zip"
+          test -s "$tar_archive"
+          test -s "$zip_archive"
+          unzip -tq "$zip_archive"
+
+          verify_dir="$(mktemp -d)"
+          trap 'rm -rf "$verify_dir"' EXIT
+          tar -xzf "$tar_archive" -C "$verify_dir"
+          distribution_root="$verify_dir/kkrepo-${RELEASE_VERSION}${RELEASE_SUFFIX}"
+          test -x "$distribution_root/bin/start.sh"
+
+          case "$RELEASE_VARIANT" in
+            jvm)
+              runtime="$distribution_root/lib/kkrepo.jar"
+              test -s "$runtime"
+              unzip -p "$runtime" META-INF/MANIFEST.MF \
+                | grep -q '^Main-Class: org.springframework.boot.loader.launch.JarLauncher'
+              ;;
+            native-linux-amd64)
+              runtime="$distribution_root/lib/kkrepo"
+              test -x "$runtime"
+              file "$runtime" | grep -Eq 'x86-64|x86_64'
+              ;;
+            native-linux-arm64)
+              runtime="$distribution_root/lib/kkrepo"
+              test -x "$runtime"
+              file "$runtime" | grep -Eq 'aarch64|ARM aarch64'
+              ;;
+            *)
+              echo "Unknown release variant: $RELEASE_VARIANT" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Upload package pair
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-package-${{ matrix.id }}
+          path: |
+            server/target/kkrepo-${{ inputs.version }}${{ matrix.suffix }}.tar.gz
+            server/target/kkrepo-${{ inputs.version }}${{ matrix.suffix }}.zip
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 7
+
+  collect:
+    name: Collect release assets and checksums
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Download package matrix
+        uses: actions/download-artifact@v8
+        with:
+          pattern: release-package-*
+          path: release-assets
+          merge-multiple: true
+
+      - name: Verify matrix and write checksums
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          expected=(
+            "kkrepo-${RELEASE_VERSION}.tar.gz"
+            "kkrepo-${RELEASE_VERSION}.zip"
+            "kkrepo-${RELEASE_VERSION}-native-linux-amd64.tar.gz"
+            "kkrepo-${RELEASE_VERSION}-native-linux-amd64.zip"
+            "kkrepo-${RELEASE_VERSION}-native-linux-arm64.tar.gz"
+            "kkrepo-${RELEASE_VERSION}-native-linux-arm64.zip"
+          )
+
+          for asset in "${expected[@]}"; do
+            test -s "release-assets/$asset"
+          done
+
+          asset_count="$(find release-assets -maxdepth 1 -type f | wc -l | tr -d ' ')"
+          if [[ "$asset_count" != "${#expected[@]}" ]]; then
+            echo "Expected ${#expected[@]} package assets, found $asset_count" >&2
+            find release-assets -maxdepth 1 -type f -print >&2
+            exit 1
+          fi
+
+          (
+            cd release-assets
+            sha256sum "${expected[@]}" > "kkrepo-${RELEASE_VERSION}.sha256.txt"
+          )
+          cat "release-assets/kkrepo-${RELEASE_VERSION}.sha256.txt"
+
+      - name: Upload complete release asset set
+        uses: actions/upload-artifact@v7
+        with:
+          name: kkrepo-${{ inputs.version }}-release-assets
+          path: release-assets/
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 14

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 concurrency:
   group: release-packages-${{ inputs.version }}
@@ -70,16 +71,25 @@ jobs:
             runner: ubuntu-24.04
             build-argument: --jvm
             suffix: ""
+            image-suffix: ""
+            image-architecture: ""
+            keep-native-image: "false"
           - id: native-linux-amd64
             label: Native Linux amd64 archives
             runner: ubuntu-24.04
             build-argument: --native
             suffix: -native-linux-amd64
+            image-suffix: -native-amd64
+            image-architecture: amd64
+            keep-native-image: "true"
           - id: native-linux-arm64
             label: Native Linux arm64 archives
             runner: ubuntu-24.04-arm
             build-argument: --native
             suffix: -native-linux-arm64
+            image-suffix: -native-arm64
+            image-architecture: arm64
+            keep-native-image: "true"
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
@@ -94,6 +104,8 @@ jobs:
       - name: Build distribution
         env:
           BUILD_ARGUMENT: ${{ matrix.build-argument }}
+          KKREPO_KEEP_NATIVE_IMAGE: ${{ matrix.keep-native-image }}
+          KKREPO_NATIVE_IMAGE: ghcr.io/klboke/kkrepo:${{ inputs.version }}${{ matrix.image-suffix }}
           MAVEN_OPTS: -Xmx3g
         run: scripts/build-dist.sh "$BUILD_ARGUMENT"
 
@@ -138,6 +150,28 @@ jobs:
               exit 1
               ;;
           esac
+
+      - name: Log in to GitHub Container Registry
+        if: matrix.image-architecture != ''
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push architecture-specific Native image
+        if: matrix.image-architecture != ''
+        env:
+          EXPECTED_ARCHITECTURE: ${{ matrix.image-architecture }}
+          NATIVE_IMAGE: ghcr.io/klboke/kkrepo:${{ inputs.version }}${{ matrix.image-suffix }}
+        run: |
+          actual_platform="$(docker image inspect "$NATIVE_IMAGE" --format '{{.Os}}/{{.Architecture}}')"
+          expected_platform="linux/${EXPECTED_ARCHITECTURE}"
+          if [[ "$actual_platform" != "$expected_platform" ]]; then
+            echo "Expected $expected_platform Native image, got $actual_platform" >&2
+            exit 1
+          fi
+          docker push "$NATIVE_IMAGE"
 
       - name: Upload package pair
         uses: actions/upload-artifact@v7
@@ -201,3 +235,45 @@ jobs:
           if-no-files-found: error
           compression-level: 0
           retention-days: 14
+
+  publish-native-image:
+    name: Publish multi-architecture Native image
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Publish and verify Native image manifest
+        env:
+          IMAGE: ghcr.io/klboke/kkrepo
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          docker buildx imagetools create \
+            --tag "${IMAGE}:${RELEASE_VERSION}-native" \
+            --tag "${IMAGE}:native-latest" \
+            "${IMAGE}:${RELEASE_VERSION}-native-amd64" \
+            "${IMAGE}:${RELEASE_VERSION}-native-arm64"
+
+          for tag in "${RELEASE_VERSION}-native" native-latest; do
+            manifest="$(docker buildx imagetools inspect "${IMAGE}:${tag}")"
+            grep -Eq 'Platform:[[:space:]]+linux/amd64' <<<"$manifest"
+            grep -Eq 'Platform:[[:space:]]+linux/arm64' <<<"$manifest"
+            printf '%s\n' "$manifest"
+          done
+
+          {
+            echo "### Native container image"
+            echo
+            echo "- \`${IMAGE}:${RELEASE_VERSION}-native\`"
+            echo "- \`${IMAGE}:native-latest\`"
+            echo "- Platforms: \`linux/amd64\`, \`linux/arm64\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ This project follows a pragmatic early-stage release process. Until a stable `1.
 
 ### Changed
 
-- Release packages now use a reproducible GitHub Actions matrix: platform-independent JVM archives plus Native Linux `amd64` and `arm64` archives, each in tar.gz and zip formats, with one combined SHA-256 manifest.
+- Release packages now use a reproducible GitHub Actions matrix: platform-independent JVM archives plus Native Linux `amd64` and `arm64` archives, each in tar.gz and zip formats, with one combined SHA-256 manifest. The Native builds are also published as the multi-architecture `0.6.0-native` and `native-latest` GHCR images.
 - Quickstart defaults, Dockerfile packaging, deployment documentation, and the Helm application version now use `0.6.0`.
+- Quickstart accepts `KKREPO_RUNTIME=jvm|native`, independently of `KKREPO_DATABASE_TYPE`, and selects the matching JVM or Native release image while preserving explicit image-tag overrides.
 - Native startup and memory guidance reflects the measured roughly one-second readiness and below-200-MiB idle memory baseline, while retaining the JVM recommendation for maximum warmed throughput. (#154, #155, #156)
 - Maven, Bouncy Castle, XZ, AWS SDK, and GitHub Actions dependencies were refreshed. (#143, #144, #145, #146, #147, #148, #149, #150)
 
@@ -33,7 +34,7 @@ This project follows a pragmatic early-stage release process. Until a stable `1.
 
 - Existing `0.5.1` MySQL and PostgreSQL deployments can upgrade in place through Flyway V34-V35. Back up the database and blob store together before upgrading, and do not run mixed application versions after the new migrations are applied.
 - V34 adds the rebuildable npm release-age index, and V35 adds Ansible Galaxy registry, import, cache, lease, and group-binding state. Large collection archives and package blobs remain in the configured blob store.
-- Native archives require Linux and the matching `amd64` or `arm64` architecture. Use the JVM archive or container image when portability and maximum warmed throughput matter more than startup time and memory.
+- Native archives require Linux and the matching `amd64` or `arm64` architecture. The `0.6.0-native` container tag is multi-architecture and lets Docker select the matching image automatically. Use the JVM archive or container image when maximum warmed throughput matters more than startup time and memory.
 
 ## 0.5.1 - 2026-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable public changes to kkrepo are documented in this file.
 
 This project follows a pragmatic early-stage release process. Until a stable `1.0.0` release is announced, minor versions may include behavior changes, but releases should call out migration impact, compatibility changes, and operational notes.
 
+## 0.6.0 - 2026-07-24
+
+### Added
+
+- Nexus-compatible Ansible Galaxy v3 hosted, proxy, and group repositories, including immutable collection publication, dependency and artifact APIs, import-task recovery, proxy/group coordination, Components API/UI upload, Browse/Search/Admin integration, migration, metrics, and current plus Ansible 2.9 client coverage. (#158)
+- npm proxy repositories can enforce a configurable minimum release age across packuments, dist-tags, cached and uncached tarball requests, and group resolution. The default remains `0`, preserving existing repository behavior until administrators opt in. (#141)
+- Opt-in Spring AOT and GraalVM Native Image builds, Docker images, archive distributions, automatic launcher runtime selection, runtime hints, and real-client E2E coverage. JVM remains the default runtime. (#151)
+
+### Changed
+
+- Release packages now use a reproducible GitHub Actions matrix: platform-independent JVM archives plus Native Linux `amd64` and `arm64` archives, each in tar.gz and zip formats, with one combined SHA-256 manifest.
+- Quickstart defaults, Dockerfile packaging, deployment documentation, and the Helm application version now use `0.6.0`.
+- Native startup and memory guidance reflects the measured roughly one-second readiness and below-200-MiB idle memory baseline, while retaining the JVM recommendation for maximum warmed throughput. (#154, #155, #156)
+- Maven, Bouncy Castle, XZ, AWS SDK, and GitHub Actions dependencies were refreshed. (#143, #144, #145, #146, #147, #148, #149, #150)
+
+### Fixed
+
+- Docker Bearer challenges and upload, blob, and manifest response locations now honor forwarded host, scheme, and port values only from configured trusted proxies, without changing explicit connector public-URL precedence. (#142)
+
+### Compatibility And Validation
+
+- Native packaging has passed the full real-client E2E matrix on MySQL and PostgreSQL; the release matrix builds Linux `amd64` and `arm64` executables on matching GitHub-hosted runners. (#151)
+- Ansible Galaxy behavior is covered against Nexus 3.93.x-3.94.x, current Ansible clients, Ansible 2.9, dual-replica coordination, MySQL/PostgreSQL persistence, and source migration. (#158)
+- npm minimum-release-age coverage includes fail-closed timestamp handling, cache revalidation, group policy, indexed MySQL/PostgreSQL state, and existing-repository compatibility. (#141)
+
+### Upgrade Notes
+
+- Existing `0.5.1` MySQL and PostgreSQL deployments can upgrade in place through Flyway V34-V35. Back up the database and blob store together before upgrading, and do not run mixed application versions after the new migrations are applied.
+- V34 adds the rebuildable npm release-age index, and V35 adds Ansible Galaxy registry, import, cache, lease, and group-binding state. Large collection archives and package blobs remain in the configured blob store.
+- Native archives require Linux and the matching `amd64` or `arm64` architecture. Use the JVM archive or container image when portability and maximum warmed throughput matter more than startup time and memory.
+
 ## 0.5.1 - 2026-07-18
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:25-jre-jammy
 
 WORKDIR /app
 
-ARG JAR_FILE=server/target/kkrepo-server-0.5.1.jar
+ARG JAR_FILE=server/target/kkrepo-server-0.6.0.jar
 
 RUN groupadd --system kkrepo \
     && useradd --system --gid kkrepo --home-dir /app --shell /usr/sbin/nologin kkrepo

--- a/README.cn.md
+++ b/README.cn.md
@@ -46,6 +46,14 @@ curl -fsSL https://raw.githubusercontent.com/klboke/kkrepo/main/scripts/quicksta
 curl -fsSL https://raw.githubusercontent.com/klboke/kkrepo/main/scripts/quickstart.sh | KKREPO_DATABASE_TYPE=postgresql bash
 ```
 
+如需从默认 JVM 镜像切换到多架构 Native 镜像：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/klboke/kkrepo/main/scripts/quickstart.sh | KKREPO_RUNTIME=native bash
+```
+
+`KKREPO_RUNTIME` 和 `KKREPO_DATABASE_TYPE` 可以独立选择，也可以组合使用，例如 `KKREPO_RUNTIME=native KKREPO_DATABASE_TYPE=postgresql`。
+
 启动后访问：
 
 - 管理控制台：`http://127.0.0.1:19090/admin/`

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ To run the same image with the default PostgreSQL 16 quickstart instead (the run
 curl -fsSL https://raw.githubusercontent.com/klboke/kkrepo/main/scripts/quickstart.sh | KKREPO_DATABASE_TYPE=postgresql bash
 ```
 
+To use the multi-architecture Native image instead of the default JVM image:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/klboke/kkrepo/main/scripts/quickstart.sh | KKREPO_RUNTIME=native bash
+```
+
+`KKREPO_RUNTIME` and `KKREPO_DATABASE_TYPE` are independent and can be combined, for example with `KKREPO_RUNTIME=native KKREPO_DATABASE_TYPE=postgresql`.
+
 Open:
 
 - Admin console: `http://127.0.0.1:19090/admin/`

--- a/deploy/helm/kkrepo/Chart.yaml
+++ b/deploy/helm/kkrepo/Chart.yaml
@@ -3,5 +3,5 @@ name: kkrepo
 description: Multi-replica kkRepo artifact repository with an external MySQL or PostgreSQL database
 type: application
 version: 0.1.0
-appVersion: "0.5.1"
+appVersion: "0.6.0"
 kubeVersion: ">=1.27.0-0"

--- a/docker-compose.quickstart-postgresql.yml
+++ b/docker-compose.quickstart-postgresql.yml
@@ -25,7 +25,7 @@ services:
     command: ["sh", "-c", "mkdir -p /data/blobs && chown -R 999:999 /data"]
 
   kkrepo:
-    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.5.1}
+    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.6.0}
     depends_on:
       postgresql:
         condition: service_healthy

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -26,7 +26,7 @@ services:
     command: ["sh", "-c", "mkdir -p /data/blobs && chown -R 999:999 /data"]
 
   kkrepo:
-    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.5.1}
+    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.6.0}
     depends_on:
       mysql:
         condition: service_healthy

--- a/docs/en/build-deployment-guide.md
+++ b/docs/en/build-deployment-guide.md
@@ -45,7 +45,7 @@ bash quickstart.sh
 
 By default, it starts:
 
-- `ghcr.io/klboke/kkrepo:0.5.1`
+- `ghcr.io/klboke/kkrepo:0.6.0`
 - MySQL 8.0
 - Persistent MySQL and File blob storage volumes for local trials
 
@@ -137,7 +137,7 @@ Note: a normal `server` module jar does not contain a Spring Boot executable ent
 Pull the latest public release image:
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:0.5.1
+docker pull ghcr.io/klboke/kkrepo:0.6.0
 ```
 
 You can also use `latest` to follow the latest public release:
@@ -217,6 +217,8 @@ This opt-in build generates both archive formats with a platform suffix:
 server/target/kkrepo-<release-version>-native-linux-<architecture>.tar.gz
 server/target/kkrepo-<release-version>-native-linux-<architecture>.zip
 ```
+
+The GitHub `Release Packages` workflow builds the public release matrix from merged `main`: one platform-independent JVM archive pair, Native Linux `amd64` and `arm64` archive pairs, and a combined SHA-256 manifest. It only produces verified workflow artifacts; creating the GitHub Release and uploading those assets remain a separate, explicit release step.
 
 The default remains JVM packaging. A JVM archive contains `lib/kkrepo.jar`; a Native archive contains the executable `lib/kkrepo`. The shared `bin/start.sh` selects the packaged runtime automatically, so the service commands and external configuration layout remain the same. Native archives do not require a Java runtime on the target host, but they must run on the matching operating system and CPU architecture.
 

--- a/docs/en/build-deployment-guide.md
+++ b/docs/en/build-deployment-guide.md
@@ -7,7 +7,7 @@ This document covers local startup, release builds, archive package deployment, 
 - JDK 25
 - Maven 3.9 or a compatible version
 - MySQL 8.0 or PostgreSQL 12+ (use a maintained PostgreSQL release in production)
-- Optional: Docker, for building images or running containerized dependencies
+- Optional: Docker, for building images or running containerized dependencies; a running Docker daemon with access to pull the Cloud Native Buildpacks builder/run images is required for Native images and Native archives
 
 The service requires one shared relational backend: MySQL is the default and PostgreSQL is also supported. For local trials, the blob store can use File storage. For production, OSS/S3 is recommended. See [Database Backends](database-backends.md).
 
@@ -26,11 +26,27 @@ curl -fsSL https://raw.githubusercontent.com/klboke/kkrepo/main/scripts/quicksta
   | KKREPO_DATABASE_TYPE=postgresql bash
 ```
 
+JVM is the default runtime. To use the Native image instead:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/klboke/kkrepo/main/scripts/quickstart.sh \
+  | KKREPO_RUNTIME=native bash
+```
+
+Runtime and database selection are independent. To start the Native image with PostgreSQL:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/klboke/kkrepo/main/scripts/quickstart.sh \
+  | KKREPO_RUNTIME=native KKREPO_DATABASE_TYPE=postgresql bash
+```
+
+`KKREPO_RUNTIME=jvm` selects `ghcr.io/klboke/kkrepo:0.6.0`, while `KKREPO_RUNTIME=native` selects `ghcr.io/klboke/kkrepo:0.6.0-native`. Both are published for Linux `amd64` and `arm64`. An explicit `KKREPO_IMAGE_TAG` overrides the runtime's default tag.
+
 The script prints each step and:
 
 1. Checks Docker, Docker Compose, and curl.
 2. Creates the `kkrepo-quickstart/` working directory.
-3. Generates `.env` with the image tag, ports, and local-trial secrets.
+3. Generates `.env` with the runtime, image tag, ports, and local-trial secrets.
 4. Downloads `docker-compose.quickstart.yml`.
 5. Checks host port availability.
 6. Pulls images and runs `docker compose up -d`.
@@ -45,7 +61,7 @@ bash quickstart.sh
 
 By default, it starts:
 
-- `ghcr.io/klboke/kkrepo:0.6.0`
+- The JVM runtime from `ghcr.io/klboke/kkrepo:0.6.0`
 - MySQL 8.0
 - Persistent MySQL and File blob storage volumes for local trials
 
@@ -146,6 +162,13 @@ You can also use `latest` to follow the latest public release:
 docker pull ghcr.io/klboke/kkrepo:latest
 ```
 
+The Native image is published separately:
+
+```bash
+docker pull ghcr.io/klboke/kkrepo:0.6.0-native
+docker pull ghcr.io/klboke/kkrepo:native-latest
+```
+
 Build the default image:
 
 ```bash
@@ -157,6 +180,16 @@ Specify an image tag:
 ```bash
 ./scripts/build-docker-image.sh kkrepo:local
 ```
+
+Build a Native image for the current Docker host architecture:
+
+```bash
+./scripts/build-docker-image.sh --native kkrepo:native-local
+docker image inspect kkrepo:native-local \
+  --format '{{.Os}}/{{.Architecture}} {{json .Config.Entrypoint}}'
+```
+
+This command performs the GraalVM compilation in a container through Spring Boot Cloud Native Buildpacks, so GraalVM does not need to be installed on the host. It produces a directly runnable OCI image, not an intermediate binary that must be copied by the existing `Dockerfile`; a separate Native Dockerfile is therefore unnecessary. The first build downloads the builder, run image, and Native toolchain, and takes substantially more time and memory than the JVM image build.
 
 Container deployments should still use an independent MySQL instance and OSS/S3 blob store. Do not use a container-local filesystem as long-term production blob storage.
 
@@ -172,19 +205,31 @@ mvn -Pnative -pl server -am -DskipTests package
 You can build the native executable inside a Cloud Native Buildpacks container instead of installing GraalVM locally:
 
 ```bash
-mvn -Pnative -pl server -am -Dmaven.test.skip=true \
+mvn -Pnative -pl server -am -DskipTests \
   -DskipNativeBuild=true \
   -Dspring-boot.build-image.imageName=kkrepo:native \
-  package spring-boot:build-image-no-fork
+  clean install spring-boot:build-image-no-fork
 ```
 
-Use `build-image-no-fork` for this multi-module reactor. The resulting `kkrepo:native` image accepts the same database, secret, storage, and server configuration as the JVM image.
+Use `build-image-no-fork` for this multi-module reactor. This command must use `-DskipTests`, not `-Dmaven.test.skip=true`, because downstream persistence modules still consume test-jars compiled and attached by the reactor. The resulting `kkrepo:native` image accepts the same database, secret, storage, and server configuration as the JVM image.
 
-The Docker image helper exposes the same behavior through an explicit option:
+The recommended helper wraps these arguments and verifies that the image exists:
 
 ```bash
 ./scripts/build-docker-image.sh --native kkrepo:native
 ```
+
+To compile Native once, generate the release archives, and retain the corresponding image, run:
+
+```bash
+KKREPO_NATIVE_IMAGE=kkrepo:native \
+KKREPO_KEEP_NATIVE_IMAGE=true \
+  ./scripts/build-dist.sh --native
+```
+
+`KKREPO_NATIVE_IMAGE` selects the intermediate and retained image tag. By default, `build-dist.sh --native` removes its temporary image after extracting the executable; it retains that image only when `KKREPO_KEEP_NATIVE_IMAGE` is explicitly set to `true`.
+
+These local commands build only for the Docker daemon's current platform: for example, an x86_64 Linux Docker host produces `linux/amd64`, while an ARM64 Linux Docker host produces `linux/arm64`. They do not cross-compile the Native binary through emulation. The GitHub `Release Packages` workflow builds on native `amd64` and `arm64` runners and then combines the results into a multi-architecture manifest.
 
 Without `--native`, the helper continues to build the JVM image. Native packaging has passed the full real-client E2E matrix on both MySQL and PostgreSQL. Before production adoption, validate the optional integrations used by your deployment, especially external Apollo configuration and OSS/S3 providers. See the [Native Image or JVM Selection Guide](native-vs-jvm-guide.md) for the measured tradeoffs and current recommendation.
 
@@ -218,7 +263,7 @@ server/target/kkrepo-<release-version>-native-linux-<architecture>.tar.gz
 server/target/kkrepo-<release-version>-native-linux-<architecture>.zip
 ```
 
-The GitHub `Release Packages` workflow builds the public release matrix from merged `main`: one platform-independent JVM archive pair, Native Linux `amd64` and `arm64` archive pairs, and a combined SHA-256 manifest. It only produces verified workflow artifacts; creating the GitHub Release and uploading those assets remain a separate, explicit release step.
+When manually dispatched, the GitHub `Release Packages` workflow accepts only a version already merged into `main` and builds the public release matrix: one platform-independent JVM archive pair, Native Linux `amd64` and `arm64` archive pairs, and a combined SHA-256 manifest. The same architecture-native builds first push `<version>-native-amd64` and `<version>-native-arm64`, then combine them into the public versioned `<version>-native` and rolling `native-latest` multi-architecture manifests. Creating the GitHub Release and uploading the archive assets remain a separate, explicit release step.
 
 The default remains JVM packaging. A JVM archive contains `lib/kkrepo.jar`; a Native archive contains the executable `lib/kkrepo`. The shared `bin/start.sh` selects the packaged runtime automatically, so the service commands and external configuration layout remain the same. Native archives do not require a Java runtime on the target host, but they must run on the matching operating system and CPU architecture.
 

--- a/docs/zh/build-deployment-guide.md
+++ b/docs/zh/build-deployment-guide.md
@@ -45,7 +45,7 @@ bash quickstart.sh
 
 默认会启动：
 
-- `ghcr.io/klboke/kkrepo:0.5.1`
+- `ghcr.io/klboke/kkrepo:0.6.0`
 - MySQL 8.0
 - 用于本地试用的持久化 MySQL volume 和 File blob storage volume
 
@@ -137,7 +137,7 @@ server/target/kkrepo-server-<version>.jar
 拉取最新公开发行镜像：
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:0.5.1
+docker pull ghcr.io/klboke/kkrepo:0.6.0
 ```
 
 也可以使用 `latest` 跟随最新公开发行版本：
@@ -217,6 +217,8 @@ server/target/kkrepo-<release-version>.zip
 server/target/kkrepo-<release-version>-native-linux-<architecture>.tar.gz
 server/target/kkrepo-<release-version>-native-linux-<architecture>.zip
 ```
+
+GitHub 的 `Release Packages` 工作流会从已合并的 `main` 构建公开发行矩阵：一组平台无关的 JVM 压缩包、Native Linux `amd64` 和 `arm64` 压缩包，以及一份合并的 SHA-256 清单。该工作流只生成经过校验的工作流产物；创建 GitHub Release 和上传这些资产仍是后续独立、显式的发行步骤。
 
 默认仍是 JVM 打包。JVM 压缩包包含 `lib/kkrepo.jar`，Native 压缩包包含可执行文件 `lib/kkrepo`。共用的 `bin/start.sh` 会自动选择包内运行时，因此服务命令和外部配置目录保持一致。Native 压缩包的目标机器不需要 Java，但操作系统和 CPU 架构必须与包名一致。
 

--- a/docs/zh/build-deployment-guide.md
+++ b/docs/zh/build-deployment-guide.md
@@ -7,7 +7,7 @@
 - JDK 25
 - Maven 3.9 或兼容版本
 - MySQL 8.0 或 PostgreSQL 12+（生产使用仍在维护期的 PostgreSQL 版本）
-- 可选：Docker，用于构建镜像或运行容器化依赖
+- 可选：Docker，用于构建镜像或运行容器化依赖；构建 Native 镜像或 Native 压缩包时必须启动 Docker daemon，并允许拉取 Cloud Native Buildpacks 的 builder/run 镜像
 
 服务运行时依赖一个共享关系数据库：默认使用 MySQL，也支持 PostgreSQL。blob store 本地试用可以使用 File，生产环境建议使用 OSS/S3。详见[数据库后端](database-backends.md)。
 
@@ -26,11 +26,27 @@ curl -fsSL https://raw.githubusercontent.com/klboke/kkrepo/main/scripts/quicksta
   | KKREPO_DATABASE_TYPE=postgresql bash
 ```
 
+默认使用 JVM 运行时。如需改用 Native 镜像：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/klboke/kkrepo/main/scripts/quickstart.sh \
+  | KKREPO_RUNTIME=native bash
+```
+
+运行时和数据库可以独立选择。使用 Native 镜像和 PostgreSQL 启动：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/klboke/kkrepo/main/scripts/quickstart.sh \
+  | KKREPO_RUNTIME=native KKREPO_DATABASE_TYPE=postgresql bash
+```
+
+`KKREPO_RUNTIME=jvm` 选择 `ghcr.io/klboke/kkrepo:0.6.0`，`KKREPO_RUNTIME=native` 选择 `ghcr.io/klboke/kkrepo:0.6.0-native`。两种镜像均发布 Linux `amd64` 和 `arm64` 架构。显式设置 `KKREPO_IMAGE_TAG` 时，会覆盖对应运行时的默认 tag。
+
 该脚本会逐步打印日志并执行：
 
 1. 检查 Docker、Docker Compose 和 curl。
 2. 创建 `kkrepo-quickstart/` 工作目录。
-3. 生成 `.env`，保存镜像 tag、端口和本地试用密钥。
+3. 生成 `.env`，保存运行时、镜像 tag、端口和本地试用密钥。
 4. 下载 `docker-compose.quickstart.yml`。
 5. 检查宿主机端口占用。
 6. 拉取镜像并执行 `docker compose up -d`。
@@ -45,7 +61,7 @@ bash quickstart.sh
 
 默认会启动：
 
-- `ghcr.io/klboke/kkrepo:0.6.0`
+- `ghcr.io/klboke/kkrepo:0.6.0` 中的 JVM 运行时
 - MySQL 8.0
 - 用于本地试用的持久化 MySQL volume 和 File blob storage volume
 
@@ -146,6 +162,13 @@ docker pull ghcr.io/klboke/kkrepo:0.6.0
 docker pull ghcr.io/klboke/kkrepo:latest
 ```
 
+Native 镜像使用独立 tag：
+
+```bash
+docker pull ghcr.io/klboke/kkrepo:0.6.0-native
+docker pull ghcr.io/klboke/kkrepo:native-latest
+```
+
 构建默认镜像：
 
 ```bash
@@ -157,6 +180,16 @@ docker pull ghcr.io/klboke/kkrepo:latest
 ```bash
 ./scripts/build-docker-image.sh kkrepo:local
 ```
+
+构建当前 Docker 主机架构的 Native 镜像：
+
+```bash
+./scripts/build-docker-image.sh --native kkrepo:native-local
+docker image inspect kkrepo:native-local \
+  --format '{{.Os}}/{{.Architecture}} {{json .Config.Entrypoint}}'
+```
+
+该命令通过 Spring Boot Cloud Native Buildpacks 在容器中完成 GraalVM 编译，本机不需要预装 GraalVM。它生成的是可直接运行的 OCI 镜像，而不是供现有 `Dockerfile` 再次复制的中间二进制，因此不需要新增 Native 专用 Dockerfile。首次构建需要下载 builder、run image 和 Native 工具链，耗时与内存占用会明显高于 JVM 镜像构建。
 
 容器化部署仍建议使用独立 MySQL 和 OSS/S3 blob store，不建议把容器本地文件系统作为长期生产 blob 存储。
 
@@ -172,19 +205,31 @@ mvn -Pnative -pl server -am -DskipTests package
 如果不想在本机安装 GraalVM，也可以通过 Cloud Native Buildpacks 在容器中完成原生编译：
 
 ```bash
-mvn -Pnative -pl server -am -Dmaven.test.skip=true \
+mvn -Pnative -pl server -am -DskipTests \
   -DskipNativeBuild=true \
   -Dspring-boot.build-image.imageName=kkrepo:native \
-  package spring-boot:build-image-no-fork
+  clean install spring-boot:build-image-no-fork
 ```
 
-本项目是多模块 Maven reactor，构建镜像时应使用 `build-image-no-fork`。生成的 `kkrepo:native` 镜像沿用 JVM 镜像的数据库、密钥、存储和服务端配置。
+本项目是多模块 Maven reactor，构建镜像时应使用 `build-image-no-fork`。这里必须使用 `-DskipTests`，不能使用 `-Dmaven.test.skip=true`，因为下游 persistence 模块仍需要 reactor 中编译并附加的 test-jar。生成的 `kkrepo:native` 镜像沿用 JVM 镜像的数据库、密钥、存储和服务端配置。
 
-Docker 镜像辅助脚本也提供相同的显式入口：
+推荐使用封装了上述参数和镜像存在性检查的辅助脚本：
 
 ```bash
 ./scripts/build-docker-image.sh --native kkrepo:native
 ```
+
+如果需要一次 Native 编译同时生成发行压缩包并保留对应镜像，可以执行：
+
+```bash
+KKREPO_NATIVE_IMAGE=kkrepo:native \
+KKREPO_KEEP_NATIVE_IMAGE=true \
+  ./scripts/build-dist.sh --native
+```
+
+`KKREPO_NATIVE_IMAGE` 指定中间及最终保留的镜像 tag；默认情况下 `build-dist.sh --native` 会在提取可执行文件后清理临时镜像，只有将 `KKREPO_KEEP_NATIVE_IMAGE` 显式设为 `true` 才会保留。
+
+以上本地命令只生成 Docker daemon 当前平台的镜像，例如在 x86_64 Linux Docker 主机上生成 `linux/amd64`，在 ARM64 Linux Docker 主机上生成 `linux/arm64`。它不通过模拟器交叉编译 Native 二进制。正式发行由 GitHub `Release Packages` 工作流分别在原生 `amd64` 和 `arm64` runner 上构建，再合并为多架构 manifest。
 
 不传 `--native` 时，脚本仍构建 JVM 镜像。Native 打包已在 MySQL 和 PostgreSQL 上通过完整真实客户端 E2E 矩阵。用于生产前，应验证实际部署使用的可选集成，尤其是外部 Apollo 配置中心及 OSS/S3 存储提供方。实测差异和当前建议见 [Native Image 与 JVM 选型指南](native-vs-jvm-guide.md)。
 
@@ -218,7 +263,7 @@ server/target/kkrepo-<release-version>-native-linux-<architecture>.tar.gz
 server/target/kkrepo-<release-version>-native-linux-<architecture>.zip
 ```
 
-GitHub 的 `Release Packages` 工作流会从已合并的 `main` 构建公开发行矩阵：一组平台无关的 JVM 压缩包、Native Linux `amd64` 和 `arm64` 压缩包，以及一份合并的 SHA-256 清单。该工作流只生成经过校验的工作流产物；创建 GitHub Release 和上传这些资产仍是后续独立、显式的发行步骤。
+手动触发 GitHub 的 `Release Packages` 工作流后，它只接受已经合并到 `main` 的版本，并构建公开发行矩阵：一组平台无关的 JVM 压缩包、Native Linux `amd64` 和 `arm64` 压缩包，以及一份合并的 SHA-256 清单。同一批对应架构的 Native 构建会先推送 `<version>-native-amd64` 和 `<version>-native-arm64` 镜像，再合成为公开使用的版本化 `<version>-native` 和滚动更新的 `native-latest` 多架构 manifest。创建 GitHub Release 和上传压缩包资产仍是后续独立、显式的发行步骤。
 
 默认仍是 JVM 打包。JVM 压缩包包含 `lib/kkrepo.jar`，Native 压缩包包含可执行文件 `lib/kkrepo`。共用的 `bin/start.sh` 会自动选择包内运行时，因此服务命令和外部配置目录保持一致。Native 压缩包的目标机器不需要 Java，但操作系统和 CPU 架构必须与包名一致。
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
   </modules>
 
   <properties>
-    <revision>0.5.1</revision>
+    <revision>0.6.0</revision>
     <java.version>25</java.version>
     <spring.boot.version>4.1.0</spring.boot.version>
     <native-build-tools-plugin.version>1.1.1</native-build-tools-plugin.version>

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -12,6 +12,9 @@ Usage: scripts/build-dist.sh [--native]
 
 Builds JVM tar.gz and zip archives by default. Pass --native explicitly to
 build platform-specific Spring AOT/GraalVM native archives through Docker.
+
+Set KKREPO_NATIVE_IMAGE to choose the intermediate Native image tag. Set
+KKREPO_KEEP_NATIVE_IMAGE=true to retain that image after packaging.
 EOF
 }
 
@@ -47,16 +50,19 @@ echo "[dist] project version: $PROJECT_VERSION"
 echo "[dist] archive version: $DIST_VERSION"
 
 if [[ "$BUILD_MODE" == "native" ]]; then
-  NATIVE_IMAGE="kkrepo:native-dist-${DIST_VERSION//[^a-zA-Z0-9_.-]/-}-$$"
+  NATIVE_IMAGE="${KKREPO_NATIVE_IMAGE:-kkrepo:native-dist-${DIST_VERSION//[^a-zA-Z0-9_.-]/-}-$$}"
+  KEEP_NATIVE_IMAGE="${KKREPO_KEEP_NATIVE_IMAGE:-false}"
   NATIVE_CONTAINER="kkrepo-native-dist-extract-$$"
 
   cleanup_native_build() {
     docker rm -f "$NATIVE_CONTAINER" >/dev/null 2>&1 || true
-    docker image rm "$NATIVE_IMAGE" >/dev/null 2>&1 || true
+    if [[ "$KEEP_NATIVE_IMAGE" != "true" ]]; then
+      docker image rm "$NATIVE_IMAGE" >/dev/null 2>&1 || true
+    fi
   }
   trap cleanup_native_build EXIT
 
-  echo "[dist] building Spring AOT/GraalVM native image..."
+  echo "[dist] building Spring AOT/GraalVM native image $NATIVE_IMAGE..."
   scripts/build-docker-image.sh --native "$NATIVE_IMAGE"
 
   NATIVE_OS="$(docker image inspect "$NATIVE_IMAGE" --format '{{.Os}}')"

--- a/scripts/ci/test-quickstart-runtime.sh
+++ b/scripts/ci/test-quickstart-runtime.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/kkrepo-quickstart-runtime.XXXXXX")"
+FAKE_BIN="$TMP_ROOT/bin"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+mkdir -p "$FAKE_BIN"
+
+cat >"$FAKE_BIN/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "info" ]]; then
+  exit 0
+fi
+if [[ "${1:-}" == "compose" && "${2:-}" == "version" ]]; then
+  exit 0
+fi
+if [[ "${1:-}" == "compose" ]]; then
+  if [[ " $* " == *" pull "* ]]; then
+    printf '%s|%s\n' "$KKREPO_RUNTIME" "$KKREPO_IMAGE_TAG" >> "$KKREPO_TEST_LOG"
+  fi
+  exit 0
+fi
+
+echo "unexpected docker invocation: $*" >&2
+exit 1
+EOF
+
+cat >"$FAKE_BIN/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '{"status":"UP"}\n'
+EOF
+
+chmod 0755 "$FAKE_BIN/docker" "$FAKE_BIN/curl"
+
+run_quickstart() {
+  local name=$1
+  shift
+  local workdir="$TMP_ROOT/$name"
+  local log_file="$TMP_ROOT/$name.log"
+  : > "$log_file"
+  env \
+    PATH="$FAKE_BIN:$PATH" \
+    KKREPO_DIR="$workdir" \
+    KKREPO_SKIP_PORT_CHECK=true \
+    KKREPO_TEST_LOG="$log_file" \
+    "$@" \
+    bash "$ROOT/scripts/quickstart.sh" >"$TMP_ROOT/$name.out" 2>&1
+}
+
+run_quickstart default-jvm
+grep -qx 'KKREPO_RUNTIME=jvm' "$TMP_ROOT/default-jvm/.env"
+grep -qx 'KKREPO_IMAGE_TAG=0.6.0' "$TMP_ROOT/default-jvm/.env"
+grep -qx 'jvm|0.6.0' "$TMP_ROOT/default-jvm.log"
+
+run_quickstart native KKREPO_RUNTIME=native
+grep -qx 'KKREPO_RUNTIME=native' "$TMP_ROOT/native/.env"
+grep -qx 'KKREPO_IMAGE_TAG=0.6.0-native' "$TMP_ROOT/native/.env"
+grep -qx 'native|0.6.0-native' "$TMP_ROOT/native.log"
+
+mkdir -p "$TMP_ROOT/existing-jvm"
+cat >"$TMP_ROOT/existing-jvm/.env" <<'EOF'
+KKREPO_RUNTIME=jvm
+KKREPO_IMAGE_TAG=0.6.0
+EOF
+run_quickstart existing-jvm KKREPO_RUNTIME=native
+grep -qx 'native|0.6.0-native' "$TMP_ROOT/existing-jvm.log"
+
+run_quickstart custom-native \
+  KKREPO_RUNTIME=native \
+  KKREPO_IMAGE_TAG=custom-native
+grep -qx 'native|custom-native' "$TMP_ROOT/custom-native.log"
+
+if run_quickstart invalid-runtime KKREPO_RUNTIME=invalid; then
+  echo "invalid runtime unexpectedly succeeded" >&2
+  exit 1
+fi
+grep -q 'KKREPO_RUNTIME must be jvm or native' "$TMP_ROOT/invalid-runtime.out"
+
+echo "[test] quickstart runtime selection passed"

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -61,6 +61,7 @@ load_env_file_defaults() {
   [[ -f "$file" ]] || return 0
   for key in \
     KKREPO_DATABASE_TYPE \
+    KKREPO_RUNTIME \
     KKREPO_IMAGE_TAG \
     KKREPO_HTTP_PORT \
     KKREPO_MANAGEMENT_PORT \
@@ -89,6 +90,7 @@ create_env_file_if_missing() {
   export KKREPO_CREDENTIAL_SECRET KKREPO_API_KEY_PAYLOAD_SECRET
 
   cat >"$file" <<EOF
+KKREPO_RUNTIME=${KKREPO_RUNTIME}
 KKREPO_IMAGE_TAG=${KKREPO_IMAGE_TAG}
 KKREPO_HTTP_PORT=${KKREPO_HTTP_PORT}
 KKREPO_MANAGEMENT_PORT=${KKREPO_MANAGEMENT_PORT}
@@ -169,9 +171,35 @@ wait_for_health() {
 }
 
 WORKDIR="${KKREPO_DIR:-kkrepo-quickstart}"
+RUNTIME_WAS_EXPLICIT=false
+IMAGE_TAG_WAS_EXPLICIT=false
+if [[ -n "${KKREPO_RUNTIME+x}" ]]; then
+  RUNTIME_WAS_EXPLICIT=true
+fi
+if [[ -n "${KKREPO_IMAGE_TAG+x}" ]]; then
+  IMAGE_TAG_WAS_EXPLICIT=true
+fi
 if [[ -f "${WORKDIR}/.env" ]]; then
   load_env_file_defaults "${WORKDIR}/.env"
 fi
+
+KKREPO_RUNTIME="${KKREPO_RUNTIME:-jvm}"
+case "$KKREPO_RUNTIME" in
+  jvm)
+    DEFAULT_IMAGE_TAG="0.6.0"
+    ;;
+  native)
+    DEFAULT_IMAGE_TAG="0.6.0-native"
+    ;;
+  *)
+    fail "KKREPO_RUNTIME must be jvm or native, got: $KKREPO_RUNTIME"
+    ;;
+esac
+if [[ "$RUNTIME_WAS_EXPLICIT" == "true" && "$IMAGE_TAG_WAS_EXPLICIT" == "false" ]]; then
+  unset KKREPO_IMAGE_TAG
+fi
+: "${KKREPO_IMAGE_TAG:=$DEFAULT_IMAGE_TAG}"
+
 KKREPO_DATABASE_TYPE="${KKREPO_DATABASE_TYPE:-mysql}"
 case "$KKREPO_DATABASE_TYPE" in
   mysql)
@@ -211,11 +239,11 @@ if [[ -f .env ]]; then
   load_env_file_defaults .env
 fi
 
-: "${KKREPO_IMAGE_TAG:=0.6.0}"
 : "${KKREPO_HTTP_PORT:=19090}"
 : "${KKREPO_MANAGEMENT_PORT:=19091}"
 : "${KKREPO_PROJECT_NAME:=kkrepo-quickstart}"
 export \
+  KKREPO_RUNTIME \
   KKREPO_IMAGE_TAG \
   KKREPO_HTTP_PORT \
   KKREPO_MANAGEMENT_PORT \
@@ -231,6 +259,7 @@ download_compose_file "$COMPOSE_FILE"
 COMPOSE_READY=true
 log "Compose file: $(pwd)/$COMPOSE_FILE"
 log "Database backend: ${KKREPO_DATABASE_TYPE}"
+log "Runtime: ${KKREPO_RUNTIME}"
 log "Image tag: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG}"
 log "HTTP port: ${KKREPO_HTTP_PORT}"
 log "Management port: ${KKREPO_MANAGEMENT_PORT}"

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -211,7 +211,7 @@ if [[ -f .env ]]; then
   load_env_file_defaults .env
 fi
 
-: "${KKREPO_IMAGE_TAG:=0.5.1}"
+: "${KKREPO_IMAGE_TAG:=0.6.0}"
 : "${KKREPO_HTTP_PORT:=19090}"
 : "${KKREPO_MANAGEMENT_PORT:=19091}"
 : "${KKREPO_PROJECT_NAME:=kkrepo-quickstart}"


### PR DESCRIPTION
## Summary

- bump the Maven revision, Dockerfile, quickstart defaults, Helm app version, and English/Chinese deployment guides to `0.6.0`
- add the `0.6.0` changelog for Ansible Galaxy, npm minimum release age, Spring Native/AOT, trusted Docker forwarded headers, dependency updates, and the V34-V35 upgrade path
- add `KKREPO_RUNTIME=jvm|native` to quickstart, independently composable with `KKREPO_DATABASE_TYPE=mysql|postgresql`
- document local Native image builds, one-pass Native image/archive builds, platform limits, and why Cloud Native Buildpacks do not require a separate Native Dockerfile
- add a manually dispatched `Release Packages` workflow that only runs from merged `main`
- build and verify JVM plus Native Linux `amd64`/`arm64` archives, push per-architecture Native images, and publish `0.6.0-native` plus `native-latest` multi-architecture manifests
- keep package/image generation separate from GitHub Release creation so assets can be inspected before `v0.6.0` is published

## Release package matrix

| Runtime | Runner | Assets | Container image |
| --- | --- | --- | --- |
| JVM | `ubuntu-24.04` | `kkrepo-0.6.0.tar.gz`, `kkrepo-0.6.0.zip` | existing release-image workflow |
| Native Linux amd64 | `ubuntu-24.04` | `kkrepo-0.6.0-native-linux-amd64.tar.gz`, `kkrepo-0.6.0-native-linux-amd64.zip` | `ghcr.io/klboke/kkrepo:0.6.0-native-amd64` |
| Native Linux arm64 | `ubuntu-24.04-arm` | `kkrepo-0.6.0-native-linux-arm64.tar.gz`, `kkrepo-0.6.0-native-linux-arm64.zip` | `ghcr.io/klboke/kkrepo:0.6.0-native-arm64` |

The workflow validates the requested version against the POM, checks the JVM manifest or Native executable architecture, verifies both archive formats, emits one combined SHA-256 manifest, and combines the Native images into `ghcr.io/klboke/kkrepo:0.6.0-native` and `ghcr.io/klboke/kkrepo:native-latest`. It does not create a tag or GitHub Release.

## Quickstart

```bash
# Native + MySQL
curl -fsSL https://raw.githubusercontent.com/klboke/kkrepo/main/scripts/quickstart.sh | KKREPO_RUNTIME=native bash

# Native + PostgreSQL
curl -fsSL https://raw.githubusercontent.com/klboke/kkrepo/main/scripts/quickstart.sh | KKREPO_RUNTIME=native KKREPO_DATABASE_TYPE=postgresql bash
```

An explicit `KKREPO_IMAGE_TAG` still overrides the runtime default. A regression script covers JVM defaults, Native selection, existing `.env` overrides, custom tags, and invalid runtime rejection.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release-packages.yml .github/workflows/ci.yml`
- `mvn -B -ntp -N validate`
- `scripts/build-dist.sh --jvm` — all 27 reactor modules built successfully and both JVM archives were verified
- `KKREPO_NATIVE_IMAGE=kkrepo:0.6.0-native-release-test KKREPO_KEEP_NATIVE_IMAGE=true scripts/build-dist.sh --native` — all 27 reactor modules built successfully; a runnable `linux/amd64` non-root Buildpacks image plus tar.gz/zip Native archives were produced
- verified the Native image platform, user, entrypoint, archive integrity, executable mode, and x86-64 ELF runtime
- `scripts/ci/test-quickstart-runtime.sh`
- `scripts/ci/test-dist-launcher.sh`
- MySQL and PostgreSQL quickstart Compose configuration validation
- `helm lint deploy/helm/kkrepo`
- `git diff --check`

The current `main` baseline also built a Native candidate and passed the full Native real-client matrix on MySQL and PostgreSQL during the Ansible Galaxy PR validation.