### PR TITLE
Release kkRepo 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable public changes to kkrepo are documented in this file.
 
 This project follows a pragmatic early-stage release process. Until a stable `1.0.0` release is announced, minor versions may include behavior changes, but releases should call out migration impact, compatibility changes, and operational notes.
 
+## 0.7.0 - 2026-08-06
+
+### Added
+
+- Opt-in asynchronous artifact security scanning with Syft/Grype, durable MySQL/PostgreSQL task and result state, CycloneDX SBOMs, vulnerability findings, audit/enforcement policies, waivers, and Admin/Browse integration. A hardened standalone scanner adapter, isolated Docker Compose profile, and multi-replica Helm deployment keep untrusted scanning work outside the kkRepo JVM and off upload request paths. (#170)
+- Repository cleanup policies for every current format, targeting Hosted and Proxy repositories with bounded Try Run, manual and Quartz-scheduled execution, run history, cancellation, retries, usage-aware retention, protocol-aware deletion, and database-backed leases and fencing across replicas. (#180)
+- Nexus-compatible asset search and detail APIs plus Raw hosted asset deletion, with `nx-search-read`, per-asset repository/content-selector authorization, stable keyset pagination, audit coverage, and cross-replica cache invalidation. (#171)
+
+### Changed
+
+- Admin, Browse, and login surfaces now share a unified design-token foundation for typography, tables, buttons, elevation, and interaction states while preserving the existing DOM and JavaScript contracts. (#162)
+- Quickstart defaults, Dockerfile packaging, deployment documentation, and the Helm application version now use `0.7.0`; the optional scanner profile uses the matching `kkrepo-scanner:0.7.0` image.
+- AWS SDK, Alibaba Cloud OSS, zstd-jni, GraalVM Native Build Tools, Maven Jar/Flatten plugins, and GitHub Actions dependencies were refreshed. (#164, #165, #166, #167, #168, #169, #176, #177)
+
+### Fixed
+
+- npm hosted publication now stream-decodes base64 attachments to bounded request-local staging files, allowing large packages beyond Jackson's default 20-million-character string limit without materializing the full archive payload in heap. (#173)
+- Repository upstream DNS can be delegated to an explicitly configured HTTP or SOCKS5 proxy while direct traffic and non-repository security endpoints retain local resolution, validation, and IP pinning. Explicit private or local upstream targets remain rejected by default. (#175)
+- RubyGems hosted, proxy, and group repository roots now return Nexus-compatible HTML for trailing-slash requests and the compatible `400` HTML response for bare roots, without changing explicit metadata or gem download endpoints. (#182)
+
+### Compatibility And Validation
+
+- Security scanning includes MySQL/PostgreSQL persistence contracts, multi-replica coordination, hardened archive and OCI staging limits, Compose/Helm network isolation checks, and an end-to-end vulnerable Maven artifact scan. (#170)
+- Cleanup policies are covered across every repository format, both database backends, clustered scheduling, worker takeover, fencing, bounded scans, group-to-source usage attribution, protocol metadata updates, and restart-safe online index migrations. (#180)
+- Asset management and RubyGems root behavior include live Nexus comparisons, while npm publication coverage includes a 30 MiB incompressible package through the real npm client. (#171, #173, #182)
+
+### Upgrade Notes
+
+- Existing `0.6.0` MySQL and PostgreSQL deployments can upgrade in place through Flyway V36-V40. Back up the database and blob store together before upgrading, allow time for DDL and online-index work on large tables, and do not run mixed application versions after the migrations are applied.
+- V36-V37 add artifact-change, Blob-reference, security-scan, policy, result, and online-index state. Scanning remains disabled by default after upgrade: enabling `KKREPO_SECURITY_SCANNING_ENABLED`, deploying the matching scanner image, and activating repositories are separate explicit steps.
+- V38-V40 add cleanup runtime state, clustered Quartz JobStore tables, and cleanup/scan indexes. New cleanup policies always start paused and never delete content until an administrator runs or explicitly schedules them; use a bounded Try Run and retain a tested backup before the first execution.
+
 ## 0.6.0 - 2026-07-24
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:25-jre-jammy
 
 WORKDIR /app
 
-ARG JAR_FILE=server/target/kkrepo-server-0.6.0.jar
+ARG JAR_FILE=server/target/kkrepo-server-0.7.0.jar
 
 RUN groupadd --system kkrepo \
     && useradd --system --gid kkrepo --home-dir /app --shell /usr/sbin/nologin kkrepo

--- a/deploy/helm/kkrepo/Chart.yaml
+++ b/deploy/helm/kkrepo/Chart.yaml
@@ -3,5 +3,5 @@ name: kkrepo
 description: Multi-replica kkRepo artifact repository with an external MySQL or PostgreSQL database
 type: application
 version: 0.2.0
-appVersion: "0.6.0"
+appVersion: "0.7.0"
 kubeVersion: ">=1.27.0-0"

--- a/docker-compose.quickstart-postgresql.yml
+++ b/docker-compose.quickstart-postgresql.yml
@@ -28,7 +28,7 @@ services:
     network_mode: none
 
   kkrepo:
-    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.6.0}
+    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.7.0}
     depends_on:
       postgresql:
         condition: service_healthy
@@ -61,7 +61,7 @@ services:
     restart: unless-stopped
 
   scanner:
-    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.6.0}
+    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.7.0}
     profiles: ["security-scanning"]
     environment:
       KKREPO_SCANNER_SERVICE_CREDENTIAL: ${KKREPO_SECURITY_SCANNING_SERVICE_CREDENTIAL:-}
@@ -91,7 +91,7 @@ services:
     restart: unless-stopped
 
   scanner-database-updater:
-    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.6.0}
+    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.7.0}
     profiles: ["security-scanning"]
     entrypoint: ["/bin/sh", "-ec"]
     command:

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -29,7 +29,7 @@ services:
     network_mode: none
 
   kkrepo:
-    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.6.0}
+    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.7.0}
     depends_on:
       mysql:
         condition: service_healthy
@@ -62,7 +62,7 @@ services:
     restart: unless-stopped
 
   scanner:
-    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.6.0}
+    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.7.0}
     profiles: ["security-scanning"]
     environment:
       KKREPO_SCANNER_SERVICE_CREDENTIAL: ${KKREPO_SECURITY_SCANNING_SERVICE_CREDENTIAL:-}
@@ -92,7 +92,7 @@ services:
     restart: unless-stopped
 
   scanner-database-updater:
-    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.6.0}
+    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.7.0}
     profiles: ["security-scanning"]
     entrypoint: ["/bin/sh", "-ec"]
     command:

--- a/docs/en/build-deployment-guide.md
+++ b/docs/en/build-deployment-guide.md
@@ -40,7 +40,7 @@ curl -fsSL https://raw.githubusercontent.com/klboke/kkrepo/main/scripts/quicksta
   | KKREPO_RUNTIME=native KKREPO_DATABASE_TYPE=postgresql bash
 ```
 
-`KKREPO_RUNTIME=jvm` selects `ghcr.io/klboke/kkrepo:0.6.0`, while `KKREPO_RUNTIME=native` selects `ghcr.io/klboke/kkrepo:0.6.0-native`. Both are published for Linux `amd64` and `arm64`. An explicit `KKREPO_IMAGE_TAG` overrides the runtime's default tag.
+`KKREPO_RUNTIME=jvm` selects `ghcr.io/klboke/kkrepo:0.7.0`, while `KKREPO_RUNTIME=native` selects `ghcr.io/klboke/kkrepo:0.7.0-native`. Both are published for Linux `amd64` and `arm64`. An explicit `KKREPO_IMAGE_TAG` overrides the runtime's default tag.
 
 The script prints each step and:
 
@@ -61,7 +61,7 @@ bash quickstart.sh
 
 By default, it starts:
 
-- The JVM runtime from `ghcr.io/klboke/kkrepo:0.6.0`
+- The JVM runtime from `ghcr.io/klboke/kkrepo:0.7.0`
 - MySQL 8.0
 - Persistent MySQL and File blob storage volumes for local trials
 
@@ -153,7 +153,7 @@ Note: a normal `server` module jar does not contain a Spring Boot executable ent
 Pull the latest public release image:
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:0.6.0
+docker pull ghcr.io/klboke/kkrepo:0.7.0
 ```
 
 You can also use `latest` to follow the latest public release:
@@ -165,7 +165,7 @@ docker pull ghcr.io/klboke/kkrepo:latest
 The Native image is published separately:
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:0.6.0-native
+docker pull ghcr.io/klboke/kkrepo:0.7.0-native
 docker pull ghcr.io/klboke/kkrepo:native-latest
 ```
 

--- a/docs/zh/build-deployment-guide.md
+++ b/docs/zh/build-deployment-guide.md
@@ -40,7 +40,7 @@ curl -fsSL https://raw.githubusercontent.com/klboke/kkrepo/main/scripts/quicksta
   | KKREPO_RUNTIME=native KKREPO_DATABASE_TYPE=postgresql bash
 ```
 
-`KKREPO_RUNTIME=jvm` 选择 `ghcr.io/klboke/kkrepo:0.6.0`，`KKREPO_RUNTIME=native` 选择 `ghcr.io/klboke/kkrepo:0.6.0-native`。两种镜像均发布 Linux `amd64` 和 `arm64` 架构。显式设置 `KKREPO_IMAGE_TAG` 时，会覆盖对应运行时的默认 tag。
+`KKREPO_RUNTIME=jvm` 选择 `ghcr.io/klboke/kkrepo:0.7.0`，`KKREPO_RUNTIME=native` 选择 `ghcr.io/klboke/kkrepo:0.7.0-native`。两种镜像均发布 Linux `amd64` 和 `arm64` 架构。显式设置 `KKREPO_IMAGE_TAG` 时，会覆盖对应运行时的默认 tag。
 
 该脚本会逐步打印日志并执行：
 
@@ -61,7 +61,7 @@ bash quickstart.sh
 
 默认会启动：
 
-- `ghcr.io/klboke/kkrepo:0.6.0` 中的 JVM 运行时
+- `ghcr.io/klboke/kkrepo:0.7.0` 中的 JVM 运行时
 - MySQL 8.0
 - 用于本地试用的持久化 MySQL volume 和 File blob storage volume
 
@@ -153,7 +153,7 @@ server/target/kkrepo-server-<version>.jar
 拉取最新公开发行镜像：
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:0.6.0
+docker pull ghcr.io/klboke/kkrepo:0.7.0
 ```
 
 也可以使用 `latest` 跟随最新公开发行版本：
@@ -165,7 +165,7 @@ docker pull ghcr.io/klboke/kkrepo:latest
 Native 镜像使用独立 tag：
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:0.6.0-native
+docker pull ghcr.io/klboke/kkrepo:0.7.0-native
 docker pull ghcr.io/klboke/kkrepo:native-latest
 ```
 

--- a/persistence-jdbc/src/test/java/com/github/klboke/kkrepo/persistence/jdbc/contract/PersistenceApiContract.java
+++ b/persistence-jdbc/src/test/java/com/github/klboke/kkrepo/persistence/jdbc/contract/PersistenceApiContract.java
@@ -420,7 +420,11 @@ public abstract class PersistenceApiContract {
   void cleanupRuntimeIsMonotonicFencedRecoverableAndGloballyBounded() {
     CleanupPolicyDao cleanup = stores().cleanupPolicies();
     assertNotNull(cleanup.currentTime());
-    Instant base = Instant.now().plusSeconds(1).truncatedTo(ChronoUnit.MILLIS);
+    // Run shards initialize next_attempt_at from the database clock. Keep this synthetic lease
+    // timeline comfortably ahead of real setup time so slower container hosts do not make the
+    // first shard ineligible before the claim assertions begin.
+    Instant base = cleanup.currentTime().plus(Duration.ofHours(1))
+        .truncatedTo(ChronoUnit.MILLIS);
     long blobStoreId = stores().blobStores().insert(blobStore("cleanup-runtime-contract"));
     long firstRepositoryId = insertRepository(
         "cleanup-runtime-first", RepositoryFormat.RAW, blobStoreId);

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
   </modules>
 
   <properties>
-    <revision>0.6.0</revision>
+    <revision>0.7.0</revision>
     <java.version>25</java.version>
     <spring.boot.version>4.1.0</spring.boot.version>
     <native-build-tools-plugin.version>1.1.6</native-build-tools-plugin.version>

--- a/scripts/ci/test-quickstart-runtime.sh
+++ b/scripts/ci/test-quickstart-runtime.sh
@@ -58,21 +58,22 @@ run_quickstart() {
 
 run_quickstart default-jvm
 grep -qx 'KKREPO_RUNTIME=jvm' "$TMP_ROOT/default-jvm/.env"
-grep -qx 'KKREPO_IMAGE_TAG=0.6.0' "$TMP_ROOT/default-jvm/.env"
-grep -qx 'jvm|0.6.0' "$TMP_ROOT/default-jvm.log"
+grep -qx 'KKREPO_IMAGE_TAG=0.7.0' "$TMP_ROOT/default-jvm/.env"
+grep -qx 'jvm|0.7.0' "$TMP_ROOT/default-jvm.log"
 
 run_quickstart native KKREPO_RUNTIME=native
 grep -qx 'KKREPO_RUNTIME=native' "$TMP_ROOT/native/.env"
-grep -qx 'KKREPO_IMAGE_TAG=0.6.0-native' "$TMP_ROOT/native/.env"
-grep -qx 'native|0.6.0-native' "$TMP_ROOT/native.log"
+grep -qx 'KKREPO_IMAGE_TAG=0.7.0-native' "$TMP_ROOT/native/.env"
+grep -qx 'native|0.7.0-native' "$TMP_ROOT/native.log"
 
 mkdir -p "$TMP_ROOT/existing-jvm"
+# Simulate a persisted v0.6.0 JVM quickstart before explicitly switching runtimes.
 cat >"$TMP_ROOT/existing-jvm/.env" <<'EOF'
 KKREPO_RUNTIME=jvm
 KKREPO_IMAGE_TAG=0.6.0
 EOF
 run_quickstart existing-jvm KKREPO_RUNTIME=native
-grep -qx 'native|0.6.0-native' "$TMP_ROOT/existing-jvm.log"
+grep -qx 'native|0.7.0-native' "$TMP_ROOT/existing-jvm.log"
 
 run_quickstart custom-native \
   KKREPO_RUNTIME=native \

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -186,10 +186,10 @@ fi
 KKREPO_RUNTIME="${KKREPO_RUNTIME:-jvm}"
 case "$KKREPO_RUNTIME" in
   jvm)
-    DEFAULT_IMAGE_TAG="0.6.0"
+    DEFAULT_IMAGE_TAG="0.7.0"
     ;;
   native)
-    DEFAULT_IMAGE_TAG="0.6.0-native"
+    DEFAULT_IMAGE_TAG="0.7.0-native"
     ;;
   *)
     fail "KKREPO_RUNTIME must be jvm or native, got: $KKREPO_RUNTIME"


### PR DESCRIPTION
## Summary

- bump the Maven revision, Dockerfile, JVM/Native quickstart defaults, Helm app version, English/Chinese deployment docs, and regression expectations to `0.7.0`
- move the optional Compose scanner and updater defaults to matching `ghcr.io/klboke/kkrepo-scanner:0.7.0`
- add release notes for artifact security scanning, cleanup policies, Nexus asset APIs, UI refresh, compatibility fixes, dependency updates, and Flyway V36-V40 upgrade guidance
- stabilize the shared cleanup persistence contract by deriving its synthetic lease timeline from the database clock with enough setup headroom; production DAO behavior is unchanged

## Release scope

`0.7.0` includes artifact security scanning (#170), repository cleanup policies (#180), Nexus-compatible asset APIs (#171), the shared UI design system (#162), large npm publish streaming (#173), proxy-resolved upstream DNS (#175), and Nexus-compatible RubyGems repository roots (#182).

Existing `0.6.0` MySQL and PostgreSQL deployments upgrade through Flyway V36-V40. Security scanning remains opt-in, and new cleanup policies start paused.

## Validation

- `mvn -B -ntp -N validate` and project version check for `0.7.0`
- `scripts/build-dist.sh --jvm` — all 28 modules packaged; verified `kkrepo-0.7.0.tar.gz` and `.zip`
- scanner adapter `0.7.0` Spring Boot repackage and manifest verification
- `scripts/ci/test-dist-launcher.sh`
- `scripts/ci/test-quickstart-runtime.sh`
- MySQL/PostgreSQL Compose config, with and without `security-scanning`
- `helm lint deploy/helm/kkrepo`
- `scripts/ci/check-flyway-parity.sh` — V40
- focused cleanup persistence contract passed on MySQL 8 and PostgreSQL 12 after removing the host-speed timing assumption
- `git diff --check`

The initial broad `server,scanner-adapter -am test` run passed 24 reactor modules before exposing the cleanup contract's one-second timing assumption on the local container host. The focused regression now passes on both database backends; the `run-full-e2e` label will exercise the complete PR matrix.