### PR TITLE
Refine admin/browse/login UI with a shared design system

### DIFF
--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
@@ -1,14 +1,4 @@
-:root {
-  --topbar: #202020;
-  --sidebar: #d9d9d9;
-  --sidebar-head: #4a4a4a;
-  --active: #2db671;
-  --text: #3a3a3a;
-  --line: #c4c4c4;
-  --row: #ffffff;
-  --row-alt: #f7f7f7;
-  --header: #f1f1f1;
-}
+/* Theme tokens live in the shared tokens.css (linked before this file). */
 
 * {
   box-sizing: border-box;
@@ -73,15 +63,15 @@ select {
 }
 
 .toast.ok {
-  border-color: #9fd3b5;
-  background: #f2fbf6;
-  color: #137546;
+  border-color: var(--success-line);
+  background: var(--success-bg);
+  color: var(--success);
 }
 
 .toast.error {
-  border-color: #efb2b0;
-  background: #fff5f5;
-  color: #a12622;
+  border-color: var(--danger-line);
+  background: var(--danger-bg);
+  color: var(--danger);
 }
 
 .migration-result {
@@ -151,7 +141,7 @@ select {
 }
 
 .ops-status.error {
-  color: #a12622;
+  color: var(--danger);
 }
 
 .migration-progress-panel {
@@ -196,7 +186,7 @@ select {
 .repo-progress-track i {
   display: block;
   height: 100%;
-  background: #26816f;
+  background: var(--brand);
 }
 
 .migration-progress-meta {
@@ -234,14 +224,14 @@ select {
 }
 
 .migration-error-panel {
-  border: 1px solid #efb2b0;
-  background: #fff5f5;
+  border: 1px solid var(--danger-line);
+  background: var(--danger-bg);
   padding: 10px;
 }
 
 .migration-error-panel .migration-list-title {
   margin-top: 0;
-  color: #a12622;
+  color: var(--danger);
 }
 
 .nx-table.compact th,
@@ -448,7 +438,7 @@ select {
   border: 1px solid #cfd8d4;
   border-radius: 8px;
   background: #ffffff;
-  box-shadow: 0 12px 28px rgba(12, 25, 21, 0.18);
+  box-shadow: var(--shadow-pop);
   padding: 6px;
 }
 
@@ -468,7 +458,7 @@ select {
   color: #22312e;
   cursor: pointer;
   font-size: 13px;
-  font-weight: 650;
+  font-weight: var(--fw-semibold);
   padding: 0 10px;
   text-align: left;
 }
@@ -1026,7 +1016,7 @@ body {
 }
 
 .member-list:focus-within {
-  border-color: #2db671;
+  border-color: var(--brand);
   outline: none;
 }
 
@@ -1057,7 +1047,7 @@ body {
 
 .member-row.is-selected {
   background: #d9efe2;
-  color: #11663f;
+  color: var(--success);
   font-weight: 600;
 }
 
@@ -1070,11 +1060,11 @@ body {
 }
 
 .member-row.drop-target-above {
-  box-shadow: inset 0 2px 0 0 #2db671;
+  box-shadow: inset 0 2px 0 0 var(--brand);
 }
 
 .member-row.drop-target-below {
-  box-shadow: inset 0 -2px 0 0 #2db671;
+  box-shadow: inset 0 -2px 0 0 var(--brand);
 }
 
 .member-handle {
@@ -1089,7 +1079,7 @@ body {
   height: 20px;
   place-items: center;
   border-radius: 3px;
-  background: #2db671;
+  background: var(--brand);
   color: #ffffff;
   font-size: 11px;
   font-weight: 700;
@@ -1138,8 +1128,8 @@ body {
 }
 
 .member-action:hover:not(:disabled) {
-  border-color: #2db671;
-  color: #11663f;
+  border-color: var(--brand);
+  color: var(--success);
 }
 
 .member-action:disabled {
@@ -1182,22 +1172,22 @@ body {
 
 .state-badge.ok {
   background: #dff6e9;
-  color: #137546;
+  color: var(--success);
 }
 
 .state-badge.warn {
-  background: #fff2cc;
+  background: var(--warning-bg);
   color: #8a5a00;
 }
 
 .state-badge.checking {
-  background: #e8eef7;
+  background: var(--info-bg);
   color: #355272;
 }
 
 .state-badge.bad {
-  background: #fde2e1;
-  color: #a12622;
+  background: var(--danger-bg);
+  color: var(--danger);
 }
 
 .health-detail {
@@ -1272,7 +1262,7 @@ code {
 .repo-sort-indicator {
   display: inline-block;
   width: 12px;
-  color: #737f7b;
+  color: var(--ink-4);
   opacity: 0.65;
 }
 
@@ -1451,37 +1441,14 @@ code {
   }
 }
 
-/* --- kkrepo visual refresh: CSS-only, non-Nexus treatment --- */
-
-:root {
-  --topbar: #000000;
-  --topbar-line: #1a1a1a;
-  --topbar-ink: #f5fbf8;
-  --topbar-muted: #c7d7d2;
-  --topbar-hover: rgba(255, 255, 255, 0.08);
-  --topbar-active: #36c6ae;
-  --sidebar: #ffffff;
-  --sidebar-head: #ffffff;
-  --active: #14756b;
-  --active-ink: #ffffff;
-  --accent: #b85f3d;
-  --accent-soft: #fff1eb;
-  --text: #22312e;
-  --muted: #65746f;
-  --line: #d9e1dc;
-  --row: #ffffff;
-  --row-alt: #f8faf8;
-  --header: #edf3ef;
-  --canvas: #ffffff;
-  --panel: #ffffff;
-  --focus: rgba(20, 117, 107, 0.18);
-  --shadow-soft: 0 10px 28px rgba(37, 52, 48, 0.08);
-}
+/* --- kkRepo visual system: consumes shared tokens.css --- */
 
 body {
   background: var(--canvas);
   color: var(--text);
-  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: var(--font-sans);
+  font-size: var(--fs-base);
+  line-height: var(--lh-base);
 }
 
 button,
@@ -1492,7 +1459,7 @@ textarea {
 }
 
 button {
-  transition: background-color 0.14s ease, border-color 0.14s ease, color 0.14s ease, box-shadow 0.14s ease;
+  transition: background-color 0.14s ease, border-color 0.14s ease, color 0.14s ease, box-shadow 0.14s ease, transform 0.1s ease;
 }
 
 button:focus-visible,
@@ -1535,7 +1502,7 @@ textarea:focus-visible {
     linear-gradient(135deg, var(--active), #1f9380 58%, var(--accent));
   color: #ffffff;
   font-size: 13px;
-  font-weight: 850;
+  font-weight: var(--fw-bold);
   letter-spacing: 0;
   line-height: 1;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.34);
@@ -1544,7 +1511,7 @@ textarea:focus-visible {
 .product-name {
   color: var(--topbar-ink);
   font-size: 15px;
-  font-weight: 750;
+  font-weight: var(--fw-bold);
   line-height: 1.12;
   white-space: nowrap;
 }
@@ -1553,7 +1520,7 @@ textarea:focus-visible {
   margin-left: 4px;
   color: var(--topbar-muted);
   font-size: 11px;
-  font-weight: 650;
+  font-weight: var(--fw-semibold);
   white-space: nowrap;
 }
 
@@ -1570,7 +1537,7 @@ textarea:focus-visible {
   padding: 0 18px;
   color: var(--topbar-muted);
   font-size: 13px;
-  font-weight: 750;
+  font-weight: var(--fw-bold);
 }
 
 .workspace-tab:hover {
@@ -1636,7 +1603,7 @@ textarea:focus-visible {
 .user-pill,
 .signout {
   font-size: 13px;
-  font-weight: 650;
+  font-weight: var(--fw-semibold);
 }
 
 .user-pill {
@@ -1669,13 +1636,13 @@ textarea:focus-visible {
 .toast.ok {
   border-color: #b9dfcf;
   background: #f1faf5;
-  color: #116244;
+  color: var(--success);
 }
 
 .toast.error {
-  border-color: #e6b6ab;
-  background: #fff5f2;
-  color: #9d3e2d;
+  border-color: var(--danger-line);
+  background: var(--danger-bg);
+  color: var(--danger);
 }
 
 .nx-sidebar {
@@ -1715,7 +1682,7 @@ textarea:focus-visible {
   color: #70807a;
   cursor: pointer;
   font-size: 12px;
-  font-weight: 800;
+  font-weight: var(--fw-bold);
   letter-spacing: 0;
   text-transform: uppercase;
 }
@@ -1733,7 +1700,7 @@ textarea:focus-visible {
 .side-group.is-current:not(.is-open) {
   background: var(--active);
   color: var(--active-ink);
-  box-shadow: 0 6px 16px rgba(20, 117, 107, 0.16);
+  box-shadow: var(--shadow-nav);
 }
 
 .side-group-caret {
@@ -1761,14 +1728,14 @@ textarea:focus-visible {
 .side-item {
   padding: 0 14px 0 34px;
   font-size: 14px;
-  font-weight: 650;
+  font-weight: var(--fw-semibold);
 }
 
 .side-item:hover,
 .side-item.is-active {
   background: var(--active);
   color: var(--active-ink);
-  box-shadow: 0 6px 16px rgba(20, 117, 107, 0.16);
+  box-shadow: var(--shadow-nav);
 }
 
 .nx-content {
@@ -1792,19 +1759,21 @@ textarea:focus-visible {
 
 .heading-icon {
   display: inline-grid;
-  width: 34px;
-  height: 34px;
+  width: 36px;
+  height: 36px;
   place-items: center;
-  border-radius: 8px;
+  border-radius: var(--r-md);
   background: var(--accent-soft);
   color: var(--accent);
-  font-size: 19px;
+  font-size: 20px;
 }
 
 h1 {
-  color: #172420;
-  font-size: 22px;
-  font-weight: 760;
+  color: var(--ink-1);
+  font-size: var(--fs-3xl);
+  font-weight: var(--fw-bold);
+  letter-spacing: -0.01em;
+  line-height: var(--lh-tight);
 }
 
 .heading-copy {
@@ -1860,7 +1829,7 @@ h1 {
 .member-action,
 .analyze-button {
   border-radius: 8px;
-  font-weight: 750;
+  font-weight: var(--fw-bold);
 }
 
 .create-button {
@@ -1868,11 +1837,17 @@ h1 {
   border: 1px solid var(--active);
   background: var(--active);
   color: #ffffff;
-  box-shadow: 0 6px 16px rgba(20, 117, 107, 0.18);
+  box-shadow: var(--shadow-nav);
 }
 
 .create-button:hover {
-  background: #0f665e;
+  background: var(--brand-strong);
+  transform: translateY(-1px);
+}
+
+.create-button:active {
+  transform: translateY(0);
+  box-shadow: var(--shadow-press);
 }
 
 .create-button.secondary,
@@ -1890,7 +1865,16 @@ h1 {
 .member-action:hover:not(:disabled),
 .analyze-button:hover {
   border-color: var(--active);
+  background: var(--brand-tint);
   color: var(--active);
+}
+
+.create-button.secondary:active,
+.row-action:active,
+.member-action:active:not(:disabled),
+.analyze-button:active {
+  background: var(--brand-tint-strong);
+  box-shadow: var(--shadow-press);
 }
 
 .row-action.delete-repository-button {
@@ -1900,7 +1884,7 @@ h1 {
 
 .row-action.delete-repository-button:hover {
   border-color: #c97962;
-  background: #fff5f2;
+  background: var(--danger-bg);
 }
 
 .blobstore-form,
@@ -1949,9 +1933,9 @@ h1 {
   max-height: calc(100vh - 48px);
   overflow: auto;
   border: 1px solid var(--line);
-  border-radius: 8px;
+  border-radius: var(--r-md);
   background: #ffffff;
-  box-shadow: 0 28px 80px rgba(17, 24, 39, 0.28);
+  box-shadow: var(--shadow-modal);
 }
 
 .form-modal-panel-narrow {
@@ -2013,7 +1997,7 @@ h1 {
 .form-title,
 .role-transfer-title,
 .migration-list-title {
-  color: #172420;
+  color: var(--ink-1);
 }
 
 .form-grid label,
@@ -2021,7 +2005,7 @@ h1 {
 .member-pane-head {
   color: #344641;
   font-size: 13px;
-  font-weight: 760;
+  font-weight: var(--fw-bold);
   letter-spacing: 0;
 }
 
@@ -2054,7 +2038,7 @@ h1 {
 }
 
 .recipe-combobox-trigger:focus-visible {
-  outline: 3px solid rgba(20, 117, 107, 0.18);
+  outline: 3px solid var(--focus);
   outline-offset: 1px;
 }
 
@@ -2094,7 +2078,7 @@ h1 {
   border: 1px solid var(--line);
   border-radius: 8px;
   background: #ffffff;
-  box-shadow: 0 18px 40px rgba(17, 36, 31, 0.2);
+  box-shadow: var(--shadow-pop);
   padding: 8px;
 }
 
@@ -2151,7 +2135,7 @@ h1 {
 
 .recipe-option-copy strong {
   overflow: hidden;
-  color: #172420;
+  color: var(--ink-1);
   font-size: 13px;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -2163,7 +2147,7 @@ h1 {
   background: #eef2f0;
   color: #53635e;
   font-size: 10px;
-  font-weight: 800;
+  font-weight: var(--fw-bold);
   padding: 4px 6px;
   text-transform: uppercase;
 }
@@ -2194,7 +2178,7 @@ h1 {
 }
 
 .form-grid fieldset legend {
-  color: #52615c;
+  color: var(--ink-3);
   letter-spacing: 0;
 }
 
@@ -2222,12 +2206,12 @@ h1 {
 }
 
 .member-row:hover {
-  background: #f1f7f4;
+  background: var(--row-hover);
 }
 
 .member-row.is-selected {
   background: #e1f1eb;
-  color: #0f665e;
+  color: var(--brand-strong);
 }
 
 .member-order {
@@ -2267,12 +2251,12 @@ code {
 }
 
 .summary-grid strong {
-  color: #172420;
+  color: var(--ink-1);
 }
 
 .migration-error-panel {
-  border-color: #e6b6ab;
-  background: #fff5f2;
+  border-color: var(--danger-line);
+  background: var(--danger-bg);
 }
 
 .code-panel,
@@ -2283,7 +2267,7 @@ code {
 .nx-table-frame {
   margin: 0 24px 24px;
   border: 1px solid var(--line);
-  border-radius: 8px;
+  border-radius: var(--r-md);
   background: var(--panel);
   box-shadow: var(--shadow-soft);
 }
@@ -2305,9 +2289,9 @@ code {
 .nx-table th {
   height: 42px;
   background: var(--header);
-  color: #52615c;
+  color: var(--table-head-ink);
   font-size: 12px;
-  font-weight: 800;
+  font-weight: var(--fw-bold);
   letter-spacing: 0;
   text-transform: uppercase;
 }
@@ -2318,7 +2302,7 @@ code {
 }
 
 .nx-table tbody tr:hover {
-  background: #f1f7f4;
+  background: var(--row-hover);
 }
 
 .nx-table tbody tr:last-child td {
@@ -2348,22 +2332,22 @@ code {
 
 .state-badge.ok {
   background: #e1f1eb;
-  color: #116244;
+  color: var(--success);
 }
 
 .state-badge.warn {
-  background: #fff4d8;
+  background: var(--warning-bg);
   color: #805b16;
 }
 
 .state-badge.checking {
-  background: #e8eef7;
+  background: var(--info-bg);
   color: #40577d;
 }
 
 .state-badge.bad {
-  background: #fff0ed;
-  color: #9d3e2d;
+  background: var(--danger-bg);
+  color: var(--danger);
 }
 
 .health-score {

--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
@@ -1499,7 +1499,7 @@ textarea:focus-visible {
   border-radius: 8px;
   background:
     linear-gradient(135deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0) 45%),
-    linear-gradient(135deg, var(--active), #1f9380 58%, var(--accent));
+    linear-gradient(135deg, var(--active), var(--brand-bright) 58%, var(--accent));
   color: #ffffff;
   font-size: 13px;
   font-weight: var(--fw-bold);

--- a/admin-ui/src/main/resources/META-INF/resources/admin/index.html
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/index.html
@@ -5,9 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>kkrepo administration</title>
     <link rel="icon" type="image/svg+xml" href="/admin/assets/favicon.svg?v=20260609-kl-logo-1">
+    <link rel="stylesheet" href="/browse/assets/tokens.css?v=20260724-visual-upgrade-1">
     <link rel="stylesheet" href="/browse/assets/format-icons.css?v=20260721-ansiblegalaxy-1">
     <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260712-sortable-headers-1">
-    <link rel="stylesheet" href="./assets/admin.css?v=20260712-sortable-headers-1">
+    <link rel="stylesheet" href="./assets/admin.css?v=20260724-visual-upgrade-1">
   </head>
   <body>
     <div class="nx-shell">

--- a/admin-ui/src/main/resources/META-INF/resources/login/assets/login-modal.css
+++ b/admin-ui/src/main/resources/META-INF/resources/login/assets/login-modal.css
@@ -15,10 +15,10 @@
 
 .login-dialog {
   width: min(100%, 420px);
-  border: 1px solid #cbd4cf;
-  border-radius: 6px;
-  background: #ffffff;
-  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.26);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-md);
+  background: var(--surface);
+  box-shadow: var(--shadow-modal);
 }
 
 .login-dialog-header {
@@ -26,13 +26,13 @@
   align-items: center;
   justify-content: space-between;
   min-height: 52px;
-  border-bottom: 1px solid #d8dfdb;
+  border-bottom: 1px solid var(--line);
   padding: 0 16px 0 20px;
 }
 
 .login-dialog-title {
   margin: 0;
-  color: #2f3b35;
+  color: var(--ink-1);
   font-size: 20px;
   font-weight: 700;
 }
@@ -41,16 +41,16 @@
   width: 34px;
   height: 34px;
   border: 0;
-  border-radius: 4px;
+  border-radius: var(--r-sm);
   background: transparent;
-  color: #4a5650;
+  color: var(--ink-3);
   cursor: pointer;
   font-size: 24px;
   line-height: 1;
 }
 
 .login-dialog-close:hover {
-  background: #edf1ef;
+  background: var(--surface-sunken);
 }
 
 .login-dialog-close {
@@ -79,7 +79,7 @@
 .login-dialog-tabs:not([hidden]) {
   display: flex !important;
   gap: 6px;
-  border-bottom: 1px solid #d8dfdb;
+  border-bottom: 1px solid var(--line);
   padding: 12px 20px 0;
 }
 
@@ -87,24 +87,24 @@
   height: 36px;
   border: 1px solid transparent;
   border-bottom: 0;
-  border-radius: 5px 5px 0 0;
+  border-radius: var(--r-sm) var(--r-sm) 0 0;
   background: transparent;
-  color: #52605a;
+  color: var(--ink-3);
   cursor: pointer;
   font-weight: 700;
   padding: 0 14px;
 }
 
 .login-dialog-tab:hover {
-  background: #eef3f0;
-  color: #24332d;
+  background: var(--surface-sunken);
+  color: var(--ink-1);
 }
 
 .login-dialog-tab.is-active {
-  border-color: #d8dfdb;
-  background: #ffffff;
-  color: #14756b;
-  box-shadow: 0 1px 0 #ffffff;
+  border-color: var(--line);
+  background: var(--surface);
+  color: var(--brand);
+  box-shadow: 0 1px 0 var(--surface);
 }
 
 .login-dialog-oidc-panel:not([hidden]) {
@@ -115,30 +115,30 @@
 .login-dialog-form label {
   display: grid;
   gap: 6px;
-  color: #68736d;
+  color: var(--ink-3);
   font-weight: 700;
 }
 
 .login-dialog-form input {
   width: 100%;
   height: 38px;
-  border: 1px solid #cbd4cf;
-  border-radius: 4px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-sm);
   outline: 0;
-  color: #2f3b35;
+  color: var(--ink-1);
   padding: 0 10px;
 }
 
 .login-dialog-form input:focus {
-  border-color: #2db671;
-  box-shadow: 0 0 0 2px rgba(45, 182, 113, 0.16);
+  border-color: var(--brand);
+  box-shadow: var(--focus-ring);
 }
 
 .login-dialog-error {
-  border: 1px solid #efb2b0;
-  border-radius: 4px;
-  background: #fff5f5;
-  color: #9f2622;
+  border: 1px solid var(--danger-line);
+  border-radius: var(--r-sm);
+  background: var(--danger-bg);
+  color: var(--danger);
   line-height: 1.35;
   padding: 9px 10px;
 }
@@ -151,31 +151,50 @@
 .login-dialog-primary,
 .login-dialog-secondary {
   height: 40px;
-  border-radius: 4px;
+  border-radius: var(--r-sm);
   cursor: pointer;
   font-weight: 700;
+  transition: background-color 0.14s ease, border-color 0.14s ease, color 0.14s ease, box-shadow 0.14s ease, transform 0.1s ease;
 }
 
 .login-dialog-primary {
-  border: 1px solid var(--active, #14756b);
-  background: var(--active, #14756b);
-  color: #ffffff;
+  border: 1px solid var(--brand);
+  background: var(--brand);
+  color: var(--active-ink);
+  box-shadow: var(--shadow-nav);
 }
 
 .login-dialog-primary:hover {
-  border-color: #0f665d;
-  background: #0f665d;
+  border-color: var(--brand-strong);
+  background: var(--brand-strong);
+  transform: translateY(-1px);
+}
+
+.login-dialog-primary:active {
+  transform: translateY(0);
+  box-shadow: var(--shadow-press);
 }
 
 .login-dialog-primary:disabled {
-  border-color: #b8b8b8;
-  background: #d6d9d7;
-  color: #646b67;
+  border-color: var(--line-strong);
+  background: var(--surface-sunken);
+  color: var(--ink-4);
   cursor: not-allowed;
 }
 
 .login-dialog-secondary {
-  border: 1px solid #9ea8a3;
-  background: #ffffff;
-  color: #2f3b35;
+  border: 1px solid var(--line-strong);
+  background: var(--surface);
+  color: var(--ink-1);
+}
+
+.login-dialog-secondary:hover {
+  border-color: var(--brand);
+  background: var(--brand-tint);
+  color: var(--brand);
+}
+
+.login-dialog-secondary:active {
+  background: var(--brand-tint-strong);
+  box-shadow: var(--shadow-press);
 }

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
@@ -1,15 +1,4 @@
-:root {
-  --topbar: #202020;
-  --sidebar: #d9d9d9;
-  --sidebar-head: #4a4a4a;
-  --active: #2db671;
-  --text: #3a3a3a;
-  --muted: #666666;
-  --line: #c4c4c4;
-  --row: #ffffff;
-  --row-alt: #f7f7f7;
-  --header: #f1f1f1;
-}
+/* Theme tokens live in the shared tokens.css (linked before this file). */
 
 * {
   box-sizing: border-box;
@@ -216,7 +205,7 @@ select {
   border: 1px solid #cfd8d4;
   border-radius: 8px;
   background: #ffffff;
-  box-shadow: 0 12px 28px rgba(12, 25, 21, 0.18);
+  box-shadow: var(--shadow-pop);
   padding: 6px;
 }
 
@@ -236,7 +225,7 @@ select {
   color: #22312e;
   cursor: pointer;
   font-size: 13px;
-  font-weight: 650;
+  font-weight: var(--fw-semibold);
   padding: 0 10px;
   text-align: left;
 }
@@ -456,7 +445,7 @@ h1 {
 .repo-sort-indicator {
   display: inline-block;
   width: 12px;
-  color: #737f7b;
+  color: var(--ink-4);
   opacity: 0.65;
 }
 
@@ -580,8 +569,8 @@ h1 {
 }
 
 .repo-copy-button.copy-failed {
-  border-color: #b42318;
-  color: #b42318;
+  border-color: var(--danger);
+  color: var(--danger);
   opacity: 1;
 }
 
@@ -753,7 +742,7 @@ h1 {
 
 .upload-button {
   height: 34px;
-  border: 1px solid #1f8a52;
+  border: 1px solid var(--success);
   border-radius: 3px;
   background: var(--active);
   color: #ffffff;
@@ -774,8 +763,8 @@ h1 {
   font-size: 13px;
 }
 
-.upload-status.ok { color: #1d7b4a; }
-.upload-status.error { color: #b03030; }
+.upload-status.ok { color: var(--success); }
+.upload-status.error { color: var(--danger); }
 
 .token-layout {
   display: grid;
@@ -825,12 +814,12 @@ h1 {
 }
 
 .required-mark {
-  color: #b42318;
+  color: var(--danger);
 }
 
 .token-form input.is-invalid,
 .token-form select.is-invalid {
-  border-color: #d92d20;
+  border-color: var(--danger);
   box-shadow: 0 0 0 2px rgba(217, 45, 32, 0.14);
 }
 
@@ -841,13 +830,13 @@ h1 {
   line-height: 20px;
 }
 
-.token-status.ok { color: #1d7b4a; }
-.token-status.error { color: #b03030; }
+.token-status.ok { color: var(--success); }
+.token-status.error { color: var(--danger); }
 
 .token-panel-title {
-  color: #2d2d2d;
-  font-size: 17px;
-  font-weight: 700;
+  color: var(--ink-1);
+  font-size: var(--fs-lg);
+  font-weight: var(--fw-bold);
 }
 
 .token-note {
@@ -878,7 +867,10 @@ h1 {
 
 .token-table-frame {
   margin-top: 12px;
+  overflow-x: auto;
   border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  box-shadow: var(--shadow-soft);
 }
 
 .token-table {
@@ -896,8 +888,8 @@ h1 {
 }
 
 .token-danger-button {
-  border-color: #c66b6b;
-  color: #9f2f2f;
+  border-color: var(--danger-line);
+  color: var(--danger);
 }
 
 .result-note {
@@ -1001,7 +993,7 @@ h1 {
 
 .admin-bootstrap-button {
   height: 34px;
-  border: 1px solid #1f8a52;
+  border: 1px solid var(--success);
   border-radius: 3px;
   background: var(--active);
   color: #ffffff;
@@ -1023,11 +1015,11 @@ h1 {
 }
 
 .admin-bootstrap-status.error {
-  color: #b03030;
+  color: var(--danger);
 }
 
 .admin-bootstrap-status.ok {
-  color: #1d7b4a;
+  color: var(--success);
 }
 
 @media (max-width: 980px) {
@@ -1092,7 +1084,7 @@ h1 {
 }
 
 .repo-row { cursor: pointer; }
-.repo-row:hover { background: var(--row-alt); }
+.repo-row:hover { background: var(--row-hover); }
 
 .component-result-row {
   cursor: pointer;
@@ -1100,7 +1092,7 @@ h1 {
 
 .component-result-row:hover,
 .component-result-row:focus {
-  background: var(--row-alt);
+  background: var(--row-hover);
   outline: none;
 }
 
@@ -1288,7 +1280,7 @@ h1 {
   font-size: 13px;
 }
 
-.tree-error { color: #b03030; }
+.tree-error { color: var(--danger); }
 
 /* --- Split layout: tree on left, detail on right --- */
 
@@ -1359,10 +1351,10 @@ h1 {
   flex: 0 0 auto;
   min-width: 72px;
   height: 31px;
-  border: 1px solid #b33a3a;
-  border-radius: 3px;
+  border: 1px solid var(--danger);
+  border-radius: var(--r-md);
   background: #ffffff;
-  color: #a32626;
+  color: var(--danger);
   cursor: pointer;
   font-size: 14px;
   font-weight: 700;
@@ -1370,12 +1362,12 @@ h1 {
 }
 
 .detail-delete-button:hover {
-  background: #fff2f2;
+  background: var(--danger-bg);
 }
 
 .detail-delete-button:disabled {
-  border-color: #d8b0b0;
-  color: #b58282;
+  border-color: var(--danger-line);
+  color: var(--danger-line);
   cursor: wait;
 }
 
@@ -1480,7 +1472,7 @@ h1 {
 }
 
 .docker-descriptor-title {
-  color: #333333;
+  color: var(--ink-1);
   font-size: 13px;
   font-weight: 700;
 }
@@ -1528,7 +1520,7 @@ h1 {
 }
 
 .attr-group-title {
-  color: #333333;
+  color: var(--ink-1);
   font-size: 14px;
   font-weight: 700;
   padding: 2px 0 4px 0;
@@ -1578,7 +1570,7 @@ h1 {
   padding: 0;
 }
 
-.usage-copy.copied { background: #2db671; color: #ffffff; border-color: #2db671; }
+.usage-copy.copied { background: var(--brand); color: #ffffff; border-color: var(--brand); }
 
 .usage-hint {
   margin: 10px 0 6px;
@@ -1603,37 +1595,14 @@ h1 {
 
 .download-row { margin-top: 4px; }
 
-/* --- kkrepo visual refresh: CSS-only, non-Nexus treatment --- */
-
-:root {
-  --topbar: #000000;
-  --topbar-line: #1a1a1a;
-  --topbar-ink: #f5fbf8;
-  --topbar-muted: #c7d7d2;
-  --topbar-hover: rgba(255, 255, 255, 0.08);
-  --topbar-active: #36c6ae;
-  --sidebar: #ffffff;
-  --sidebar-head: #ffffff;
-  --active: #14756b;
-  --active-ink: #ffffff;
-  --accent: #b85f3d;
-  --accent-soft: #fff1eb;
-  --text: #22312e;
-  --muted: #65746f;
-  --line: #d9e1dc;
-  --row: #ffffff;
-  --row-alt: #f8faf8;
-  --header: #edf3ef;
-  --canvas: #ffffff;
-  --panel: #ffffff;
-  --focus: rgba(20, 117, 107, 0.18);
-  --shadow-soft: 0 10px 28px rgba(37, 52, 48, 0.08);
-}
+/* --- kkRepo visual system: consumes shared tokens.css --- */
 
 body {
   background: var(--canvas);
   color: var(--text);
-  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: var(--font-sans);
+  font-size: var(--fs-base);
+  line-height: var(--lh-base);
 }
 
 button,
@@ -1644,7 +1613,7 @@ textarea {
 }
 
 button {
-  transition: background-color 0.14s ease, border-color 0.14s ease, color 0.14s ease, box-shadow 0.14s ease;
+  transition: background-color 0.14s ease, border-color 0.14s ease, color 0.14s ease, box-shadow 0.14s ease, transform 0.1s ease;
 }
 
 button:focus-visible,
@@ -1684,10 +1653,10 @@ textarea:focus-visible {
   border-radius: 8px;
   background:
     linear-gradient(135deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0) 45%),
-    linear-gradient(135deg, var(--active), #1f9380 58%, var(--accent));
+    linear-gradient(135deg, var(--active), var(--brand-bright) 58%, var(--accent));
   color: #ffffff;
   font-size: 13px;
-  font-weight: 850;
+  font-weight: var(--fw-bold);
   letter-spacing: 0;
   line-height: 1;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.34);
@@ -1696,7 +1665,7 @@ textarea:focus-visible {
 .product-name {
   color: var(--topbar-ink);
   font-size: 15px;
-  font-weight: 750;
+  font-weight: var(--fw-bold);
   line-height: 1.12;
   white-space: nowrap;
 }
@@ -1705,7 +1674,7 @@ textarea:focus-visible {
   margin-left: 4px;
   color: var(--topbar-muted);
   font-size: 11px;
-  font-weight: 650;
+  font-weight: var(--fw-semibold);
   white-space: nowrap;
 }
 
@@ -1722,7 +1691,7 @@ textarea:focus-visible {
   padding: 0 18px;
   color: var(--topbar-muted);
   font-size: 13px;
-  font-weight: 750;
+  font-weight: var(--fw-bold);
 }
 
 .workspace-tab:hover {
@@ -1788,7 +1757,7 @@ textarea:focus-visible {
 .user-pill,
 .signout {
   font-size: 13px;
-  font-weight: 650;
+  font-weight: var(--fw-semibold);
 }
 
 .user-pill {
@@ -1827,7 +1796,7 @@ textarea:focus-visible {
   height: 42px;
   border-radius: 8px;
   color: #344641;
-  font-weight: 650;
+  font-weight: var(--fw-semibold);
 }
 
 .side-item {
@@ -1868,7 +1837,7 @@ textarea:focus-visible {
 .side-subitem.is-active {
   background: var(--active);
   color: var(--active-ink);
-  box-shadow: 0 6px 16px rgba(20, 117, 107, 0.16);
+  box-shadow: var(--shadow-nav);
 }
 
 .side-item.is-active .side-icon,
@@ -1891,28 +1860,32 @@ textarea:focus-visible {
 
 .heading-icon {
   display: inline-grid;
-  width: 34px;
-  height: 34px;
+  width: 36px;
+  height: 36px;
   place-items: center;
-  border-radius: 8px;
+  border-radius: var(--r-md);
   background: var(--accent-soft);
   color: var(--accent);
-  font-size: 19px;
+  font-size: 20px;
 }
 
 h1 {
-  color: #172420;
-  font-size: 22px;
-  font-weight: 760;
+  color: var(--ink-1);
+  font-size: var(--fs-3xl);
+  font-weight: var(--fw-bold);
+  letter-spacing: -0.01em;
+  line-height: var(--lh-tight);
 }
 
 h2 {
-  color: #172420;
+  color: var(--ink-1);
+  font-size: var(--fs-xl);
+  font-weight: var(--fw-bold);
 }
 
 .heading-copy {
   color: var(--muted);
-  font-size: 14px;
+  font-size: var(--fs-base);
 }
 
 .admin-bootstrap-panel,
@@ -2010,14 +1983,14 @@ h2 {
 
 .format-brand strong {
   min-width: 0;
-  color: #172420;
+  color: var(--ink-1);
   font-size: 14px;
   overflow-wrap: anywhere;
 }
 
 .format-modes {
   font-size: 11px;
-  font-weight: 650;
+  font-weight: var(--fw-semibold);
   line-height: 1.35;
 }
 
@@ -2067,7 +2040,7 @@ h2 {
 .nx-table-frame {
   margin: 0 24px 24px;
   border: 1px solid var(--line);
-  border-radius: 8px;
+  border-radius: var(--r-md);
   background: var(--panel);
   box-shadow: var(--shadow-soft);
 }
@@ -2089,9 +2062,9 @@ h2 {
 .nx-table th {
   height: 42px;
   background: var(--header);
-  color: #52615c;
+  color: var(--table-head-ink);
   font-size: 12px;
-  font-weight: 800;
+  font-weight: var(--fw-bold);
   letter-spacing: 0;
   text-transform: uppercase;
 }
@@ -2102,7 +2075,7 @@ h2 {
 }
 
 .nx-table tbody tr:hover {
-  background: #f1f7f4;
+  background: var(--row-hover);
 }
 
 .nx-table tbody tr:last-child td {
@@ -2139,7 +2112,7 @@ h2 {
 .analyze-btn,
 .usage-copy {
   border-radius: 8px;
-  font-weight: 750;
+  font-weight: var(--fw-bold);
 }
 
 .criteria-button,
@@ -2148,13 +2121,21 @@ h2 {
   border: 1px solid var(--active);
   background: var(--active);
   color: #ffffff;
-  box-shadow: 0 6px 16px rgba(20, 117, 107, 0.18);
+  box-shadow: var(--shadow-nav);
 }
 
 .criteria-button:hover,
 .upload-button:hover,
 .admin-bootstrap-button:hover {
-  background: #0f665e;
+  background: var(--brand-strong);
+  transform: translateY(-1px);
+}
+
+.criteria-button:active,
+.upload-button:active,
+.admin-bootstrap-button:active {
+  transform: translateY(0);
+  box-shadow: var(--shadow-press);
 }
 
 .secondary-button,
@@ -2169,12 +2150,24 @@ h2 {
 }
 
 .secondary-button:hover,
+.criteria-button.secondary:hover,
 .copy-button:hover,
 .repo-copy-button:hover,
 .usage-copy:hover,
 .analyze-btn:hover {
   border-color: var(--active);
+  background: var(--brand-tint);
   color: var(--active);
+}
+
+.secondary-button:active,
+.criteria-button.secondary:active,
+.copy-button:active,
+.repo-copy-button:active,
+.usage-copy:active,
+.analyze-btn:active {
+  background: var(--brand-tint-strong);
+  box-shadow: var(--shadow-press);
 }
 
 .repo-copy-button.copied,
@@ -2196,7 +2189,7 @@ h2 {
 .token-form label {
   color: #344641;
   font-size: 13px;
-  font-weight: 760;
+  font-weight: var(--fw-bold);
 }
 
 .search-form input,
@@ -2270,7 +2263,7 @@ code,
 }
 
 .tree-error {
-  color: #a33a2a;
+  color: var(--danger);
 }
 
 .detail-crumb {
@@ -2288,13 +2281,13 @@ code,
 }
 
 .detail-delete-button {
-  border-color: #d9b8ad;
-  background: #fff8f5;
+  border-color: var(--danger-line);
+  background: var(--danger-bg);
   color: #a54830;
 }
 
 .detail-delete-button:hover {
-  background: #fff1eb;
+  background: var(--danger-bg);
 }
 
 .health-score {
@@ -2533,7 +2526,7 @@ body {
 
 .tree-icon.icon-file-check,
 .crumb-icon.icon-file-check {
-  color: #397667;
+  color: var(--brand);
 }
 
 .tree-icon.icon-binary,
@@ -2603,9 +2596,9 @@ body {
 }
 
 .repo-url-content .repo-copy-button.copy-failed {
-  border-color: #e2a8a8;
-  background: #fff3f3;
-  color: #b42318;
+  border-color: var(--danger-line);
+  background: var(--danger-bg);
+  color: var(--danger);
   opacity: 1;
 }
 

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/tokens.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/tokens.css
@@ -1,0 +1,126 @@
+/*
+ * kkRepo design tokens — single source of truth for the admin console, the
+ * browse UI and the shared login modal. Linked (first) from both
+ * admin/index.html and browse/index.html; login-modal.css consumes the same
+ * variables through those documents.
+ *
+ * Component rules reference the semantic names below. The legacy aliases at the
+ * bottom (--active, --line, --text, ...) map the older names still used across
+ * admin.css / browse.css onto this ramp, so retuning a value here propagates
+ * everywhere at once. Keep this the ONLY :root theme block: the in-file :root
+ * blocks were removed so this file always wins the cascade.
+ */
+:root {
+  color-scheme: light;
+
+  /* ===== Brand — emerald/teal, the single primary accent ===== */
+  --brand: #0e7c6f;
+  --brand-strong: #0a6055;   /* hover / pressed */
+  --brand-tint: #e6f4f0;     /* selected / hover fills */
+  --brand-tint-strong: #d4ebe4;
+  --brand-bright: #2fbfa4;   /* accents on the dark topbar */
+
+  /* ===== Warm signature accent — page-heading chips, logo ===== */
+  --accent: #b8623f;
+  --accent-soft: #f8ede6;
+
+  /* ===== Neutral ramp — cool, faint green undertone ===== */
+  --ink-1: #12211d;          /* headings */
+  --ink-2: #24322e;          /* body text */
+  --ink-3: #5a6a64;          /* muted / secondary */
+  --ink-4: #8b968f;          /* placeholder / disabled text */
+  --line: #dbe2de;           /* hairline borders */
+  --line-strong: #c3cec8;    /* input hover / stronger dividers */
+  --surface: #ffffff;        /* cards, rows, panels */
+  --surface-muted: #f7faf9;  /* zebra / subtle fills */
+  --surface-sunken: #eef3f1; /* table headers, chips */
+  --canvas: #ffffff;         /* page background */
+
+  /* ===== Semantic status ===== */
+  --success: #0f6d47;
+  --success-bg: #e5f4ec;
+  --success-line: #b6ddca;
+  --warning: #8a5a12;
+  --warning-bg: #fdf3d8;
+  --warning-line: #f0dda6;
+  --danger: #a63a26;
+  --danger-bg: #fdefeb;
+  --danger-line: #eec2b6;
+  --info: #2c5686;
+  --info-bg: #e9f0fb;
+  --info-line: #c4d7f0;
+
+  /* ===== Dark topbar ===== */
+  --topbar: #16191b;
+  --topbar-line: #2a2f31;
+  --topbar-ink: #f4f7f6;
+  --topbar-muted: #b4bfba;
+  --topbar-hover: rgba(255, 255, 255, 0.09);
+  --topbar-active: var(--brand-bright);
+
+  /* ===== Radius scale ===== */
+  --r-xs: 4px;
+  --r-sm: 6px;
+  --r-md: 8px;
+  --r-lg: 12px;
+  --r-pill: 999px;
+
+  /* ===== Elevation ===== */
+  --shadow-sm: 0 1px 2px rgba(18, 33, 29, 0.06);
+  --shadow-soft: 0 8px 24px rgba(28, 44, 40, 0.07);
+  --shadow-pop: 0 18px 44px rgba(17, 36, 31, 0.18);
+  --shadow-modal: 0 28px 80px rgba(17, 24, 39, 0.26);
+  --shadow-nav: 0 6px 16px rgba(14, 124, 111, 0.16);
+  --shadow-press: inset 0 1px 2px rgba(17, 36, 31, 0.14);
+
+  /* ===== Focus ===== */
+  --focus: rgba(15, 124, 111, 0.22);
+  --focus-ring: 0 0 0 3px var(--focus);
+
+  /* ===== Spacing scale ===== */
+  --s-1: 4px;
+  --s-2: 8px;
+  --s-3: 12px;
+  --s-4: 16px;
+  --s-5: 24px;
+  --s-6: 32px;
+
+  /* ===== Typography ===== */
+  --font-sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+
+  /* Type scale — used at the hierarchy anchors (headings, body, captions). */
+  --fs-xs: 12px;
+  --fs-sm: 13px;
+  --fs-base: 14px;
+  --fs-lg: 16px;
+  --fs-xl: 18px;
+  --fs-2xl: 22px;
+  --fs-3xl: 26px;
+
+  /* Weight ramp — replaces the scattered fractional weights (650/750/760/850). */
+  --fw-regular: 400;
+  --fw-medium: 500;
+  --fw-semibold: 600;
+  --fw-bold: 700;
+
+  /* Line height */
+  --lh-tight: 1.25;
+  --lh-base: 1.5;
+
+  /* ===== Table ===== */
+  --row-hover: var(--brand-tint);   /* hover row — distinct from the zebra --row-alt */
+  --table-head-ink: var(--ink-3);   /* uppercase column labels */
+
+  /* ===== Legacy aliases — map older names onto the ramp above ===== */
+  --active: var(--brand);
+  --active-ink: #ffffff;
+  --sidebar: var(--surface);
+  --sidebar-head: var(--surface);
+  --text: var(--ink-2);
+  --muted: var(--ink-3);
+  --row: var(--surface);
+  --row-alt: var(--surface-muted);
+  --header: var(--surface-sunken);
+  --panel: var(--surface);
+}

--- a/browse-ui/src/main/resources/META-INF/resources/browse/index.html
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/index.html
@@ -5,10 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>kkrepo browse</title>
     <link rel="icon" type="image/svg+xml" href="/browse/assets/favicon.svg?v=20260609-kl-logo-1">
+    <link rel="stylesheet" href="/browse/assets/tokens.css?v=20260724-visual-upgrade-1">
     <link rel="stylesheet" href="/browse/assets/format-icons.css?v=20260721-ansiblegalaxy-1">
     <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260712-sortable-headers-1">
-    <link rel="stylesheet" href="/browse/assets/browse.css?v=20260712-sortable-headers-1">
-    <link rel="stylesheet" href="/login/assets/login-modal.css?v=20260616-login-method-tabs-2">
+    <link rel="stylesheet" href="/browse/assets/browse.css?v=20260724-visual-upgrade-1">
+    <link rel="stylesheet" href="/login/assets/login-modal.css?v=20260724-visual-upgrade-1">
   </head>
   <body>
     <div class="nx-shell">


### PR DESCRIPTION
## Summary

Systematizes the scattered hardcoded colors/type/tables across the three UI surfaces (Admin console, Browse UI, Login modal) onto a shared design-token foundation, then applies a **visible-but-restrained** visual polish. The dark topbar + sidebar skeleton, DOM structure, and class names are all unchanged — only styling is touched, so `admin.js` bindings are unaffected.

## What changed

**New foundation — `tokens.css`**
Single source of truth extended with a type scale (`--fs-*`), weight ramp (`--fw-*`), line heights, table colors (`--row-hover`, `--table-head-ink`), and a pressed-state shadow (`--shadow-press`).

**Typography & hierarchy**
- H1 bumped to 26px bold with tightened letter-spacing/line-height
- Warm accent chip on page-heading icons
- `body` on the sans token stack + base line-height
- Fractional weights (650/750/760/850/800) collapsed onto `--fw-semibold` / `--fw-bold`
- Heading/label colors moved to `--ink-*` tokens

**Buttons & cards**
- Primary buttons: hardcoded glow → `--shadow-nav`; new hover lift (`translateY(-1px)`) + `:active` pressed state
- Secondary/ghost buttons: `--brand-tint` hover fill + pressed state
- Sidebar/nav glows and popover/modal shadows unified onto elevation tokens
- `.detail-delete-button` radius aligned with sibling buttons

**Tables**
- Unified row hover onto `--row-hover`, removing the two previously inconsistent hover colors
- Table-head ink + sort indicators tokenized
- Table frames share `--r-md` radius and `--shadow-soft`

## Verification
- CSS validity: braces balanced, no broken `var()`, no leftover fractional weights or stale glow literals
- Clean `restart.sh` (authoritative `mvn` recompile)
- Headless-Chrome screenshots confirmed on the Welcome page, Browse table, and login modal — hierarchy clearer, buttons tactile, no broken layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)