### PR TITLE
fix: preserve Nginx bind mount during bootstrap

### DIFF
--- a/.github/deploy/dev/bootstrap-dual-runtime.sh
+++ b/.github/deploy/dev/bootstrap-dual-runtime.sh
@@ -4,6 +4,7 @@ set -Eeuo pipefail
 DEPLOY_CONFIG_ROOT="${KKREPO_DEPLOY_CONFIG_ROOT:-/opt/kkrepo/runtime/deploy-config}"
 NGINX_CONTAINER="${KKREPO_NGINX_CONTAINER:-kkrepo-nginx}"
 NGINX_TARGET="${KKREPO_NGINX_CONFIG:-/opt/kkrepo/.github/deploy/dev/nginx/kkrepo.conf}"
+NGINX_CONTAINER_CONFIG="${KKREPO_NGINX_CONTAINER_CONFIG:-/etc/nginx/conf.d/default.conf}"
 SYSTEMD_DIR="${KKREPO_SYSTEMD_DIR:-/etc/systemd/system}"
 BACKUP_ROOT="$DEPLOY_CONFIG_ROOT/backups"
 ACTIVATION_MARKER="$DEPLOY_CONFIG_ROOT/dual-runtime-active"
@@ -26,59 +27,103 @@ require_file() {
   [[ -s "$path" ]] || fail "required file is missing or empty: $path"
 }
 
-if (( EUID != 0 )); then
-  fail "run this one-time bootstrap as root"
-  exit 1
-fi
-
-require_file "$JVM_UNIT_SOURCE"
-require_file "$NATIVE_UNIT_SOURCE"
-require_file "$NGINX_SOURCE"
-rm -f "$ACTIVATION_MARKER"
-
-grep -Fq '127.0.0.1:8080 weight=1' "$NGINX_SOURCE"
-grep -Fq '127.0.0.1:8090 weight=1' "$NGINX_SOURCE"
-
-log "installing JVM and Native systemd units"
-install -m 0644 "$JVM_UNIT_SOURCE" "$SYSTEMD_DIR/kkrepo.service"
-install -m 0644 "$NATIVE_UNIT_SOURCE" "$SYSTEMD_DIR/kkrepo-native.service"
-systemctl daemon-reload
-systemctl enable kkrepo.service kkrepo-native.service >/dev/null
-systemctl start kkrepo.service
-systemctl start kkrepo-native.service
-
-log "verifying both runtime readiness endpoints"
-curl --fail --silent --show-error --max-time 10 \
-  http://127.0.0.1:8081/actuator/health/readiness >/dev/null
-curl --fail --silent --show-error --max-time 10 \
-  http://127.0.0.1:8091/actuator/health/readiness >/dev/null
-
-mkdir -p "$BACKUP_ROOT"
-backup_dir="$(mktemp -d "$BACKUP_ROOT/bootstrap-XXXXXXXX")"
-if [[ -f "$NGINX_TARGET" ]]; then
-  install -m 0644 "$NGINX_TARGET" "$backup_dir/kkrepo.conf"
-fi
-
-restore_nginx() {
-  if [[ -f "$backup_dir/kkrepo.conf" ]]; then
-    install -m 0644 "$backup_dir/kkrepo.conf" "$NGINX_TARGET"
+# The Nginx container bind-mounts this single file. Replacing the destination inode (for example
+# with install(1)) leaves the running container attached to the unlinked old file, so update an
+# existing target in place and prove that the container observes the exact staged bytes.
+copy_config_preserving_inode() {
+  local source="$1"
+  local target="$2"
+  if [[ -e "$target" ]]; then
+    cp -- "$source" "$target"
+    chmod 0644 "$target"
+  else
+    install -m 0644 "$source" "$target"
   fi
 }
 
-log "installing and validating the 50/50 Nginx upstream"
-install -m 0644 "$NGINX_SOURCE" "$NGINX_TARGET"
-if ! docker exec "$NGINX_CONTAINER" nginx -t; then
-  restore_nginx
-  fail "Nginx validation failed; restored the previous configuration"
-  exit 1
-fi
-if ! docker exec "$NGINX_CONTAINER" nginx -s reload; then
-  restore_nginx
-  docker exec "$NGINX_CONTAINER" nginx -s reload || true
-  fail "Nginx reload failed; restored the previous configuration"
-  exit 1
-fi
+file_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk 'NR == 1 {print $1}'
+  else
+    LC_ALL=C shasum -a 256 "$1" | awk 'NR == 1 {print $1}'
+  fi
+}
 
-touch "$ACTIVATION_MARKER"
-chmod 0644 "$ACTIVATION_MARKER"
-log "dual runtime bootstrap complete: JVM 8080/8081, Native 8090/8091, traffic 50/50"
+container_nginx_sha256() {
+  docker exec "$NGINX_CONTAINER" sha256sum "$NGINX_CONTAINER_CONFIG" \
+    | awk 'NR == 1 {print $1}'
+}
+
+main() {
+  local backup_dir
+  local expected_nginx_sha
+  local mounted_nginx_sha
+
+  if (( EUID != 0 )); then
+    fail "run this one-time bootstrap as root"
+    exit 1
+  fi
+
+  require_file "$JVM_UNIT_SOURCE"
+  require_file "$NATIVE_UNIT_SOURCE"
+  require_file "$NGINX_SOURCE"
+  rm -f "$ACTIVATION_MARKER"
+
+  grep -Fq '127.0.0.1:8080 weight=1' "$NGINX_SOURCE"
+  grep -Fq '127.0.0.1:8090 weight=1' "$NGINX_SOURCE"
+
+  log "installing JVM and Native systemd units"
+  install -m 0644 "$JVM_UNIT_SOURCE" "$SYSTEMD_DIR/kkrepo.service"
+  install -m 0644 "$NATIVE_UNIT_SOURCE" "$SYSTEMD_DIR/kkrepo-native.service"
+  systemctl daemon-reload
+  systemctl enable kkrepo.service kkrepo-native.service >/dev/null
+  systemctl start kkrepo.service
+  systemctl start kkrepo-native.service
+
+  log "verifying both runtime readiness endpoints"
+  curl --fail --silent --show-error --max-time 10 \
+    http://127.0.0.1:8081/actuator/health/readiness >/dev/null
+  curl --fail --silent --show-error --max-time 10 \
+    http://127.0.0.1:8091/actuator/health/readiness >/dev/null
+
+  mkdir -p "$BACKUP_ROOT"
+  backup_dir="$(mktemp -d "$BACKUP_ROOT/bootstrap-XXXXXXXX")"
+  if [[ -f "$NGINX_TARGET" ]]; then
+    install -m 0644 "$NGINX_TARGET" "$backup_dir/kkrepo.conf"
+  fi
+
+  restore_nginx() {
+    if [[ -f "$backup_dir/kkrepo.conf" ]]; then
+      copy_config_preserving_inode "$backup_dir/kkrepo.conf" "$NGINX_TARGET"
+    fi
+  }
+
+  log "installing and validating the 50/50 Nginx upstream"
+  copy_config_preserving_inode "$NGINX_SOURCE" "$NGINX_TARGET"
+  expected_nginx_sha="$(file_sha256 "$NGINX_SOURCE")"
+  mounted_nginx_sha="$(container_nginx_sha256 2>/dev/null || true)"
+  if [[ "$mounted_nginx_sha" != "$expected_nginx_sha" ]]; then
+    restore_nginx
+    fail "Nginx bind mount did not observe the staged configuration; restored the previous configuration"
+    exit 1
+  fi
+  if ! docker exec "$NGINX_CONTAINER" nginx -t; then
+    restore_nginx
+    fail "Nginx validation failed; restored the previous configuration"
+    exit 1
+  fi
+  if ! docker exec "$NGINX_CONTAINER" nginx -s reload; then
+    restore_nginx
+    docker exec "$NGINX_CONTAINER" nginx -s reload || true
+    fail "Nginx reload failed; restored the previous configuration"
+    exit 1
+  fi
+
+  touch "$ACTIVATION_MARKER"
+  chmod 0644 "$ACTIVATION_MARKER"
+  log "dual runtime bootstrap complete: JVM 8080/8081, Native 8090/8091, traffic 50/50"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,7 @@ jobs:
           bash -n scripts/deploy/kkrepo-dual-runtime-deploy.sh
           bash -n scripts/ci/test-dev-jar-deploy.sh
           bash -n scripts/ci/test-dev-dual-runtime-deploy.sh
+          bash -n scripts/ci/test-dev-nginx-bind-mount.sh
           bash -n scripts/ci/check-dev-dual-runtime-deploy.sh
           bash -n .github/deploy/dev/bootstrap-dual-runtime.sh
           bash -n scripts/build-dist.sh
@@ -171,6 +172,7 @@ jobs:
           bash -n server/src/dist/bin/stop.sh
           scripts/ci/test-dev-jar-deploy.sh
           scripts/ci/test-dev-dual-runtime-deploy.sh
+          scripts/ci/test-dev-nginx-bind-mount.sh
           scripts/ci/check-dev-dual-runtime-deploy.sh
           scripts/ci/test-e2e-image-artifact.sh
           scripts/ci/test-quickstart-runtime.sh

--- a/scripts/ci/test-dev-nginx-bind-mount.sh
+++ b/scripts/ci/test-dev-nginx-bind-mount.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BOOTSTRAP="$ROOT/.github/deploy/dev/bootstrap-dual-runtime.sh"
+TEST_ROOT="$(mktemp -d)"
+SOURCE_CONFIG="$TEST_ROOT/staged.conf"
+TARGET_CONFIG="$TEST_ROOT/live.conf"
+CONTAINER="kkrepo-nginx-bind-mount-test-$$"
+
+cleanup() {
+  docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+# shellcheck disable=SC1090
+source "$BOOTSTRAP"
+
+file_inode() {
+  if stat -c '%i' "$1" >/dev/null 2>&1; then
+    stat -c '%i' "$1"
+  else
+    stat -f '%i' "$1"
+  fi
+}
+
+printf 'old upstream\n' >"$TARGET_CONFIG"
+printf 'new equal-weight upstream\n' >"$SOURCE_CONFIG"
+
+docker run -d --rm --name "$CONTAINER" \
+  -v "$TARGET_CONFIG:/tmp/kkrepo.conf:ro" \
+  nginx:stable-alpine sh -c 'while :; do sleep 60; done' >/dev/null
+
+for _attempt in $(seq 1 20); do
+  if docker exec "$CONTAINER" test -r /tmp/kkrepo.conf >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.1
+done
+docker exec "$CONTAINER" test -r /tmp/kkrepo.conf
+
+inode_before="$(file_inode "$TARGET_CONFIG")"
+[[ "$(file_sha256 "$TARGET_CONFIG")" \
+    == "$(docker exec "$CONTAINER" sha256sum /tmp/kkrepo.conf | awk 'NR == 1 {print $1}')" ]]
+copy_config_preserving_inode "$SOURCE_CONFIG" "$TARGET_CONFIG"
+inode_after="$(file_inode "$TARGET_CONFIG")"
+
+[[ "$inode_after" == "$inode_before" ]]
+[[ "$(file_sha256 "$SOURCE_CONFIG")" == "$(file_sha256 "$TARGET_CONFIG")" ]]
+[[ "$(file_sha256 "$SOURCE_CONFIG")" \
+    == "$(docker exec "$CONTAINER" sha256sum /tmp/kkrepo.conf | awk 'NR == 1 {print $1}')" ]]
+
+printf '[test] dev Nginx single-file bind mount update passed\n'


### PR DESCRIPTION
## What

- update the live Nginx configuration in place so its single-file bind mount keeps the same inode
- compare the staged configuration SHA-256 with the file visible inside the running Nginx container before validation and reload
- restore the previous configuration through the same inode-preserving path
- add a Docker contract test that proves the host inode is unchanged and the mounted container sees the new bytes

## Root cause

The initial dual-runtime bootstrap used `install` for the host-side Nginx configuration. That replaced the destination inode, while the running container remained attached to the unlinked old inode. As a result, `nginx -t` and reload validated the old JVM-only configuration even though the host path contained the new 50/50 upstream.

The live dev host was remediated by recreating only the Nginx container so it rebound the current host file. Twenty marked public requests then split exactly 10 to JVM and 10 to Native.

## Impact

Future bootstrap runs fail closed unless the container observes the exact staged configuration. A successful activation marker therefore means the live container actually sees the 50/50 configuration.

## Checks

- `scripts/ci/test-dev-nginx-bind-mount.sh`
- `scripts/ci/check-dev-dual-runtime-deploy.sh`
- `actionlint`
- `bash -n` for the changed shell scripts
- `git diff --check`