### PR TITLE
fix(proxy): delegate upstream DNS to configured proxies

### DIFF
--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
@@ -44,7 +44,7 @@ select {
   position: fixed;
   top: 70px;
   right: 16px;
-  z-index: 20;
+  z-index: 1100;
   display: grid;
   gap: 8px;
   max-width: min(420px, calc(100vw - 32px));

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminToastLayerContractTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminToastLayerContractTest.java
@@ -1,0 +1,39 @@
+package com.github.klboke.kkrepo.admin.ui;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+class AdminToastLayerContractTest {
+  private static final Pattern Z_INDEX = Pattern.compile("z-index:\\s*(\\d+)");
+
+  @Test
+  void errorToastsRenderAboveRepositoryFormModal() throws IOException {
+    String stylesheet = resource("/META-INF/resources/admin/assets/admin.css");
+
+    assertTrue(zIndex(stylesheet, ".toast-region") > zIndex(stylesheet, ".form-modal"),
+        "repository save errors must remain visible while the form modal is open");
+  }
+
+  private int zIndex(String stylesheet, String selector) {
+    int selectorStart = stylesheet.indexOf(selector + " {");
+    int blockEnd = stylesheet.indexOf('}', selectorStart);
+    assertTrue(selectorStart >= 0 && blockEnd > selectorStart,
+        "missing CSS block for " + selector);
+    Matcher matcher = Z_INDEX.matcher(stylesheet.substring(selectorStart, blockEnd));
+    assertTrue(matcher.find(), "missing z-index for " + selector);
+    return Integer.parseInt(matcher.group(1));
+  }
+
+  private String resource(String path) throws IOException {
+    try (InputStream stream = getClass().getResourceAsStream(path)) {
+      return new String(Objects.requireNonNull(stream).readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+}

--- a/docs/en/security-model.md
+++ b/docs/en/security-model.md
@@ -208,6 +208,14 @@ KKREPO_OUTBOUND_ALLOWED_HOSTS=
 
 Only allow internal upstream hosts when required. This helps reduce SSRF-style risk from misconfigured proxy repositories.
 
+Direct outbound requests are resolved locally and pinned to policy-approved IP addresses. When a
+repository has an explicit HTTP or SOCKS5 outbound proxy, the upstream hostname is instead sent to
+that proxy for resolution so proxy DNS rules and hostname-based routing remain effective. Treat the
+configured proxy as a trusted egress boundary: by default kkrepo still rejects explicit private IP
+targets and local-only names, but it cannot inspect the IP address returned by DNS inside the proxy.
+The proxy should deny loopback, private-network, link-local, and cloud-metadata destinations unless
+that access is intentionally required.
+
 ## Audit Logs
 
 Security-sensitive actions should be recorded in `security_audit_log`, including administrative changes such as user, role, privilege, realm, and token operations.

--- a/docs/zh/security-model.md
+++ b/docs/zh/security-model.md
@@ -201,6 +201,11 @@ KKREPO_OUTBOUND_ALLOWED_HOSTS=
 
 只有确实需要内部上游仓库时才允许内部 host。这可以降低 proxy repository 配置错误带来的 SSRF 类风险。
 
+直连出站请求仍由 kkrepo 在本机解析，并固定到策略允许的 IP。仓库显式配置 HTTP 或 SOCKS5
+出站代理后，上游域名会交给该代理解析，确保代理 DNS 规则和基于域名的路由生效。此时应把所配置的
+代理视为可信出站边界：kkrepo 默认仍会拒绝显式私网 IP 和仅限本地的域名，但无法检查代理内部 DNS
+最终返回的 IP。除非业务明确需要，代理侧应拒绝 loopback、私网、link-local 和云 metadata 目标。
+
 ## 审计日志
 
 安全敏感动作应记录到 `security_audit_log`，包括用户、角色、权限、realm、token 等管理变更。

--- a/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClient.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClient.java
@@ -123,7 +123,7 @@ public class DockerRemoteRegistryClient {
     }
   }
 
-  /** DNS-pinned Docker fetch, optionally routed through the repository's SOCKS/HTTP proxy. */
+  /** Docker fetch using either direct DNS pinning or the repository's SOCKS/HTTP proxy DNS. */
   private RemoteFetch pinnedFetchWithHeaders(
       String url,
       RepositoryRuntime runtime,
@@ -138,7 +138,8 @@ public class DockerRemoteRegistryClient {
     ProxiedHttpClientFactory.ProxiedResponse response = null;
     try {
       OutboundRequestPolicy.ResolvedHttpTarget target =
-          outboundPolicy.resolveHttpTarget(url, "docker remote fetch");
+          outboundPolicy.resolveHttpTarget(
+              url, "docker remote fetch", proxyResolvesDns(runtime));
       URI uri = target.uri();
       Map<String, String> headers = new LinkedHashMap<>();
       headers.put("User-Agent", "kkrepo/0.1");
@@ -194,7 +195,7 @@ public class DockerRemoteRegistryClient {
     }
   }
 
-  /** DNS-pinned Docker OAuth token exchange using the same optional outbound proxy. */
+  /** Docker OAuth token exchange using the same direct or proxied resolution mode. */
   private Optional<RemoteToken> pinnedFetchToken(
       RepositoryRuntime runtime,
       BearerChallenge bearer,
@@ -206,7 +207,8 @@ public class DockerRemoteRegistryClient {
     ProxiedHttpClientFactory.ProxiedResponse response = null;
     try {
       OutboundRequestPolicy.ResolvedHttpTarget target =
-          outboundPolicy.resolveHttpTarget(url, "docker token fetch");
+          outboundPolicy.resolveHttpTarget(
+              url, "docker token fetch", proxyResolvesDns(runtime));
       Map<String, String> headers = new LinkedHashMap<>();
       headers.put("User-Agent", "kkrepo/0.1");
       basicAuthorization(runtime).ifPresent(value -> headers.put("Authorization", value));
@@ -358,6 +360,12 @@ public class DockerRemoteRegistryClient {
 
   private static long runtimeId(RepositoryRuntime runtime) {
     return runtime == null ? 0 : runtime.id();
+  }
+
+  private static boolean proxyResolvesDns(RepositoryRuntime runtime) {
+    return runtime != null
+        && runtime.outboundProxy() != null
+        && runtime.outboundProxy().enabled();
   }
 
   private static String credentialFingerprint(RepositoryRuntime runtime) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcher.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcher.java
@@ -459,7 +459,9 @@ public class HttpRemoteFetcher {
 
     OutboundRequestPolicy.ResolvedHttpTarget resolvedTarget(
         OutboundRequestPolicy policy, String purpose) {
-      OutboundRequestPolicy.ResolvedHttpTarget target = policy.resolveHttpTarget(url, purpose);
+      boolean proxyResolvesDns = outboundProxy != null && outboundProxy.enabled();
+      OutboundRequestPolicy.ResolvedHttpTarget target =
+          policy.resolveHttpTarget(url, purpose, proxyResolvesDns);
       if (trustedHost != null && !normalizeHost(target.uri().getHost()).equals(trustedHost)) {
         throw new SecurityValidationException(purpose + " URL host must remain " + trustedHost);
       }

--- a/server/src/main/java/com/github/klboke/kkrepo/server/proxy/ProxiedHttpClientFactory.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/proxy/ProxiedHttpClientFactory.java
@@ -13,6 +13,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import org.apache.hc.client5.http.DnsResolver;
 import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
@@ -78,6 +79,19 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
   private static final Logger log = LoggerFactory.getLogger(ProxiedHttpClientFactory.class);
   private static final String ORIGINAL_TARGET_CONTEXT =
       ProxiedHttpClientFactory.class.getName() + ".originalTarget";
+  // HttpClient turns a null DNS answer into an unresolved socket address. The SOCKS socket then
+  // serializes that address as RFC 1928 ATYP=domain instead of resolving it in this JVM.
+  private static final DnsResolver PROXY_DNS_RESOLVER = new DnsResolver() {
+    @Override
+    public InetAddress[] resolve(String host) {
+      return null;
+    }
+
+    @Override
+    public String resolveCanonicalHostname(String host) {
+      return host;
+    }
+  };
 
   private final Cache<String, CloseableHttpClient> cache;
   private final CloseableHttpClient directClient;
@@ -153,15 +167,15 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
   }
 
   /**
-   * Executes a GET/HEAD against an already validated and DNS-resolved target. The caller must
+   * Executes a GET/HEAD against an already validated target. The caller must
    * {@link ProxiedResponse#close()} it after draining the body so the connection returns to the pool.
    * When {@code config} is enabled, {@code owner} keys the proxy client; otherwise the shared direct
    * client is used.
    *
-   * <p>The actual socket or HTTP CONNECT destination is one of the policy-approved IP addresses.
-   * The original host remains the HTTP Host / TLS SNI and certificate-verification name. This binds
-   * address validation to connection establishment and prevents a second DNS lookup from changing
-   * the destination after validation.
+   * <p>Direct requests connect to policy-approved pinned IP addresses. Requests with an explicitly
+   * configured repository proxy can instead carry a proxy-resolved target, in which case HTTP
+   * CONNECT or SOCKS5 receives the original hostname and owns DNS resolution. The original host is
+   * always retained for HTTP Host, TLS SNI, and certificate verification.
    *
    * <p>The connect timeout is configured once per cached client on its connection manager
    * ({@code kkrepo.outbound-proxy.connect-timeout-ms}), because HttpClient 5.4+ removed per-request
@@ -181,9 +195,9 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
   }
 
   /**
-   * Executes an HTTP request with an optional repeatable body against an already validated and
-   * DNS-resolved target. Non-idempotent requests are not retried against another approved address
-   * after an I/O failure, because doing so could submit the same operation twice.
+   * Executes an HTTP request with an optional repeatable body against an already validated target.
+   * Non-idempotent pinned requests are not retried against another approved address after an I/O
+   * failure, because doing so could submit the same operation twice.
    */
   @SuppressWarnings("resource") // the shared client is closed by this factory, not per request
   public ProxiedResponse execute(
@@ -201,17 +215,26 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
     CloseableHttpClient client = config != null && config.enabled()
         ? clientFor(owner, config)
         : directClient;
+    boolean proxyEnabled = config != null && config.enabled();
     RequestConfig requestConfig = RequestConfig.custom()
         .setResponseTimeout(Timeout.ofMilliseconds(Math.max(1L, responseTimeoutMillis)))
         .build();
     String requestMethod = method == null || method.isBlank() ? "GET" : method;
+    if (target.proxyResolvesDns()) {
+      if (!proxyEnabled) {
+        throw new IllegalArgumentException(
+            "proxy-resolved outbound target requires an enabled proxy config");
+      }
+      return executeAtTarget(
+          client, config, requestMethod, target.uri(), null, true, headers, body, requestConfig);
+    }
     boolean retryable =
         "GET".equalsIgnoreCase(requestMethod) || "HEAD".equalsIgnoreCase(requestMethod);
     IOException failure = null;
     for (InetAddress address : target.addresses()) {
       try {
-        return executeAtAddress(
-            client, config, requestMethod, target.uri(), address, headers, body, requestConfig);
+        return executeAtTarget(
+            client, config, requestMethod, target.uri(), address, false, headers, body, requestConfig);
       } catch (IOException e) {
         failure = e;
         if (!retryable) {
@@ -223,20 +246,22 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
   }
 
   @SuppressWarnings("resource") // the client is pooled and closed by this factory, not per request
-  private ProxiedResponse executeAtAddress(
+  private ProxiedResponse executeAtTarget(
       CloseableHttpClient client,
       OutboundProxyConfig config,
       String method,
       URI uri,
       InetAddress address,
+      boolean proxyResolvesDns,
       Map<String, String> headers,
       byte[] body,
       RequestConfig requestConfig)
       throws IOException {
     int port = effectivePort(uri);
     String originalHost = endpointHost(uri);
-    HttpHost pinnedTarget =
-        new HttpHost(uri.getScheme(), address, address.getHostAddress(), port);
+    HttpHost connectionTarget = proxyResolvesDns
+        ? new HttpHost(uri.getScheme(), originalHost, port)
+        : new HttpHost(uri.getScheme(), address, address.getHostAddress(), port);
     HttpHost originalTarget = new HttpHost(uri.getScheme(), originalHost, port);
     ClassicRequestBuilder requestBuilder =
         ClassicRequestBuilder.create(method).setPath(requestPath(uri));
@@ -258,8 +283,9 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
         && URIScheme.HTTP.same(uri.getScheme());
     request.setScheme(uri.getScheme());
     request.setAuthority(new URIAuthority(
-        plainHttpProxy ? address.getHostAddress() : originalHost, uri.getPort()));
-    if (plainHttpProxy) {
+        plainHttpProxy && !proxyResolvesDns ? address.getHostAddress() : originalHost,
+        uri.getPort()));
+    if (plainHttpProxy && !proxyResolvesDns) {
       request.setHeader(HttpHeaders.HOST, hostHeader(uri));
     }
 
@@ -267,7 +293,7 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
     context.setRequestConfig(requestConfig);
     context.setAttribute(ORIGINAL_TARGET_CONTEXT, originalTarget);
     // executeOpen returns a live, caller-closed response required by streaming callers.
-    ClassicHttpResponse response = client.executeOpen(pinnedTarget, request, context);
+    ClassicHttpResponse response = client.executeOpen(connectionTarget, request, context);
     Map<String, String> responseHeaders = new LinkedHashMap<>();
     for (Header header : response.getHeaders()) {
       responseHeaders.putIfAbsent(header.getName(), header.getValue());
@@ -321,7 +347,7 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
     configureConnectionManager(connectionManager);
     return HttpClients.custom()
         .setConnectionManager(connectionManager)
-        .setRoutePlanner(new PinnedRoutePlanner(null))
+        .setRoutePlanner(new PinnedRoutePlanner(null, false))
         .disableContentCompression()
         .disableRedirectHandling()
         .build();
@@ -333,7 +359,7 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
     configureConnectionManager(connectionManager);
     var builder = HttpClients.custom()
         .setConnectionManager(connectionManager)
-        .setRoutePlanner(new PinnedRoutePlanner(proxy))
+        .setRoutePlanner(new PinnedRoutePlanner(proxy, true))
         .disableContentCompression()
         .disableRedirectHandling();
     if (config.authenticated()) {
@@ -365,7 +391,8 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
         .register(URIScheme.HTTPS.getId(), DefaultClientTlsStrategy.createDefault())
         .build();
     HttpClientConnectionOperator operator =
-        new DefaultHttpClientConnectionOperator(socketFactory, null, null, tlsStrategies);
+        new DefaultHttpClientConnectionOperator(
+            socketFactory, null, PROXY_DNS_RESOLVER, tlsStrategies);
     PoolingHttpClientConnectionManager connectionManager =
         new PoolingHttpClientConnectionManager(operator, null, null, null, null);
     configureConnectionManager(connectionManager);
@@ -373,7 +400,7 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
         config.host(), config.port());
     return HttpClients.custom()
         .setConnectionManager(connectionManager)
-        .setRoutePlanner(new PinnedRoutePlanner(null))
+        .setRoutePlanner(new PinnedRoutePlanner(null, true))
         .disableContentCompression()
         .disableRedirectHandling()
         .build();
@@ -405,16 +432,18 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
 
   private static final class PinnedRoutePlanner implements HttpRoutePlanner {
     private final HttpHost proxy;
+    private final boolean allowUnresolvedTarget;
 
-    private PinnedRoutePlanner(HttpHost proxy) {
+    private PinnedRoutePlanner(HttpHost proxy, boolean allowUnresolvedTarget) {
       this.proxy = proxy;
+      this.allowUnresolvedTarget = allowUnresolvedTarget;
     }
 
     @Override
     public HttpRoute determineRoute(
         HttpHost target, org.apache.hc.core5.http.protocol.HttpContext context)
         throws ProtocolException {
-      if (target == null || target.getAddress() == null) {
+      if (target == null || (!allowUnresolvedTarget && target.getAddress() == null)) {
         throw new ProtocolException("Resolved target address is required");
       }
       Object original = context.getAttribute(ORIGINAL_TARGET_CONTEXT);

--- a/server/src/main/java/com/github/klboke/kkrepo/server/repositories/RepositoryService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/repositories/RepositoryService.java
@@ -1015,12 +1015,13 @@ public class RepositoryService {
         && (settings.remoteUsername() == null || settings.remoteUsername().isBlank())) {
       throw new RepositoryValidationException("proxy.remoteUsername is required when proxy.remotePassword is set");
     }
+    OutboundProxyConfig outboundProxy = validateOutboundProxy(settings);
     try {
-      outboundPolicy.validateHttpUri(settings.remoteUrl(), "proxy.remoteUrl");
+      outboundPolicy.validateHttpUri(
+          settings.remoteUrl(), "proxy.remoteUrl", outboundProxy != null && outboundProxy.enabled());
     } catch (SecurityValidationException e) {
       throw new RepositoryValidationException(e.getMessage());
     }
-    validateOutboundProxy(settings);
     int minimumReleaseAge = settings.minimumReleaseAgeMinutes() == null
         ? 0
         : settings.minimumReleaseAgeMinutes();
@@ -1036,14 +1037,14 @@ public class RepositoryService {
     }
   }
 
-  private void validateOutboundProxy(ProxySettings settings) {
+  private OutboundProxyConfig validateOutboundProxy(ProxySettings settings) {
     boolean hasType = settings.outboundProxyType() != null && !settings.outboundProxyType().isBlank();
     boolean hasHost = settings.outboundProxyHost() != null && !settings.outboundProxyHost().isBlank();
     Integer port = settings.outboundProxyPort();
     if (!hasType && !hasHost && port == null
         && (settings.outboundProxyUsername() == null || settings.outboundProxyUsername().isBlank())
         && (settings.outboundProxyPassword() == null || settings.outboundProxyPassword().isBlank())) {
-      return;
+      return null;
     }
     if (!hasHost) {
       throw new RepositoryValidationException("proxy.outboundProxyHost is required when an outbound proxy is configured");
@@ -1051,8 +1052,7 @@ public class RepositoryService {
     if (port == null || port < 1 || port > 65535) {
       throw new RepositoryValidationException("proxy.outboundProxyPort must be between 1 and 65535");
     }
-    com.github.klboke.kkrepo.server.proxy.OutboundProxyConfig.Type type =
-        com.github.klboke.kkrepo.server.proxy.OutboundProxyConfig.parseType(settings.outboundProxyType());
+    OutboundProxyConfig.Type type = OutboundProxyConfig.parseType(settings.outboundProxyType());
     if (type == null) {
       throw new RepositoryValidationException(
           "proxy.outboundProxyType must be HTTP or SOCKS (was: " + settings.outboundProxyType() + ")");
@@ -1062,6 +1062,12 @@ public class RepositoryService {
       throw new RepositoryValidationException(
           "proxy.outboundProxyUsername is required when proxy.outboundProxyPassword is set");
     }
+    return new OutboundProxyConfig(
+        type,
+        settings.outboundProxyHost(),
+        port,
+        settings.outboundProxyUsername(),
+        settings.outboundProxyPassword());
   }
 
   private static String normalizeSwiftRemoteUrl(String remoteUrl) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/security/OutboundRequestPolicy.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/security/OutboundRequestPolicy.java
@@ -51,11 +51,19 @@ public class OutboundRequestPolicy {
    * transport so the approved DNS answers cannot be discarded before connection establishment.
    */
   public URI validateHttpUri(String rawUrl, String purpose) {
+    return validateHttpUri(rawUrl, purpose, false);
+  }
+
+  /**
+   * Validates a URL for storage, optionally delegating hostname resolution to an explicitly
+   * configured repository proxy.
+   */
+  public URI validateHttpUri(String rawUrl, String purpose, boolean proxyResolvesDns) {
     if (rawUrl == null || rawUrl.isBlank()) {
       throw new SecurityValidationException(purpose + " URL is required");
     }
     try {
-      return validateHttpUri(new URI(rawUrl), purpose);
+      return validateHttpUri(new URI(rawUrl), purpose, proxyResolvesDns);
     } catch (URISyntaxException e) {
       throw new SecurityValidationException(purpose + " URL is not valid: " + e.getMessage(), e);
     }
@@ -63,11 +71,16 @@ public class OutboundRequestPolicy {
 
   /** See {@link #validateHttpUri(String, String)}. */
   public URI validateHttpUri(URI uri, String purpose) {
+    return validateHttpUri(uri, purpose, false);
+  }
+
+  /** See {@link #validateHttpUri(String, String, boolean)}. */
+  public URI validateHttpUri(URI uri, String purpose, boolean proxyResolvesDns) {
     String host = validatedHost(uri, purpose);
     if (allowedHosts.contains(normalizeHost(host))) {
       return uri;
     }
-    return resolveHttpTarget(uri, purpose).uri();
+    return resolveHttpTarget(uri, purpose, proxyResolvesDns).uri();
   }
 
   /**
@@ -77,18 +90,37 @@ public class OutboundRequestPolicy {
    * checks.
    */
   public ResolvedHttpTarget resolveHttpTarget(String rawUrl, String purpose) {
+    return resolveHttpTarget(rawUrl, purpose, false);
+  }
+
+  /**
+   * Validates an outbound target. When {@code proxyResolvesDns} is true, the returned capability
+   * carries the original hostname instead of locally resolved addresses so the configured proxy can
+   * apply its own DNS and hostname-routing policy.
+   */
+  public ResolvedHttpTarget resolveHttpTarget(
+      String rawUrl, String purpose, boolean proxyResolvesDns) {
     if (rawUrl == null || rawUrl.isBlank()) {
       throw new SecurityValidationException(purpose + " URL is required");
     }
     try {
-      return resolveHttpTarget(new URI(rawUrl), purpose);
+      return resolveHttpTarget(new URI(rawUrl), purpose, proxyResolvesDns);
     } catch (URISyntaxException e) {
       throw new SecurityValidationException(purpose + " URL is not valid: " + e.getMessage(), e);
     }
   }
 
   public ResolvedHttpTarget resolveHttpTarget(URI uri, String purpose) {
+    return resolveHttpTarget(uri, purpose, false);
+  }
+
+  public ResolvedHttpTarget resolveHttpTarget(
+      URI uri, String purpose, boolean proxyResolvesDns) {
     String host = validatedHost(uri, purpose);
+    if (proxyResolvesDns) {
+      validateProxyResolvedHost(host, purpose);
+      return new ResolvedHttpTarget(uri, List.of(), true);
+    }
     InetAddress[] addresses;
     try {
       addresses = hostResolver.resolve(host);
@@ -113,7 +145,40 @@ public class OutboundRequestPolicy {
         }
       }
     }
-    return new ResolvedHttpTarget(uri, Arrays.asList(addresses));
+    return new ResolvedHttpTarget(uri, Arrays.asList(addresses), false);
+  }
+
+  private void validateProxyResolvedHost(String host, String purpose) {
+    String normalized = normalizeHost(host);
+    if (allowPrivateAddresses || allowedHosts.contains(normalized)) {
+      return;
+    }
+    InetAddress literal = literalAddress(normalized);
+    if (literal != null && blockedAddress(literal)) {
+      throw new SecurityValidationException(
+          purpose + " URL resolves to a private or local address: " + host + " -> "
+              + literal.getHostAddress());
+    }
+    if (isLocalOnlyHost(normalized)) {
+      throw new SecurityValidationException(purpose + " URL uses a local-only host: " + host);
+    }
+  }
+
+  private static InetAddress literalAddress(String host) {
+    try {
+      return InetAddress.ofLiteral(host);
+    } catch (IllegalArgumentException ignored) {
+      return null;
+    }
+  }
+
+  private static boolean isLocalOnlyHost(String host) {
+    return host.equals("localhost")
+        || host.endsWith(".localhost")
+        || host.equals("local")
+        || host.endsWith(".local")
+        || host.equals("home.arpa")
+        || host.endsWith(".home.arpa");
   }
 
   private String validatedHost(URI uri, String purpose) {
@@ -180,6 +245,9 @@ public class OutboundRequestPolicy {
     if (value.startsWith("[") && value.endsWith("]")) {
       value = value.substring(1, value.length() - 1);
     }
+    while (value.endsWith(".")) {
+      value = value.substring(0, value.length() - 1);
+    }
     return value;
   }
 
@@ -192,10 +260,13 @@ public class OutboundRequestPolicy {
   public static final class ResolvedHttpTarget {
     private final URI uri;
     private final List<InetAddress> addresses;
+    private final boolean proxyResolvesDns;
 
-    private ResolvedHttpTarget(URI uri, List<InetAddress> addresses) {
+    private ResolvedHttpTarget(
+        URI uri, List<InetAddress> addresses, boolean proxyResolvesDns) {
       this.uri = uri;
       this.addresses = List.copyOf(addresses);
+      this.proxyResolvesDns = proxyResolvesDns;
     }
 
     public URI uri() {
@@ -204,6 +275,10 @@ public class OutboundRequestPolicy {
 
     public List<InetAddress> addresses() {
       return addresses;
+    }
+
+    public boolean proxyResolvesDns() {
+      return proxyResolvesDns;
     }
   }
 }

--- a/server/src/test/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcherProxyTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcherProxyTest.java
@@ -3,7 +3,6 @@ package com.github.klboke.kkrepo.server.maven;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.klboke.kkrepo.server.proxy.OutboundProxyConfig;
 import com.github.klboke.kkrepo.server.proxy.ProxiedHttpClientFactory;
@@ -32,7 +31,7 @@ class HttpRemoteFetcherProxyTest {
       HttpRemoteFetcher fetcher = proxiedFetcher(factory);
       Instant lastModified = Instant.ofEpochMilli(1700000000000L);
       HttpRemoteFetcher.Request request = new HttpRemoteFetcher.Request(
-          "http://localhost/com/acme/lib/1.0/lib-1.0.pom",
+          "http://packages.invalid/com/acme/lib/1.0/lib-1.0.pom",
           "abc123",
           lastModified,
           null,
@@ -40,7 +39,7 @@ class HttpRemoteFetcherProxyTest {
           false,
           "maven-proxy",
           "MAVEN2",
-          "localhost",
+          "packages.invalid",
           "Basic cm9ib3Q6c2VjcmV0",
           Set.of(),
           proxyConfig(proxy.port(), null, null));
@@ -54,8 +53,9 @@ class HttpRemoteFetcherProxyTest {
       assertEquals(1, proxy.requests().size());
       FakeHttpProxyServer.RecordedRequest recorded = proxy.requests().get(0);
       assertEquals("GET", recorded.method());
-      assertPinnedLocalhostTarget(recorded, "/com/acme/lib/1.0/lib-1.0.pom");
-      assertEquals("localhost", recorded.header("Host"));
+      assertProxyResolvedTarget(
+          recorded, "packages.invalid", "/com/acme/lib/1.0/lib-1.0.pom");
+      assertEquals("packages.invalid", recorded.header("Host"));
       assertEquals("\"abc123\"", recorded.header("If-None-Match"));
       assertEquals(
           DateTimeFormatter.RFC_1123_DATE_TIME.withZone(ZoneOffset.UTC).format(lastModified),
@@ -136,7 +136,7 @@ class HttpRemoteFetcherProxyTest {
       }
 
       assertEquals(2, proxy.requests().size());
-      assertPinnedLocalhostTarget(proxy.requests().get(1), "/moved/lib-1.0.jar");
+      assertProxyResolvedTarget(proxy.requests().get(1), "localhost", "/moved/lib-1.0.jar");
       assertEquals("Basic cm9ib3Q6c2VjcmV0", proxy.requests().get(1).header("Authorization"));
       assertEquals("application/json", proxy.requests().get(0).header("Accept"));
       assertEquals("application/json", proxy.requests().get(1).header("Accept"));
@@ -226,13 +226,10 @@ class HttpRemoteFetcherProxyTest {
     return new OutboundProxyConfig(OutboundProxyConfig.Type.HTTP, "127.0.0.1", port, username, password);
   }
 
-  private static void assertPinnedLocalhostTarget(
-      FakeHttpProxyServer.RecordedRequest recorded, String expectedPath)
-      throws Exception {
+  private static void assertProxyResolvedTarget(
+      FakeHttpProxyServer.RecordedRequest recorded, String expectedHost, String expectedPath) {
     URI routed = URI.create(recorded.target());
-    java.net.InetAddress routedAddress = java.net.InetAddress.getByName(routed.getHost());
-    assertTrue(java.util.Arrays.stream(java.net.InetAddress.getAllByName("localhost"))
-        .anyMatch(routedAddress::equals));
+    assertEquals(expectedHost, routed.getHost());
     assertEquals(expectedPath, routed.getRawPath());
   }
 }

--- a/server/src/test/java/com/github/klboke/kkrepo/server/proxy/ProxiedHttpClientFactoryTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/proxy/ProxiedHttpClientFactoryTest.java
@@ -58,6 +58,25 @@ class ProxiedHttpClientFactoryTest {
   }
 
   @Test
+  void proxyResolvedTargetRequiresAnEnabledProxy() throws Exception {
+    try (ProxiedHttpClientFactory factory = new ProxiedHttpClientFactory(60000, 10000)) {
+      IllegalArgumentException error = assertThrows(
+          IllegalArgumentException.class,
+          () -> factory.execute(
+              "repo-a",
+              null,
+              "GET",
+              proxyTarget("http://packages.invalid/artifact"),
+              Map.of(),
+              5000));
+
+      assertEquals(
+          "proxy-resolved outbound target requires an enabled proxy config",
+          error.getMessage());
+    }
+  }
+
+  @Test
   void disabledProxyUsesPinnedDirectClientAndNormalizesEmptyPath() throws Exception {
     HttpServer upstream = HttpServer.create(
         new InetSocketAddress(java.net.InetAddress.getByName("127.0.0.1"), 0), 0);
@@ -334,6 +353,34 @@ class ProxiedHttpClientFactoryTest {
   }
 
   @Test
+  void socksClientDelegatesTargetDnsToConfiguredProxy() throws Exception {
+    RecordingSocksServer server = RecordingSocksServer.acceptingAny();
+    server.start();
+    try (ProxiedHttpClientFactory factory = new ProxiedHttpClientFactory(60000, 10000)) {
+      OutboundProxyConfig config = new OutboundProxyConfig(
+          OutboundProxyConfig.Type.SOCKS, "127.0.0.1", server.port(), null, null);
+
+      assertThrows(IOException.class, () -> factory.execute(
+          "repo-a",
+          config,
+          "GET",
+          proxyTarget("http://artifact.example/packages/demo.jar"),
+          Map.of(),
+          5000));
+
+      assertTrue(server.awaitHandshake(), "SOCKS server never saw CONNECT");
+      assertTrue(!server.targetAddressTypes().isEmpty(), "SOCKS server never saw a target");
+      assertTrue(server.targetAddressTypes().stream().allMatch(type -> type == 0x03),
+          "proxy-resolved SOCKS targets must use the domain address type: "
+              + server.targetAddressTypes());
+      assertTrue(server.targetHosts().stream().allMatch("artifact.example"::equals),
+          "SOCKS proxy received an unexpected target hostname: " + server.targetHosts());
+    } finally {
+      server.stop();
+    }
+  }
+
+  @Test
   void standaloneSocksSocketRetainsUnresolvedDomainCompatibility() throws Exception {
     RecordingSocksServer server = RecordingSocksServer.acceptingAny();
     server.start();
@@ -498,6 +545,34 @@ class ProxiedHttpClientFactoryTest {
   }
 
   @Test
+  void httpProxyReceivesOriginalHostnameForProxyResolvedTarget() throws Exception {
+    try (FakeHttpProxyServer proxy = FakeHttpProxyServer.start(request ->
+            FakeHttpProxyServer.FakeResponse.bytes(200, Map.of(),
+                "proxied".getBytes(StandardCharsets.UTF_8)));
+        ProxiedHttpClientFactory factory = new ProxiedHttpClientFactory(60000, 10000)) {
+      OutboundProxyConfig config = new OutboundProxyConfig(
+          OutboundProxyConfig.Type.HTTP, "127.0.0.1", proxy.port(), null, null);
+
+      try (ProxiedHttpClientFactory.ProxiedResponse response = factory.execute(
+          "repo-a",
+          config,
+          "GET",
+          proxyTarget("http://packages.invalid/org/foo.jar?raw=true"),
+          Map.of(),
+          5000)) {
+        assertEquals(200, response.status());
+      }
+
+      FakeHttpProxyServer.RecordedRequest recorded = proxy.requests().get(0);
+      URI routed = URI.create(recorded.target());
+      assertEquals("packages.invalid", routed.getHost());
+      assertEquals("/org/foo.jar", routed.getRawPath());
+      assertEquals("raw=true", routed.getRawQuery());
+      assertEquals("packages.invalid", recorded.header("Host"));
+    }
+  }
+
+  @Test
   void httpProxyHeadRequestReturnsEntityLessResponse() throws Exception {
     try (FakeHttpProxyServer proxy = FakeHttpProxyServer.start(request ->
             FakeHttpProxyServer.FakeResponse.status(200, Map.of("ETag", "\"abc\"")));
@@ -609,6 +684,28 @@ class ProxiedHttpClientFactoryTest {
       assertEquals(target.addresses().get(0),
           java.net.InetAddress.getByName(URI.create("http://" + connect.target()).getHost()));
       assertTrue(connect.target().endsWith(":8443"));
+    }
+  }
+
+  @Test
+  void httpsProxyConnectUsesOriginalHostnameForProxyResolvedTarget() throws Exception {
+    try (FakeHttpProxyServer proxy = FakeHttpProxyServer.start(request ->
+            FakeHttpProxyServer.FakeResponse.status(500, Map.of()));
+        ProxiedHttpClientFactory factory = new ProxiedHttpClientFactory(60000, 10000)) {
+      OutboundProxyConfig config = new OutboundProxyConfig(
+          OutboundProxyConfig.Type.HTTP, "127.0.0.1", proxy.port(), null, null);
+
+      assertThrows(IOException.class, () -> factory.execute(
+          "repo-a",
+          config,
+          "GET",
+          proxyTarget("https://packages.invalid:8443/path"),
+          Map.of(),
+          5000));
+
+      FakeHttpProxyServer.RecordedRequest connect = proxy.requests().get(0);
+      assertEquals("CONNECT", connect.method());
+      assertEquals("packages.invalid:8443", connect.target());
     }
   }
 
@@ -733,6 +830,11 @@ class ProxiedHttpClientFactoryTest {
         .resolveHttpTarget(url, "outbound client test");
   }
 
+  private static ResolvedHttpTarget proxyTarget(String url) {
+    return OutboundRequestPolicy.allowPrivateForTests()
+        .resolveHttpTarget(url, "outbound client test", true);
+  }
+
   private static void assertPinnedProxyTarget(
       ResolvedHttpTarget target, FakeHttpProxyServer.RecordedRequest recorded)
       throws Exception {
@@ -757,6 +859,7 @@ class ProxiedHttpClientFactoryTest {
     private final List<String> attempts = new CopyOnWriteArrayList<>();
     private final List<Integer> selectedMethods = new CopyOnWriteArrayList<>();
     private final List<Integer> targetAddressTypes = new CopyOnWriteArrayList<>();
+    private final List<String> targetHosts = new CopyOnWriteArrayList<>();
     private final CountDownLatch handshakeSeen = new CountDownLatch(1);
     private ServerSocket serverSocket;
     private Thread thread;
@@ -804,6 +907,11 @@ class ProxiedHttpClientFactoryTest {
     /** SOCKS5 address types used by CONNECT (0x01 IPv4, 0x03 domain, 0x04 IPv6). */
     List<Integer> targetAddressTypes() {
       return targetAddressTypes;
+    }
+
+    /** Domain names sent in SOCKS5 CONNECT requests. */
+    List<String> targetHosts() {
+      return targetHosts;
     }
 
     boolean awaitHandshake() throws InterruptedException {
@@ -889,7 +997,8 @@ class ProxiedHttpClientFactoryTest {
         targetAddressTypes.add(atyp);
         if (atyp == 0x03) {
           int len = in.read();
-          in.readNBytes(Math.max(0, len));
+          targetHosts.add(new String(
+              in.readNBytes(Math.max(0, len)), StandardCharsets.US_ASCII));
         } else if (atyp == 0x01) {
           in.readNBytes(4);
         } else if (atyp == 0x04) {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/repositories/RepositoryServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/repositories/RepositoryServiceTest.java
@@ -476,6 +476,32 @@ class RepositoryServiceTest {
   }
 
   @Test
+  void outboundProxyAllowsRemoteHostThatOnlyTheProxyCanResolve() {
+    StubRepositoryDao repositories = new StubRepositoryDao(repository(1L));
+    RepositoryService service = service(repositories);
+
+    RepositoryView created = service.create(new CreateCommand(
+        "maven-proxy",
+        "maven2-proxy",
+        true,
+        "default",
+        true,
+        null,
+        new ProxySettings(
+            "https://packages.invalid/maven2/",
+            1440, 1440, true,
+            null, null, null,
+            null, null,
+            "HTTP", "192.168.1.10", 7890,
+            null, null,
+            null),
+        null, null, null, null));
+
+    assertEquals("https://packages.invalid/maven2/", created.proxy().remoteUrl());
+    assertEquals("HTTP", created.proxy().outboundProxyType());
+  }
+
+  @Test
   void outboundProxyTypeAliasIsStoredAsCanonicalType() {
     StubRepositoryDao repositories = new StubRepositoryDao(repository(1L));
     RepositoryService service = service(repositories);

--- a/server/src/test/java/com/github/klboke/kkrepo/server/security/OutboundRequestPolicyTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/security/OutboundRequestPolicyTest.java
@@ -51,6 +51,53 @@ class OutboundRequestPolicyTest {
   }
 
   @Test
+  void proxyResolvedTargetSkipsLocalDnsAndCarriesTheOriginalHostname() {
+    AtomicInteger lookups = new AtomicInteger();
+    OutboundRequestPolicy policy = new OutboundRequestPolicy(
+        false,
+        "",
+        host -> {
+          lookups.incrementAndGet();
+          throw new UnknownHostException(host);
+        });
+
+    OutboundRequestPolicy.ResolvedHttpTarget target = policy.resolveHttpTarget(
+        "https://packages.invalid/repository/", "remote fetch", true);
+
+    assertEquals(0, lookups.get());
+    assertEquals("packages.invalid", target.uri().getHost());
+    assertTrue(target.proxyResolvesDns());
+    assertTrue(target.addresses().isEmpty());
+  }
+
+  @Test
+  void proxyResolvedTargetsStillRejectExplicitPrivateAndLocalOnlyHosts() {
+    OutboundRequestPolicy policy = new OutboundRequestPolicy(false, "");
+
+    assertThrows(SecurityValidationException.class, () ->
+        policy.resolveHttpTarget("http://127.0.0.1/artifact", "remote fetch", true));
+    assertThrows(SecurityValidationException.class, () ->
+        policy.resolveHttpTarget("http://2130706433/artifact", "remote fetch", true));
+    assertThrows(SecurityValidationException.class, () ->
+        policy.resolveHttpTarget("http://localhost/artifact", "remote fetch", true));
+    assertThrows(SecurityValidationException.class, () ->
+        policy.resolveHttpTarget("http://packages.local/artifact", "remote fetch", true));
+    assertThrows(SecurityValidationException.class, () ->
+        policy.resolveHttpTarget("http://registry.home.arpa/artifact", "remote fetch", true));
+  }
+
+  @Test
+  void privateAddressOverrideAlsoAppliesToProxyResolvedTargets() {
+    OutboundRequestPolicy policy = OutboundRequestPolicy.allowPrivateForTests();
+
+    OutboundRequestPolicy.ResolvedHttpTarget target =
+        policy.resolveHttpTarget("http://localhost/artifact", "remote fetch", true);
+
+    assertTrue(target.proxyResolvesDns());
+    assertTrue(target.addresses().isEmpty());
+  }
+
+  @Test
   void rejectsUnsupportedSchemes() {
     OutboundRequestPolicy policy = OutboundRequestPolicy.allowPrivateForTests();
 


### PR DESCRIPTION
## Summary

- delegate repository upstream hostname resolution to explicitly configured HTTP and SOCKS5 proxies
- preserve local DNS validation and IP pinning for direct traffic and non-repository security endpoints
- reject explicit private/local targets by default in proxy-DNS mode and document the configured proxy as the trusted egress boundary
- allow repository settings to be saved when the upstream is only resolvable by the proxy
- render repository save errors above the open form modal

SOCKS5 domain forwarding follows [RFC 1928](https://www.rfc-editor.org/rfc/rfc1928), and HTTP proxy routing uses Apache HttpClient's unresolved target route support.

## Verification

- `mvn -pl server -am -Dtest=OutboundRequestPolicyTest,ProxiedHttpClientFactoryTest,HttpRemoteFetcherProxyTest,RepositoryServiceTest,DockerRemoteRegistryClientTest -Dsurefire.failIfNoSpecifiedTests=false test` (124 tests)
- `mvn -pl admin-ui -am -Dtest=AdminToastLayerContractTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl server -am test` (1829 tests)
- `git diff --check`

Fixes #131