### PR TITLE
Fix large npm publish attachment parsing

### DIFF
--- a/compat-test/src/test/java/com/github/klboke/kkrepo/compat/NpmRepositoryBlackBoxCompatibilityTest.java
+++ b/compat-test/src/test/java/com/github/klboke/kkrepo/compat/NpmRepositoryBlackBoxCompatibilityTest.java
@@ -15,7 +15,10 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.time.Duration;
 import java.time.Instant;
@@ -27,6 +30,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -34,6 +38,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPOutputStream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Live npm compatibility checks against a reference Nexus and kkrepo.
@@ -86,6 +91,53 @@ class NpmRepositoryBlackBoxCompatibilityTest {
       assertDistTags(nexus, nexusPlus, fixture);
       assertSearchContains(nexus, fixture.packageName());
       assertSearchContains(nexusPlus, fixture.packageName());
+    } finally {
+      delete(nexus, fixture.packageName());
+      delete(nexusPlus, fixture.packageName());
+    }
+  }
+
+  @Test
+  void hostedLargePublishWithRealNpmClientMatchesNexusWhenConfigured(@TempDir Path tempDir)
+      throws Exception {
+    CompatConfig config = CompatConfig.load();
+    assumeTrue(config.configured(),
+        "Set NEXUS_COMPAT_BASE_URL and KKREPO_COMPAT_BASE_URL to run npm compatibility");
+    assumeTrue(config.writeEnabled(),
+        "Set COMPAT_WRITE_ENABLED=true to run npm write/delete compatibility against disposable repos");
+    assumeTrue(npmAvailable(), "Install npm to run the large real-client publish compatibility test");
+
+    RealNpmFixture fixture = RealNpmFixture.create(tempDir);
+    Endpoint nexus = config.nexusHosted();
+    Endpoint nexusPlus = config.nexusPlusHosted();
+    try {
+      publishWithNpm(nexus, fixture.tarball(), tempDir.resolve("nexus.npmrc"), tempDir);
+      publishWithNpm(nexusPlus, fixture.tarball(), tempDir.resolve("kkrepo.npmrc"), tempDir);
+
+      Map<String, Object> referencePackage = getJson(nexus, fixture.packageName());
+      Map<String, Object> candidatePackage = getJson(nexusPlus, fixture.packageName());
+      assertFalse(referencePackage.containsKey("_attachments"),
+          "Nexus stored package metadata must not retain publish attachments");
+      assertFalse(candidatePackage.containsKey("_attachments"),
+          "kkrepo stored package metadata must not retain publish attachments");
+
+      Map<String, Object> referenceVersion = version(referencePackage, fixture.version());
+      Map<String, Object> candidateVersion = version(candidatePackage, fixture.version());
+      assertPublishedDigests(fixture, referenceVersion, "Nexus");
+      assertPublishedDigests(fixture, candidateVersion, "kkrepo");
+
+      Exchange referenceTarball = get(
+          nexus,
+          tarballPath(nexus, referencePackage, fixture.version()));
+      Exchange candidateTarball = get(
+          nexusPlus,
+          tarballPath(nexusPlus, candidatePackage, fixture.version()));
+      assert2xx("Nexus large npm tarball", referenceTarball);
+      assert2xx("kkrepo large npm tarball", candidateTarball);
+      assertArrayEquals(fixture.tarballBytes(), referenceTarball.body(),
+          "Nexus large published tarball bytes");
+      assertArrayEquals(fixture.tarballBytes(), candidateTarball.body(),
+          "kkrepo large published tarball bytes");
     } finally {
       delete(nexus, fixture.packageName());
       delete(nexusPlus, fixture.packageName());
@@ -403,6 +455,11 @@ class NpmRepositoryBlackBoxCompatibilityTest {
   }
 
   @SuppressWarnings("unchecked")
+  private static Map<String, Object> version(Map<String, Object> doc, String version) {
+    return (Map<String, Object>) versions(doc).get(version);
+  }
+
+  @SuppressWarnings("unchecked")
   private static String latest(Map<String, Object> doc) {
     return ((Map<String, Object>) doc.get("dist-tags")).get("latest").toString();
   }
@@ -522,6 +579,142 @@ class NpmRepositoryBlackBoxCompatibilityTest {
     }
   }
 
+  private record RealNpmFixture(
+      String packageName,
+      String version,
+      Path tarball,
+      byte[] tarballBytes,
+      String sha1,
+      String integrity) {
+    private static final int FIXTURE_BYTES = 30 * 1024 * 1024;
+
+    static RealNpmFixture create(Path tempDir) throws Exception {
+      long stamp = System.currentTimeMillis();
+      String packageName = "kkrepo-npm-large-" + stamp;
+      String version = "1.0.0";
+      Path packageDir = Files.createDirectories(tempDir.resolve("package"));
+      Files.write(
+          packageDir.resolve("package.json"),
+          MAPPER.writeValueAsBytes(Map.of(
+              "name", packageName,
+              "version", version,
+              "description", "kkrepo large npm publish compatibility fixture")));
+      Random random = new Random(stamp);
+      try (OutputStream output = Files.newOutputStream(packageDir.resolve("fixture.bin"))) {
+        byte[] buffer = new byte[64 * 1024];
+        int remaining = FIXTURE_BYTES;
+        while (remaining > 0) {
+          random.nextBytes(buffer);
+          int count = Math.min(buffer.length, remaining);
+          output.write(buffer, 0, count);
+          remaining -= count;
+        }
+      }
+
+      runProcess(
+          List.of(
+              "npm",
+              "pack",
+              packageDir.toString(),
+              "--pack-destination",
+              tempDir.toString(),
+              "--ignore-scripts"),
+          tempDir,
+          Duration.ofMinutes(3));
+      Path tarball = tempDir.resolve(packageName + "-" + version + ".tgz");
+      assertTrue(Files.isRegularFile(tarball), "npm pack should create " + tarball);
+      assertTrue(Files.size(tarball) > 20_000_000L,
+          "large npm fixture must exceed Jackson's default JSON string limit after base64 encoding");
+      byte[] tarballBytes = Files.readAllBytes(tarball);
+      String sha1 = hex(MessageDigest.getInstance("SHA-1").digest(tarballBytes));
+      String integrity = "sha512-" + Base64.getEncoder().encodeToString(
+          MessageDigest.getInstance("SHA-512").digest(tarballBytes));
+      return new RealNpmFixture(packageName, version, tarball, tarballBytes, sha1, integrity);
+    }
+  }
+
+  private static void publishWithNpm(
+      Endpoint endpoint,
+      Path tarball,
+      Path npmrc,
+      Path workingDirectory) throws Exception {
+    String registry = endpoint.repositoryUrl();
+    StringBuilder config = new StringBuilder("registry=").append(registry).append('\n');
+    if (endpoint.username().isPresent() && endpoint.password().isPresent()) {
+      URI registryUri = URI.create(registry);
+      String authScope = "//" + registryUri.getRawAuthority() + registryUri.getRawPath();
+      String credentials = Base64.getEncoder().encodeToString(
+          (endpoint.username().get() + ":" + endpoint.password().get())
+              .getBytes(StandardCharsets.UTF_8));
+      config.append(authScope).append(":_auth=").append(credentials).append('\n');
+    }
+    Files.writeString(npmrc, config, StandardCharsets.UTF_8);
+    runProcess(
+        List.of(
+            "npm",
+            "publish",
+            tarball.toString(),
+            "--registry",
+            registry,
+            "--userconfig",
+            npmrc.toString(),
+            "--ignore-scripts"),
+        workingDirectory,
+        Duration.ofMinutes(5));
+  }
+
+  private static void assertPublishedDigests(
+      RealNpmFixture fixture,
+      Map<String, Object> version,
+      String label) {
+    assertTrue(version != null, label + " package metadata must contain " + fixture.version());
+    Object rawDist = version.get("dist");
+    assertTrue(rawDist instanceof Map<?, ?>, label + " version metadata must contain dist");
+    Map<?, ?> dist = (Map<?, ?>) rawDist;
+    assertEquals(fixture.sha1(), dist.get("shasum"), label + " tarball sha1");
+    assertEquals(fixture.integrity(), dist.get("integrity"), label + " tarball integrity");
+  }
+
+  private static boolean npmAvailable() {
+    try {
+      Process process = new ProcessBuilder("npm", "--version")
+          .redirectErrorStream(true)
+          .start();
+      if (!process.waitFor(15, TimeUnit.SECONDS)) {
+        process.destroyForcibly();
+        return false;
+      }
+      return process.exitValue() == 0;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    } catch (IOException e) {
+      return false;
+    }
+  }
+
+  private static void runProcess(
+      List<String> command,
+      Path workingDirectory,
+      Duration timeout) throws Exception {
+    Path output = Files.createTempFile(workingDirectory, "npm-command-", ".log");
+    Process process = new ProcessBuilder(command)
+        .directory(workingDirectory.toFile())
+        .redirectErrorStream(true)
+        .redirectOutput(output.toFile())
+        .start();
+    boolean finished = process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    if (!finished) {
+      process.destroyForcibly();
+      process.waitFor(15, TimeUnit.SECONDS);
+      throw new AssertionError("Command timed out: " + String.join(" ", command));
+    }
+    String processOutput = Files.readString(output, StandardCharsets.UTF_8);
+    Files.deleteIfExists(output);
+    assertEquals(0, process.exitValue(),
+        () -> "Command failed: " + String.join(" ", command) + "\n" + processOutput);
+  }
+
   private static byte[] tarGz(String entryName, byte[] content) throws IOException {
     ByteArrayOutputStream tar = new ByteArrayOutputStream();
     byte[] header = new byte[512];
@@ -633,8 +826,12 @@ class NpmRepositoryBlackBoxCompatibilityTest {
       String repository,
       Optional<String> username,
       Optional<String> password) {
+    String repositoryUrl() {
+      return baseUrl.orElseThrow() + "/repository/" + repository + "/";
+    }
+
     HttpRequest.Builder request(String repositoryPath) {
-      URI uri = URI.create(baseUrl.orElseThrow() + "/repository/" + repository + "/" + repositoryPath);
+      URI uri = URI.create(repositoryUrl() + repositoryPath);
       HttpRequest.Builder builder = HttpRequest.newBuilder(uri);
       addAuth(builder);
       return builder;

--- a/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmHostedService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmHostedService.java
@@ -21,7 +21,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
-import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -42,6 +41,7 @@ public class NpmHostedService {
   private final ObjectMapper mapper;
   private final AssetMetadataCache assetMetadataCache;
   private final ArtifactDownloadPolicy downloadPolicy;
+  private final NpmPublishParser publishParser;
 
   private record PublishWritePlan(Optional<Map<String, Object>> existingPackageRoot, String effectiveRevision) {}
 
@@ -62,12 +62,31 @@ public class NpmHostedService {
       ObjectMapper mapper,
       AssetMetadataCache assetMetadataCache,
       ArtifactDownloadPolicy downloadPolicy) {
+    this(
+        assetDao,
+        blobStorageRegistry,
+        writer,
+        mapper,
+        assetMetadataCache,
+        downloadPolicy,
+        new NpmPublishParser(mapper));
+  }
+
+  NpmHostedService(
+      AssetDao assetDao,
+      BlobStorageRegistry blobStorageRegistry,
+      NpmAssetWriter writer,
+      ObjectMapper mapper,
+      AssetMetadataCache assetMetadataCache,
+      ArtifactDownloadPolicy downloadPolicy,
+      NpmPublishParser publishParser) {
     this.assetDao = assetDao;
     this.blobStorageRegistry = blobStorageRegistry;
     this.writer = writer;
     this.mapper = mapper;
     this.assetMetadataCache = assetMetadataCache;
     this.downloadPolicy = downloadPolicy;
+    this.publishParser = publishParser;
   }
 
   public MavenResponse get(RepositoryRuntime runtime, NpmPath path, String repositoryBaseUrl, boolean headOnly) {
@@ -103,8 +122,8 @@ public class NpmHostedService {
       String createdBy,
       String createdByIp) {
     enforceHosted(runtime);
-    try {
-      Map<String, Object> incoming = mapper.readValue(body, MAP_TYPE);
+    try (NpmPublishParser.PublishRequest publish = publishParser.parse(body)) {
+      Map<String, Object> incoming = publish.packageRoot();
       String payloadName = NpmMetadata.stringValue(incoming.get(NpmMetadata.NAME), packageId.id());
       if (!packageId.id().equals(payloadName)) {
         throw new NpmExceptions.BadRequestException(
@@ -112,10 +131,18 @@ public class NpmHostedService {
       }
 
       PublishWritePlan plan = packageRootWritePlan(runtime, packageId, revision, incoming);
-      validateAttachmentsWrite(runtime, packageId, incoming);
+      validateAttachmentsWrite(runtime, packageId, incoming, publish.attachments());
       long blobStoreId = requireBlobStore(runtime);
       BlobStorage storage = blobStorageRegistry.forBlobStoreId(blobStoreId);
-      writeAttachments(runtime, storage, blobStoreId, packageId, incoming, createdBy, createdByIp);
+      writeAttachments(
+          runtime,
+          storage,
+          blobStoreId,
+          packageId,
+          incoming,
+          publish.attachments(),
+          createdBy,
+          createdByIp);
       Map<String, Object> toStore = packageRootForStorage(packageId, incoming, plan);
       byte[] json = NpmResponseSupport.write(mapper, toStore);
       writer.writePackageRoot(runtime, storage, blobStoreId, packageId, json, createdBy, createdByIp);
@@ -420,47 +447,33 @@ public class NpmHostedService {
       long blobStoreId,
       NpmPackageId packageId,
       Map<String, Object> packageRoot,
+      Iterable<NpmPublishParser.Attachment> attachments,
       String createdBy,
       String createdByIp) {
-    Object raw = packageRoot.get(NpmMetadata.ATTACHMENTS);
-    if (!(raw instanceof Map<?, ?> attachments)) {
-      return;
-    }
-    for (Map.Entry<?, ?> entry : attachments.entrySet()) {
-      String tarballName = NpmMetadata.extractTarballName(String.valueOf(entry.getKey()));
-      if (!(entry.getValue() instanceof Map<?, ?> attachment)) {
-        continue;
-      }
-      Object data = attachment.get("data");
-      if (data == null) {
-        continue;
-      }
+    for (NpmPublishParser.Attachment attachment : attachments) {
+      String tarballName = attachment.tarballName();
       String version = NpmMetadata.findVersionForTarball(packageRoot, tarballName);
       if (version == null) {
         throw new NpmExceptions.BadRequestException("Unable to resolve version for tarball " + tarballName);
       }
       Optional<AssetRecord> existing = assetDao.findAssetByPath(runtime.id(), packageId.tarballPath(tarballName));
       enforceWritePolicy(runtime, "tarball", existing.isPresent());
-      byte[] tarball = Base64.getMimeDecoder().decode(data.toString());
-      String contentType = NpmMetadata.stringValue(attachment.get("content_type"), NpmResponseSupport.TARBALL);
-      writer.writeTarball(runtime, storage, blobStoreId, packageId, version, tarballName,
-          new ByteArrayInputStream(tarball), contentType, createdBy, createdByIp, Map.of());
+      try (InputStream tarball = attachment.openStream()) {
+        writer.writeTarball(runtime, storage, blobStoreId, packageId, version, tarballName,
+            tarball, attachment.contentType(), createdBy, createdByIp, Map.of());
+      } catch (IOException e) {
+        throw new IllegalStateException("Failed to read staged npm attachment " + tarballName, e);
+      }
     }
   }
 
   private void validateAttachmentsWrite(
       RepositoryRuntime runtime,
       NpmPackageId packageId,
-      Map<String, Object> packageRoot) {
-    Object raw = packageRoot.get(NpmMetadata.ATTACHMENTS);
-    if (!(raw instanceof Map<?, ?> attachments)) {
-      return;
-    }
-    for (Map.Entry<?, ?> entry : attachments.entrySet()) {
-      String tarballName = NpmMetadata.extractTarballName(String.valueOf(entry.getKey()));
-      if (!(entry.getValue() instanceof Map<?, ?> attachment) || attachment.get("data") == null) {
-        continue;
-      }
+      Map<String, Object> packageRoot,
+      Iterable<NpmPublishParser.Attachment> attachments) {
+    for (NpmPublishParser.Attachment attachment : attachments) {
+      String tarballName = attachment.tarballName();
       String version = NpmMetadata.findVersionForTarball(packageRoot, tarballName);
       if (version == null) {
         throw new NpmExceptions.BadRequestException("Unable to resolve version for tarball " + tarballName);

--- a/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmPublishParser.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmPublishParser.java
@@ -1,0 +1,240 @@
+package com.github.klboke.kkrepo.server.npm;
+
+import com.fasterxml.jackson.core.Base64Variants;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.klboke.kkrepo.protocol.npm.NpmMetadata;
+import com.github.klboke.kkrepo.server.blob.TempBlobFiles;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Streams npm publish attachments to request-scoped temporary files while materializing the
+ * package metadata.
+ *
+ * <p>The npm client embeds each tarball as one base64 JSON string under {@code _attachments}.
+ * Reading the complete document into a map would materialize that string and subject it to
+ * Jackson's per-string limit. Attachment files returned by this parser are local staging only;
+ * callers must close the parsed request after persisting or rejecting it.</p>
+ */
+final class NpmPublishParser {
+  private static final String ATTACHMENT_DATA = "data";
+  private static final String ATTACHMENT_CONTENT_TYPE = "content_type";
+
+  private final ObjectMapper mapper;
+  private final Path tempDirectory;
+
+  NpmPublishParser(ObjectMapper mapper) {
+    this(mapper, null);
+  }
+
+  NpmPublishParser(ObjectMapper mapper, Path tempDirectory) {
+    this.mapper = Objects.requireNonNull(mapper, "mapper");
+    this.tempDirectory = tempDirectory;
+  }
+
+  PublishRequest parse(InputStream body) throws IOException {
+    Map<String, Object> packageRoot = new LinkedHashMap<>();
+    Map<String, Attachment> attachments = new LinkedHashMap<>();
+    try (JsonParser parser = mapper.getFactory().createParser(body)) {
+      requireToken(parser, parser.nextToken(), JsonToken.START_OBJECT, "npm publish body must be a JSON object");
+      while (true) {
+        JsonToken token = parser.nextToken();
+        if (token == JsonToken.END_OBJECT) {
+          break;
+        }
+        requireToken(parser, token, JsonToken.FIELD_NAME, "npm publish object is truncated");
+        String fieldName = parser.currentName();
+        JsonToken valueToken = parser.nextToken();
+        if (valueToken == null) {
+          throw invalidJson(parser, "npm publish field '" + fieldName + "' has no value");
+        }
+        if (NpmMetadata.ATTACHMENTS.equals(fieldName)) {
+          cleanup(attachments.values());
+          attachments.clear();
+          parseAttachments(parser, valueToken, attachments);
+        } else {
+          packageRoot.put(fieldName, mapper.readValue(parser, Object.class));
+        }
+      }
+      if (parser.nextToken() != null) {
+        throw invalidJson(parser, "npm publish body contains trailing JSON content");
+      }
+      return new PublishRequest(packageRoot, new ArrayList<>(attachments.values()));
+    } catch (IOException | RuntimeException e) {
+      cleanup(attachments.values());
+      throw e;
+    }
+  }
+
+  private void parseAttachments(
+      JsonParser parser,
+      JsonToken token,
+      Map<String, Attachment> attachments) throws IOException {
+    if (token != JsonToken.START_OBJECT) {
+      parser.skipChildren();
+      return;
+    }
+    while (true) {
+      JsonToken entryToken = parser.nextToken();
+      if (entryToken == JsonToken.END_OBJECT) {
+        return;
+      }
+      requireToken(parser, entryToken, JsonToken.FIELD_NAME, "npm _attachments object is truncated");
+      String attachmentKey = parser.currentName();
+      JsonToken valueToken = parser.nextToken();
+      if (valueToken == null) {
+        throw invalidJson(parser, "npm attachment '" + attachmentKey + "' has no value");
+      }
+      Attachment attachment = parseAttachment(parser, valueToken, attachmentKey);
+      Attachment replaced = attachments.remove(attachmentKey);
+      if (replaced != null) {
+        replaced.delete();
+      }
+      if (attachment != null) {
+        attachments.put(attachmentKey, attachment);
+      }
+    }
+  }
+
+  private Attachment parseAttachment(
+      JsonParser parser,
+      JsonToken token,
+      String attachmentKey) throws IOException {
+    if (token != JsonToken.START_OBJECT) {
+      parser.skipChildren();
+      return null;
+    }
+    String contentType = NpmResponseSupport.TARBALL;
+    Path stagedFile = null;
+    try {
+      while (true) {
+        JsonToken fieldToken = parser.nextToken();
+        if (fieldToken == JsonToken.END_OBJECT) {
+          if (stagedFile == null) {
+            return null;
+          }
+          return new Attachment(
+              NpmMetadata.extractTarballName(attachmentKey),
+              contentType,
+              stagedFile);
+        }
+        requireToken(
+            parser,
+            fieldToken,
+            JsonToken.FIELD_NAME,
+            "npm attachment '" + attachmentKey + "' is truncated");
+        String fieldName = parser.currentName();
+        JsonToken valueToken = parser.nextToken();
+        if (valueToken == null) {
+          throw invalidJson(parser, "npm attachment field '" + fieldName + "' has no value");
+        }
+        if (ATTACHMENT_DATA.equals(fieldName)) {
+          if (valueToken == JsonToken.VALUE_NULL) {
+            TempBlobFiles.deleteQuietly(stagedFile);
+            stagedFile = null;
+          } else {
+            requireToken(
+                parser,
+                valueToken,
+                JsonToken.VALUE_STRING,
+                "npm attachment data must be a base64 JSON string");
+            TempBlobFiles.deleteQuietly(stagedFile);
+            stagedFile = createTempFile();
+            try (OutputStream output = Files.newOutputStream(
+                stagedFile,
+                StandardOpenOption.TRUNCATE_EXISTING)) {
+              try {
+                parser.readBinaryValue(Base64Variants.getDefaultVariant(), output);
+              } catch (IllegalArgumentException e) {
+                throw new JsonParseException(parser, "npm attachment data is invalid base64", e);
+              }
+            }
+          }
+        } else if (ATTACHMENT_CONTENT_TYPE.equals(fieldName)) {
+          Object value = mapper.readValue(parser, Object.class);
+          contentType = NpmMetadata.stringValue(value, NpmResponseSupport.TARBALL);
+        } else {
+          parser.skipChildren();
+        }
+      }
+    } catch (IOException | RuntimeException e) {
+      TempBlobFiles.deleteQuietly(stagedFile);
+      throw e;
+    }
+  }
+
+  private Path createTempFile() throws IOException {
+    if (tempDirectory == null) {
+      return Files.createTempFile("kkrepo-npm-publish-", ".tgz");
+    }
+    Files.createDirectories(tempDirectory);
+    return Files.createTempFile(tempDirectory, "kkrepo-npm-publish-", ".tgz");
+  }
+
+  private static void requireToken(
+      JsonParser parser,
+      JsonToken actual,
+      JsonToken expected,
+      String message) throws JsonParseException {
+    if (actual != expected) {
+      throw invalidJson(parser, message);
+    }
+  }
+
+  private static JsonParseException invalidJson(JsonParser parser, String message) {
+    return new JsonParseException(parser, message);
+  }
+
+  private static void cleanup(Iterable<Attachment> attachments) {
+    for (Attachment attachment : attachments) {
+      attachment.delete();
+    }
+  }
+
+  static final class PublishRequest implements AutoCloseable {
+    private final Map<String, Object> packageRoot;
+    private final List<Attachment> attachments;
+
+    private PublishRequest(
+        Map<String, Object> packageRoot,
+        List<Attachment> attachments) {
+      this.packageRoot = packageRoot;
+      this.attachments = List.copyOf(attachments);
+    }
+
+    Map<String, Object> packageRoot() {
+      return packageRoot;
+    }
+
+    List<Attachment> attachments() {
+      return attachments;
+    }
+
+    @Override
+    public void close() {
+      cleanup(attachments);
+    }
+  }
+
+  record Attachment(String tarballName, String contentType, Path file) {
+    InputStream openStream() throws IOException {
+      return Files.newInputStream(file);
+    }
+
+    private void delete() {
+      TempBlobFiles.deleteQuietly(file);
+    }
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmHostedServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmHostedServiceTest.java
@@ -41,6 +41,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
@@ -169,6 +170,50 @@ class NpmHostedServiceTest {
             null));
 
     assertDirectoryEmpty(tempDir);
+    verify(fixture.writer, never()).writePackageRoot(
+        any(), any(), anyLong(), any(), any(), anyString(), any());
+  }
+
+  @Test
+  void reportsStagedAttachmentReadFailureAndCleansRequest(@TempDir Path tempDir) {
+    Fixture fixture = fixture(tempDir);
+    when(fixture.assetDao.findAssetByPath(10L, "demo")).thenReturn(Optional.empty());
+    AtomicInteger tarballLookups = new AtomicInteger();
+    when(fixture.assetDao.findAssetByPath(10L, "demo/-/demo-1.0.0.tgz"))
+        .thenAnswer(invocation -> {
+          if (tarballLookups.incrementAndGet() == 2) {
+            try (var files = Files.list(tempDir)) {
+              Files.delete(files.findFirst().orElseThrow());
+            }
+          }
+          return Optional.empty();
+        });
+    String body = """
+        {
+          "name":"demo",
+          "versions":{"1.0.0":{"name":"demo","version":"1.0.0",
+            "dist":{"tarball":"demo-1.0.0.tgz"}}},
+          "_attachments":{"demo-1.0.0.tgz":{"data":"dGFyYmFsbA=="}}
+        }
+        """;
+
+    IllegalStateException error = assertThrows(
+        IllegalStateException.class,
+        () -> fixture.service.putPackage(
+            runtime("ALLOW", 7L),
+            PACKAGE,
+            null,
+            new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)),
+            "alice",
+            null));
+
+    assertEquals(
+        "Failed to read staged npm attachment demo-1.0.0.tgz",
+        error.getMessage());
+    assertDirectoryEmpty(tempDir);
+    verify(fixture.writer, never()).writeTarball(
+        any(), any(), anyLong(), any(), anyString(), anyString(), any(),
+        anyString(), anyString(), any(), any());
     verify(fixture.writer, never()).writePackageRoot(
         any(), any(), anyLong(), any(), any(), anyString(), any());
   }

--- a/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmHostedServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmHostedServiceTest.java
@@ -1,6 +1,8 @@
 package com.github.klboke.kkrepo.server.npm;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -32,15 +34,19 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.springframework.mock.web.MockMultipartFile;
 
@@ -57,6 +63,15 @@ class NpmHostedServiceTest {
         .thenReturn(Optional.empty());
     String attachment = Base64.getEncoder()
         .encodeToString("tarball".getBytes(StandardCharsets.UTF_8));
+    AtomicReference<byte[]> uploadedTarball = new AtomicReference<>();
+    when(fixture.writer.writeTarball(
+        eq(runtime("ALLOW", 7L)), eq(fixture.storage), eq(7L), eq(PACKAGE),
+        eq("1.0.0"), eq("demo-1.0.0.tgz"), any(), eq("application/octet-stream"),
+        eq("alice"), eq("127.0.0.1"), eq(Map.of())))
+        .thenAnswer(invocation -> {
+          uploadedTarball.set(((InputStream) invocation.getArgument(6)).readAllBytes());
+          return null;
+        });
     String body = """
         {
           "name":"demo",
@@ -76,6 +91,7 @@ class NpmHostedServiceTest {
         eq(runtime("ALLOW", 7L)), eq(fixture.storage), eq(7L), eq(PACKAGE),
         eq("1.0.0"), eq("demo-1.0.0.tgz"), any(), eq("application/octet-stream"),
         eq("alice"), eq("127.0.0.1"), eq(Map.of()));
+    assertArrayEquals("tarball".getBytes(StandardCharsets.UTF_8), uploadedTarball.get());
     ArgumentCaptor<byte[]> json = ArgumentCaptor.forClass(byte[].class);
     verify(fixture.writer).writePackageRoot(
         eq(runtime("ALLOW", 7L)), eq(fixture.storage), eq(7L), eq(PACKAGE),
@@ -83,6 +99,78 @@ class NpmHostedServiceTest {
     Map<String, Object> stored = fixture.mapper.readValue(json.getValue(), MAP);
     assertNotNull(stored.get("_rev"));
     assertEquals(null, stored.get("_attachments"));
+  }
+
+  @Test
+  void invalidBase64AndTruncatedJsonReturnBadRequestAndCleanStaging(@TempDir Path tempDir) {
+    Fixture fixture = fixture(tempDir);
+    String invalidBase64 = """
+        {"name":"demo","_attachments":{"demo-1.0.0.tgz":{"data":"AAAA*"}}}
+        """;
+
+    NpmExceptions.BadRequestException invalidBase64Error = assertThrows(
+        NpmExceptions.BadRequestException.class,
+        () -> fixture.service.putPackage(
+            runtime("ALLOW", 7L),
+            PACKAGE,
+            null,
+            new ByteArrayInputStream(invalidBase64.getBytes(StandardCharsets.UTF_8)),
+            "alice",
+            null));
+    assertEquals("Invalid npm publish JSON", invalidBase64Error.getMessage());
+    assertDirectoryEmpty(tempDir);
+
+    String truncated = """
+        {"name":"demo","_attachments":{"demo-1.0.0.tgz":{"data":"AAAA"
+        """;
+    NpmExceptions.BadRequestException truncatedError = assertThrows(
+        NpmExceptions.BadRequestException.class,
+        () -> fixture.service.putPackage(
+            runtime("ALLOW", 7L),
+            PACKAGE,
+            null,
+            new ByteArrayInputStream(truncated.getBytes(StandardCharsets.UTF_8)),
+            "alice",
+            null));
+    assertEquals("Invalid npm publish JSON", truncatedError.getMessage());
+    assertDirectoryEmpty(tempDir);
+    verify(fixture.writer, never()).writeTarball(
+        any(), any(), anyLong(), any(), anyString(), anyString(), any(),
+        anyString(), anyString(), any(), any());
+  }
+
+  @Test
+  void cleansStagedAttachmentWhenPersistenceFails(@TempDir Path tempDir) {
+    Fixture fixture = fixture(tempDir);
+    when(fixture.assetDao.findAssetByPath(10L, "demo")).thenReturn(Optional.empty());
+    when(fixture.assetDao.findAssetByPath(10L, "demo/-/demo-1.0.0.tgz"))
+        .thenReturn(Optional.empty());
+    when(fixture.writer.writeTarball(
+        any(), any(), anyLong(), any(), anyString(), anyString(), any(),
+        anyString(), anyString(), any(), any()))
+        .thenThrow(new IllegalStateException("storage failed"));
+    String body = """
+        {
+          "name":"demo",
+          "versions":{"1.0.0":{"name":"demo","version":"1.0.0",
+            "dist":{"tarball":"demo-1.0.0.tgz"}}},
+          "_attachments":{"demo-1.0.0.tgz":{"data":"dGFyYmFsbA=="}}
+        }
+        """;
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> fixture.service.putPackage(
+            runtime("ALLOW", 7L),
+            PACKAGE,
+            null,
+            new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)),
+            "alice",
+            null));
+
+    assertDirectoryEmpty(tempDir);
+    verify(fixture.writer, never()).writePackageRoot(
+        any(), any(), anyLong(), any(), any(), anyString(), any());
   }
 
   @Test
@@ -365,6 +453,10 @@ class NpmHostedServiceTest {
   }
 
   private static Fixture fixture() {
+    return fixture(null);
+  }
+
+  private static Fixture fixture(Path tempDirectory) {
     AssetDao assetDao = mock(AssetDao.class);
     BlobStorageRegistry registry = mock(BlobStorageRegistry.class);
     NpmAssetWriter writer = mock(NpmAssetWriter.class);
@@ -373,9 +465,27 @@ class NpmHostedServiceTest {
     ArtifactDownloadPolicy downloadPolicy = mock(ArtifactDownloadPolicy.class);
     ObjectMapper mapper = new ObjectMapper();
     when(registry.forBlobStoreId(7L)).thenReturn(storage);
+    NpmPublishParser publishParser = tempDirectory == null
+        ? new NpmPublishParser(mapper)
+        : new NpmPublishParser(mapper, tempDirectory);
     return new Fixture(
         assetDao, registry, writer, storage, cache, downloadPolicy, mapper,
-        new NpmHostedService(assetDao, registry, writer, mapper, cache, downloadPolicy));
+        new NpmHostedService(
+            assetDao,
+            registry,
+            writer,
+            mapper,
+            cache,
+            downloadPolicy,
+            publishParser));
+  }
+
+  private static void assertDirectoryEmpty(Path directory) {
+    try (var files = Files.list(directory)) {
+      assertFalse(files.findAny().isPresent());
+    } catch (IOException e) {
+      throw new AssertionError(e);
+    }
   }
 
   private static RepositoryRuntime runtime(String writePolicy, Long blobStoreId) {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmPublishParserTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmPublishParserTest.java
@@ -1,0 +1,165 @@
+package com.github.klboke.kkrepo.server.npm;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.klboke.kkrepo.protocol.npm.NpmMetadata;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class NpmPublishParserTest {
+  private static final long ABOVE_DEFAULT_STRING_LIMIT_BYTES = 15_000_001L;
+
+  @Test
+  void streamsAttachmentBeyondJacksonStringLimitAndDeletesItOnClose(@TempDir Path tempDir)
+      throws Exception {
+    ObjectMapper mapper = new ObjectMapper();
+    NpmPublishParser parser = new NpmPublishParser(mapper, tempDir);
+    long base64Characters = ((ABOVE_DEFAULT_STRING_LIMIT_BYTES + 2L) / 3L) * 4L;
+    assertTrue(base64Characters > mapper.getFactory().streamReadConstraints().getMaxStringLength());
+
+    Path staged;
+    try (InputStream body = zeroFilledPublishBody(ABOVE_DEFAULT_STRING_LIMIT_BYTES);
+        NpmPublishParser.PublishRequest request = parser.parse(body)) {
+      assertEquals("demo", request.packageRoot().get("name"));
+      assertFalse(request.packageRoot().containsKey(NpmMetadata.ATTACHMENTS));
+      assertEquals(1, request.attachments().size());
+      NpmPublishParser.Attachment attachment = request.attachments().get(0);
+      assertEquals("demo-1.0.0.tgz", attachment.tarballName());
+      assertEquals("application/octet-stream", attachment.contentType());
+      staged = attachment.file();
+      assertEquals(ABOVE_DEFAULT_STRING_LIMIT_BYTES, Files.size(staged));
+      assertArrayEquals(
+          digestZeros(ABOVE_DEFAULT_STRING_LIMIT_BYTES),
+          digest(staged));
+    }
+
+    assertFalse(Files.exists(staged));
+    assertDirectoryEmpty(tempDir);
+  }
+
+  @Test
+  void deletesStagedAttachmentWhenJsonIsTruncated(@TempDir Path tempDir) {
+    NpmPublishParser parser = new NpmPublishParser(new ObjectMapper(), tempDir);
+    String truncated = """
+        {"name":"demo","_attachments":{"demo-1.0.0.tgz":{"data":"AAAA"
+        """;
+
+    assertThrows(
+        IOException.class,
+        () -> parser.parse(new ByteArrayInputStream(truncated.getBytes(StandardCharsets.UTF_8))));
+
+    assertDirectoryEmpty(tempDir);
+  }
+
+  @Test
+  void deletesPartialAttachmentWhenBase64IsInvalid(@TempDir Path tempDir) {
+    NpmPublishParser parser = new NpmPublishParser(new ObjectMapper(), tempDir);
+    String invalid = """
+        {"name":"demo","_attachments":{"demo-1.0.0.tgz":{"data":"AAAA*"}}}
+        """;
+
+    assertThrows(
+        IOException.class,
+        () -> parser.parse(new ByteArrayInputStream(invalid.getBytes(StandardCharsets.UTF_8))));
+
+    assertDirectoryEmpty(tempDir);
+  }
+
+  private static InputStream zeroFilledPublishBody(long decodedBytes) {
+    byte[] prefix = """
+        {"name":"demo",
+         "versions":{"1.0.0":{"name":"demo","version":"1.0.0",
+           "dist":{"tarball":"demo-1.0.0.tgz"}}},
+         "_attachments":{"demo-1.0.0.tgz":{
+           "content_type":"application/octet-stream","data":"
+        """.stripTrailing().getBytes(StandardCharsets.UTF_8);
+    long completeGroups = decodedBytes / 3L;
+    int remainder = (int) (decodedBytes % 3L);
+    long aCharacters = completeGroups * 4L + (remainder == 0 ? 0 : remainder + 1L);
+    int padding = remainder == 0 ? 0 : 3 - remainder;
+    byte[] suffix = ("=".repeat(padding) + "\"}}}").getBytes(StandardCharsets.UTF_8);
+    return new SequenceInputStream(Collections.enumeration(List.of(
+        new ByteArrayInputStream(prefix),
+        new RepeatingByteInputStream((byte) 'A', aCharacters),
+        new ByteArrayInputStream(suffix))));
+  }
+
+  private static byte[] digestZeros(long size) throws Exception {
+    MessageDigest digest = MessageDigest.getInstance("SHA-256");
+    byte[] zeros = new byte[64 * 1024];
+    long remaining = size;
+    while (remaining > 0) {
+      int count = (int) Math.min(zeros.length, remaining);
+      digest.update(zeros, 0, count);
+      remaining -= count;
+    }
+    return digest.digest();
+  }
+
+  private static byte[] digest(Path file) throws Exception {
+    MessageDigest digest = MessageDigest.getInstance("SHA-256");
+    try (InputStream input = Files.newInputStream(file)) {
+      byte[] buffer = new byte[64 * 1024];
+      for (int read; (read = input.read(buffer)) >= 0;) {
+        if (read > 0) {
+          digest.update(buffer, 0, read);
+        }
+      }
+    }
+    return digest.digest();
+  }
+
+  private static void assertDirectoryEmpty(Path directory) {
+    try (var files = Files.list(directory)) {
+      assertEquals(0L, files.count());
+    } catch (IOException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private static final class RepeatingByteInputStream extends InputStream {
+    private final byte value;
+    private long remaining;
+
+    private RepeatingByteInputStream(byte value, long remaining) {
+      this.value = value;
+      this.remaining = remaining;
+    }
+
+    @Override
+    public int read() {
+      if (remaining == 0) {
+        return -1;
+      }
+      remaining--;
+      return value & 0xff;
+    }
+
+    @Override
+    public int read(byte[] target, int offset, int length) {
+      if (remaining == 0) {
+        return -1;
+      }
+      int count = (int) Math.min(length, remaining);
+      Arrays.fill(target, offset, offset + count, value);
+      remaining -= count;
+      return count;
+    }
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmPublishParserTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmPublishParserTest.java
@@ -81,6 +81,97 @@ class NpmPublishParserTest {
     assertDirectoryEmpty(tempDir);
   }
 
+  @Test
+  void rejectsNonObjectRootAndTrailingJson(@TempDir Path tempDir) {
+    NpmPublishParser parser = new NpmPublishParser(new ObjectMapper(), tempDir);
+
+    assertThrows(
+        IOException.class,
+        () -> parser.parse(new ByteArrayInputStream("[]".getBytes(StandardCharsets.UTF_8))));
+    assertThrows(
+        IOException.class,
+        () -> parser.parse(new ByteArrayInputStream("{}{}".getBytes(StandardCharsets.UTF_8))));
+
+    assertDirectoryEmpty(tempDir);
+  }
+
+  @Test
+  void ignoresNonObjectAttachmentContainersAndEntries(@TempDir Path tempDir) throws Exception {
+    NpmPublishParser parser = new NpmPublishParser(new ObjectMapper(), tempDir);
+
+    try (NpmPublishParser.PublishRequest request = parser.parse(new ByteArrayInputStream("""
+        {"name":"demo","_attachments":["ignored"]}
+        """.getBytes(StandardCharsets.UTF_8)))) {
+      assertTrue(request.attachments().isEmpty());
+    }
+
+    try (NpmPublishParser.PublishRequest request = parser.parse(new ByteArrayInputStream("""
+        {
+          "name":"demo",
+          "_attachments":{
+            "not-an-object":"ignored",
+            "missing-data":{"extra":{"nested":true}}
+          }
+        }
+        """.getBytes(StandardCharsets.UTF_8)))) {
+      assertTrue(request.attachments().isEmpty());
+    }
+
+    assertDirectoryEmpty(tempDir);
+  }
+
+  @Test
+  void keepsLastDuplicateAttachmentAndDeletesReplacedFile(@TempDir Path tempDir)
+      throws Exception {
+    NpmPublishParser parser = new NpmPublishParser(new ObjectMapper(), tempDir);
+    String duplicate = """
+        {
+          "name":"demo",
+          "_attachments":{
+            "demo-1.0.0.tgz":{"data":"Zmlyc3Q="},
+            "demo-1.0.0.tgz":{"data":"c2Vjb25k"}
+          }
+        }
+        """;
+
+    try (NpmPublishParser.PublishRequest request = parser.parse(
+        new ByteArrayInputStream(duplicate.getBytes(StandardCharsets.UTF_8)))) {
+      assertEquals(1, request.attachments().size());
+      assertArrayEquals(
+          "second".getBytes(StandardCharsets.UTF_8),
+          Files.readAllBytes(request.attachments().get(0).file()));
+      try (var files = Files.list(tempDir)) {
+        assertEquals(1L, files.count());
+      }
+    }
+
+    assertDirectoryEmpty(tempDir);
+  }
+
+  @Test
+  void dropsAttachmentWhenLastDataValueIsNull(@TempDir Path tempDir) throws Exception {
+    NpmPublishParser parser = new NpmPublishParser(new ObjectMapper(), tempDir);
+    String cleared = """
+        {
+          "name":"demo",
+          "_attachments":{
+            "demo-1.0.0.tgz":{
+              "data":"Zmlyc3Q=",
+              "ignored":{"nested":true},
+              "data":null
+            }
+          }
+        }
+        """;
+
+    try (NpmPublishParser.PublishRequest request = parser.parse(
+        new ByteArrayInputStream(cleared.getBytes(StandardCharsets.UTF_8)))) {
+      assertTrue(request.attachments().isEmpty());
+    }
+
+    assertDirectoryEmpty(tempDir);
+  }
+
   private static InputStream zeroFilledPublishBody(long decodedBytes) {
     byte[] prefix = """
         {"name":"demo",


### PR DESCRIPTION
## Summary

- stream-decode npm publish attachment data into request-scoped temporary files instead of materializing the complete base64 value as a Java `String`
- preserve the existing revision, write-policy, asset persistence, digest, cache invalidation, and multi-replica semantics while guaranteeing staging cleanup
- add parser/service regressions plus a real npm-client compatibility case that publishes a 30 MiB incompressible package against Nexus and kkRepo

## Root cause

`NpmHostedService.putPackage(...)` deserialized the complete publish document into a `Map<String, Object>`. npm embeds the tarball in `_attachments.<tarball>.data` as one base64 JSON string, so archives above roughly 14.3 MiB exceeded Jackson's default 20,000,000-character string constraint and were returned as `400 Invalid npm publish JSON`.

The new dedicated parser uses Jackson's streaming API and decodes attachment data directly to request-local staging files. Package metadata remains in memory without `_attachments`; final asset data and metadata continue to use the existing shared object-storage/MySQL path.

## Validation

- `mvn -pl server -am -Dtest='NpmPublishParserTest,NpmHostedServiceTest' -Dsurefire.failIfNoSpecifiedTests=false test` — 16 tests passed
- `mvn -pl server -am -Dtest='Npm*Test' -Dsurefire.failIfNoSpecifiedTests=false test` — 113 npm-related tests passed
- `mvn -pl compat-test -am -DskipTests package`
- `git diff --check`

The live 30 MiB Nexus/kkRepo compatibility test is included and compiles, but was not executed locally because the default compatibility endpoints were not running and write-mode compatibility tests were disabled.

Closes #172