### PR TITLE
fix: allow same-host proxy HTTP to HTTPS redirects

### DIFF
--- a/server/src/main/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcher.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcher.java
@@ -528,15 +528,28 @@ public class HttpRemoteFetcher {
     }
 
     private static boolean sameOrigin(URI a, URI b) {
-      return a != null
-          && b != null
-          && a.getScheme() != null
-          && b.getScheme() != null
-          && a.getHost() != null
-          && b.getHost() != null
-          && a.getScheme().equalsIgnoreCase(b.getScheme())
-          && a.getHost().equalsIgnoreCase(b.getHost())
-          && effectivePort(a) == effectivePort(b);
+      if (a == null || b == null
+          || a.getScheme() == null || b.getScheme() == null
+          || a.getHost() == null || b.getHost() == null) {
+        return false;
+      }
+      if (!a.getHost().equalsIgnoreCase(b.getHost())) {
+        return false;
+      }
+      if (a.getScheme().equalsIgnoreCase(b.getScheme())) {
+        return effectivePort(a) == effectivePort(b);
+      }
+      return isHttpToHttpsUpgrade(a, b);
+    }
+
+    private static boolean isHttpToHttpsUpgrade(URI from, URI to) {
+      if (!"http".equalsIgnoreCase(from.getScheme())
+          || !"https".equalsIgnoreCase(to.getScheme())) {
+        return false;
+      }
+      int fromPort = effectivePort(from);
+      int toPort = effectivePort(to);
+      return (fromPort == 80 && toPort == 443) || fromPort == toPort;
     }
 
     private static int effectivePort(URI uri) {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcherTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcherTest.java
@@ -37,6 +37,9 @@ import com.github.klboke.kkrepo.server.proxy.ProxiedHttpClientFactory;
 import com.github.klboke.kkrepo.server.security.OutboundRequestPolicy;
 import com.github.klboke.kkrepo.server.security.SecurityValidationException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class HttpRemoteFetcherTest {
 
@@ -205,6 +208,22 @@ class HttpRemoteFetcherTest {
     assertNotNull(sameOrigin.authorizationHeader());
   }
 
+  @ParameterizedTest(name = "configured HTTP remote {0} trusts upgraded request {1}")
+  @CsvSource({
+      "http://repo.example.com/maven2, https://repo.example.com/maven2/app.jar",
+      "http://repo.example.com:80/maven2, https://repo.example.com:443/maven2/app.jar",
+      "http://repo.example.com:8080/maven2, https://repo.example.com:8080/maven2/app.jar"
+  })
+  void remoteAuthorizationRecognizesSafeSameHostHttpToHttpsUpgrade(
+      String remoteUrl, String requestUrl) {
+    HttpRemoteFetcher.Request request = HttpRemoteFetcher.Request
+        .get(requestUrl)
+        .withRepository(runtime(remoteUrl, "robot", "secret", null));
+
+    assertEquals("repo.example.com", request.trustedHost());
+    assertNotNull(request.authorizationHeader());
+  }
+
   @Test
   void redirectAuthorizationRequiresSameOrigin() {
     HttpRemoteFetcher.Request request = HttpRemoteFetcher.Request
@@ -224,7 +243,7 @@ class HttpRemoteFetcherTest {
   }
 
   @Test
-  void redirectAuthorizationAllowsSameHostHttpToHttpsUpgrade() {
+  void credentiallessRepositoryRequestAllowsSameHostHttpToHttpsUpgrade() {
     HttpRemoteFetcher.Request credentialless = HttpRemoteFetcher.Request
         .get("http://repo.example.com/maven2/com/example/app.jar")
         .withRepository(runtime("http://repo.example.com/maven2", null, null, null));
@@ -234,32 +253,65 @@ class HttpRemoteFetcherTest {
     assertNull(credentialless.authorizationHeader());
     assertNull(credentialless.authorizationHeaderForRedirect(defaultCurrent, defaultUpgrade));
     assertEquals("repo.example.com", credentialless.trustedHostForRedirect(defaultCurrent, defaultUpgrade));
-
-    HttpRemoteFetcher.Request defaultPorts = HttpRemoteFetcher.Request
-        .get("http://repo.example.com/maven2/com/example/app.jar")
-        .withRepository(runtime("http://repo.example.com/maven2", "robot", "secret", null));
-
-    assertEquals(
-        defaultPorts.authorizationHeader(),
-        defaultPorts.authorizationHeaderForRedirect(defaultCurrent, defaultUpgrade));
-    assertEquals("repo.example.com", defaultPorts.trustedHostForRedirect(defaultCurrent, defaultUpgrade));
-
-    HttpRemoteFetcher.Request sameExplicitPort = HttpRemoteFetcher.Request
-        .get("http://repo.example.com:8080/maven2/com/example/app.jar")
-        .withRepository(runtime("http://repo.example.com:8080/maven2", "robot", "secret", null));
-    URI explicitCurrent = URI.create("http://repo.example.com:8080/maven2/com/example/app.jar");
-    assertEquals(
-        sameExplicitPort.authorizationHeader(),
-        sameExplicitPort.authorizationHeaderForRedirect(
-            explicitCurrent, URI.create("https://repo.example.com:8080/maven2/redirect.jar")));
-    assertThrows(
-        SecurityValidationException.class,
-        () -> sameExplicitPort.authorizationHeaderForRedirect(
-            explicitCurrent, URI.create("https://repo.example.com/maven2/redirect.jar")));
   }
 
-  @Test
-  void fetchFollowsSameHostHttpToHttpsUpgradeAndPreservesAuthorization() throws Exception {
+  @ParameterizedTest(name = "safe upgrade {0} -> {1}")
+  @CsvSource({
+      "http://repo.example.com/artifact.jar, https://repo.example.com/artifact.jar",
+      "http://repo.example.com:80/artifact.jar, https://repo.example.com:443/artifact.jar",
+      "http://repo.example.com:80/artifact.jar, https://repo.example.com/artifact.jar",
+      "http://repo.example.com/artifact.jar, https://repo.example.com:443/artifact.jar",
+      "http://repo.example.com:8080/artifact.jar, https://repo.example.com:8080/artifact.jar",
+      "http://repo.example.com:443/artifact.jar, https://repo.example.com/artifact.jar",
+      "http://repo.example.com/artifact.jar, https://repo.example.com:80/artifact.jar",
+      "http://REPO.example.com/artifact.jar, https://repo.EXAMPLE.com/artifact.jar"
+  })
+  void redirectAuthorizationAllowsSafeSameHostHttpToHttpsUpgrade(
+      String currentUrl, String redirectedUrl) {
+    HttpRemoteFetcher.Request request = HttpRemoteFetcher.Request
+        .get(currentUrl)
+        .withRepository(runtime(currentUrl, "robot", "secret", null));
+    URI current = URI.create(currentUrl);
+    URI redirected = URI.create(redirectedUrl);
+
+    assertNotNull(request.authorizationHeader());
+    assertEquals(
+        request.authorizationHeader(),
+        request.authorizationHeaderForRedirect(current, redirected));
+    assertEquals("repo.example.com", request.trustedHostForRedirect(current, redirected));
+  }
+
+  @ParameterizedTest(name = "unsafe redirect {0} -> {1}")
+  @CsvSource({
+      "https://repo.example.com/artifact.jar, http://repo.example.com/artifact.jar",
+      "http://repo.example.com/artifact.jar, https://cdn.example.com/artifact.jar",
+      "http://repo.example.com:8080/artifact.jar, https://repo.example.com/artifact.jar",
+      "http://repo.example.com/artifact.jar, https://repo.example.com:8443/artifact.jar",
+      "http://repo.example.com:8080/artifact.jar, https://repo.example.com:8443/artifact.jar",
+      "https://repo.example.com/artifact.jar, https://repo.example.com:8443/artifact.jar",
+      "http://repo.example.com/artifact.jar, ftp://repo.example.com/artifact.jar"
+  })
+  void redirectAuthorizationRejectsDowngradesCrossHostAndPortChanges(
+      String currentUrl, String redirectedUrl) {
+    HttpRemoteFetcher.Request request = HttpRemoteFetcher.Request
+        .get(currentUrl)
+        .withRepository(runtime(currentUrl, "robot", "secret", null));
+    URI current = URI.create(currentUrl);
+    URI redirected = URI.create(redirectedUrl);
+
+    assertNotNull(request.authorizationHeader());
+    assertThrows(
+        SecurityValidationException.class,
+        () -> request.authorizationHeaderForRedirect(current, redirected));
+    assertThrows(
+        SecurityValidationException.class,
+        () -> request.trustedHostForRedirect(current, redirected));
+  }
+
+  @ParameterizedTest(name = "HTTP {0} follows same-host HTTPS upgrade")
+  @ValueSource(ints = {301, 302, 303, 307, 308})
+  void fetchFollowsSameHostHttpToHttpsUpgradeAndPreservesAuthorization(int redirectStatus)
+      throws Exception {
     ProxiedHttpClientFactory transport = mock(ProxiedHttpClientFactory.class);
     List<URI> targets = new ArrayList<>();
     List<String> authorizations = new ArrayList<>();
@@ -276,7 +328,7 @@ class HttpRemoteFetcherTest {
           authorizations.add(headers.get("Authorization"));
           if ("http".equalsIgnoreCase(target.uri().getScheme())) {
             return response(
-                302,
+                redirectStatus,
                 Map.of("Location", "https://localhost/artifact.jar"),
                 "");
           }
@@ -297,6 +349,57 @@ class HttpRemoteFetcherTest {
     assertEquals(List.of("http", "https"),
         targets.stream().map(URI::getScheme).toList());
     assertEquals(List.of(request.authorizationHeader(), request.authorizationHeader()), authorizations);
+  }
+
+  @Test
+  void fetchPreservesAuthorizationAcrossUpgradeAndSubsequentSameOriginRedirect() throws Exception {
+    ProxiedHttpClientFactory transport = mock(ProxiedHttpClientFactory.class);
+    List<URI> targets = new ArrayList<>();
+    List<String> authorizations = new ArrayList<>();
+    when(transport.execute(
+        anyString(),
+        nullable(OutboundProxyConfig.class),
+        eq("GET"),
+        any(OutboundRequestPolicy.ResolvedHttpTarget.class),
+        anyMap(),
+        anyLong())).thenAnswer(invocation -> {
+          OutboundRequestPolicy.ResolvedHttpTarget target = invocation.getArgument(3);
+          Map<String, String> headers = invocation.getArgument(4);
+          URI uri = target.uri();
+          targets.add(uri);
+          authorizations.add(headers.get("Authorization"));
+          if ("http".equalsIgnoreCase(uri.getScheme())) {
+            return response(301, Map.of("Location", "https://localhost/secure/artifact.jar"), "");
+          }
+          if ("/secure/artifact.jar".equals(uri.getPath())) {
+            return response(307, Map.of("Location", "/cdn/artifact.jar"), "");
+          }
+          return response(200, Map.of(), "redirected");
+        });
+    HttpRemoteFetcher fetcher = new HttpRemoteFetcher(
+        OutboundRequestPolicy.allowPrivateForTests(), null, transport,
+        "HTTP_1_1", 30, 60, 300, 3, 1);
+    HttpRemoteFetcher.Request request = HttpRemoteFetcher.Request
+        .get("http://localhost/artifact.jar")
+        .withRepository(runtime("http://localhost", "robot", "secret", null));
+
+    try (HttpRemoteFetcher.Result result = fetcher.fetch(request)) {
+      assertEquals(200, result.status());
+      assertEquals("redirected", new String(result.body().readAllBytes(), StandardCharsets.UTF_8));
+    }
+
+    assertEquals(
+        List.of(
+            URI.create("http://localhost/artifact.jar"),
+            URI.create("https://localhost/secure/artifact.jar"),
+            URI.create("https://localhost/cdn/artifact.jar")),
+        targets);
+    assertEquals(
+        List.of(
+            request.authorizationHeader(),
+            request.authorizationHeader(),
+            request.authorizationHeader()),
+        authorizations);
   }
 
   @Test

--- a/server/src/test/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcherTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcherTest.java
@@ -5,6 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.io.EOFException;
@@ -16,6 +24,7 @@ import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +32,8 @@ import java.util.Queue;
 import java.util.Set;
 import com.github.klboke.kkrepo.core.RepositoryFormat;
 import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.server.proxy.OutboundProxyConfig;
+import com.github.klboke.kkrepo.server.proxy.ProxiedHttpClientFactory;
 import com.github.klboke.kkrepo.server.security.OutboundRequestPolicy;
 import com.github.klboke.kkrepo.server.security.SecurityValidationException;
 import org.junit.jupiter.api.Test;
@@ -213,6 +224,82 @@ class HttpRemoteFetcherTest {
   }
 
   @Test
+  void redirectAuthorizationAllowsSameHostHttpToHttpsUpgrade() {
+    HttpRemoteFetcher.Request credentialless = HttpRemoteFetcher.Request
+        .get("http://repo.example.com/maven2/com/example/app.jar")
+        .withRepository(runtime("http://repo.example.com/maven2", null, null, null));
+    URI defaultCurrent = URI.create("http://repo.example.com/maven2/com/example/app.jar");
+    URI defaultUpgrade = URI.create("https://repo.example.com/maven2/redirect.jar");
+
+    assertNull(credentialless.authorizationHeader());
+    assertNull(credentialless.authorizationHeaderForRedirect(defaultCurrent, defaultUpgrade));
+    assertEquals("repo.example.com", credentialless.trustedHostForRedirect(defaultCurrent, defaultUpgrade));
+
+    HttpRemoteFetcher.Request defaultPorts = HttpRemoteFetcher.Request
+        .get("http://repo.example.com/maven2/com/example/app.jar")
+        .withRepository(runtime("http://repo.example.com/maven2", "robot", "secret", null));
+
+    assertEquals(
+        defaultPorts.authorizationHeader(),
+        defaultPorts.authorizationHeaderForRedirect(defaultCurrent, defaultUpgrade));
+    assertEquals("repo.example.com", defaultPorts.trustedHostForRedirect(defaultCurrent, defaultUpgrade));
+
+    HttpRemoteFetcher.Request sameExplicitPort = HttpRemoteFetcher.Request
+        .get("http://repo.example.com:8080/maven2/com/example/app.jar")
+        .withRepository(runtime("http://repo.example.com:8080/maven2", "robot", "secret", null));
+    URI explicitCurrent = URI.create("http://repo.example.com:8080/maven2/com/example/app.jar");
+    assertEquals(
+        sameExplicitPort.authorizationHeader(),
+        sameExplicitPort.authorizationHeaderForRedirect(
+            explicitCurrent, URI.create("https://repo.example.com:8080/maven2/redirect.jar")));
+    assertThrows(
+        SecurityValidationException.class,
+        () -> sameExplicitPort.authorizationHeaderForRedirect(
+            explicitCurrent, URI.create("https://repo.example.com/maven2/redirect.jar")));
+  }
+
+  @Test
+  void fetchFollowsSameHostHttpToHttpsUpgradeAndPreservesAuthorization() throws Exception {
+    ProxiedHttpClientFactory transport = mock(ProxiedHttpClientFactory.class);
+    List<URI> targets = new ArrayList<>();
+    List<String> authorizations = new ArrayList<>();
+    when(transport.execute(
+        anyString(),
+        nullable(OutboundProxyConfig.class),
+        eq("GET"),
+        any(OutboundRequestPolicy.ResolvedHttpTarget.class),
+        anyMap(),
+        anyLong())).thenAnswer(invocation -> {
+          OutboundRequestPolicy.ResolvedHttpTarget target = invocation.getArgument(3);
+          Map<String, String> headers = invocation.getArgument(4);
+          targets.add(target.uri());
+          authorizations.add(headers.get("Authorization"));
+          if ("http".equalsIgnoreCase(target.uri().getScheme())) {
+            return response(
+                302,
+                Map.of("Location", "https://localhost/artifact.jar"),
+                "");
+          }
+          return response(200, Map.of(), "upgraded");
+        });
+    HttpRemoteFetcher fetcher = new HttpRemoteFetcher(
+        OutboundRequestPolicy.allowPrivateForTests(), null, transport,
+        "HTTP_1_1", 30, 60, 300, 2, 1);
+    HttpRemoteFetcher.Request request = HttpRemoteFetcher.Request
+        .get("http://localhost/artifact.jar")
+        .withRepository(runtime("http://localhost", "robot", "secret", null));
+
+    try (HttpRemoteFetcher.Result result = fetcher.fetch(request)) {
+      assertEquals(200, result.status());
+      assertEquals("upgraded", new String(result.body().readAllBytes(), StandardCharsets.UTF_8));
+    }
+
+    assertEquals(List.of("http", "https"),
+        targets.stream().map(URI::getScheme).toList());
+    assertEquals(List.of(request.authorizationHeader(), request.authorizationHeader()), authorizations);
+  }
+
+  @Test
   void requestWithRepositoryAddsBasicRemoteAuthorizationWhenConfigured() {
     RepositoryRuntime runtime = runtime("robot", "secret", null);
 
@@ -391,7 +478,31 @@ class HttpRemoteFetcherTest {
         new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
   }
 
+  private static ProxiedHttpClientFactory.ProxiedResponse response(
+      int status, Map<String, String> headers, String body) throws IOException {
+    ProxiedHttpClientFactory.ProxiedResponse response =
+        mock(ProxiedHttpClientFactory.ProxiedResponse.class);
+    when(response.status()).thenReturn(status);
+    when(response.headers()).thenReturn(headers);
+    when(response.header(anyString())).thenAnswer(invocation -> {
+      String name = invocation.getArgument(0);
+      return headers.entrySet().stream()
+          .filter(entry -> entry.getKey().equalsIgnoreCase(name))
+          .map(Map.Entry::getValue)
+          .findFirst()
+          .orElse(null);
+    });
+    when(response.body()).thenAnswer(ignored ->
+        new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
+    return response;
+  }
+
   private static RepositoryRuntime runtime(String username, String password, String bearerToken) {
+    return runtime("https://repo.example.com/maven2", username, password, bearerToken);
+  }
+
+  private static RepositoryRuntime runtime(
+      String remoteUrl, String username, String password, String bearerToken) {
     return new RepositoryRuntime(
         1,
         "maven-proxy",
@@ -404,7 +515,7 @@ class HttpRemoteFetcherTest {
         "RELEASE",
         "STRICT",
         true,
-        "https://repo.example.com/maven2",
+        remoteUrl,
         1440,
         1440,
         null,

--- a/server/src/test/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcherTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcherTest.java
@@ -225,6 +225,16 @@ class HttpRemoteFetcherTest {
   }
 
   @Test
+  void relativeRemoteRequestDoesNotReceiveRepositoryTrustOrCredentials() {
+    HttpRemoteFetcher.Request request = HttpRemoteFetcher.Request
+        .get("/maven2/com/example/app.jar")
+        .withRepository(runtime("https://repo.example.com/maven2", "robot", "secret", null));
+
+    assertNull(request.trustedHost());
+    assertNull(request.authorizationHeader());
+  }
+
+  @Test
   void redirectAuthorizationRequiresSameOrigin() {
     HttpRemoteFetcher.Request request = HttpRemoteFetcher.Request
         .get("https://repo.example.com/maven2/com/example/app.jar")

--- a/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmProxyServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/npm/NpmProxyServiceTest.java
@@ -13,6 +13,7 @@ import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import com.github.klboke.kkrepo.server.support.dao.ProxyStateDaoAdapter;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayDeque;
@@ -20,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class NpmProxyServiceTest {
@@ -41,6 +43,21 @@ class NpmProxyServiceTest {
     assertEquals(HttpRemoteFetcher.TimeoutProfile.SEARCH, fetcher.request.timeoutProfile());
     assertEquals(1, proxyState.successCount);
     assertEquals(0, proxyState.failureCount);
+  }
+
+  @Test
+  void httpRegistryRequestUsesSharedSameHostRedirectPolicyWithoutAllowlist() {
+    SequencedFetcher fetcher = new SequencedFetcher(result("""
+        {"objects":[],"total":0,"time":"0ms"}
+        """));
+    NpmProxyService service = service(fetcher, new RecordingProxyStateDao());
+
+    service.search(runtime("http://mirrors.tencent.com/npm/"), "vueuse", 20);
+
+    assertEquals("http", URI.create(fetcher.request.url()).getScheme());
+    assertEquals("mirrors.tencent.com", fetcher.request.trustedHost());
+    assertEquals(Set.of(), fetcher.request.allowedUnsignedRedirectHosts());
+    assertEquals("NPM", fetcher.request.format());
   }
 
   @Test
@@ -73,6 +90,10 @@ class NpmProxyServiceTest {
   }
 
   private static RepositoryRuntime runtime() {
+    return runtime(REMOTE);
+  }
+
+  private static RepositoryRuntime runtime(String remoteUrl) {
     return new RepositoryRuntime(
         10,
         "npm-proxy",
@@ -85,7 +106,7 @@ class NpmProxyServiceTest {
         "MIXED",
         "PERMISSIVE",
         true,
-        REMOTE,
+        remoteUrl,
         1440,
         1440,
         true, null, List.of());


### PR DESCRIPTION
## Summary
- allow all proxy repositories backed by the shared remote fetcher to follow same-host HTTP-to-HTTPS upgrades
- treat only the conventional default-port upgrade (`80 -> 443`) or the same effective port as trusted, matching the existing Docker proxy behavior
- preserve repository authorization across those trusted upgrades while keeping cross-host redirects, HTTPS downgrades, and arbitrary port changes behind the existing redirect allowlist
- add regression coverage for the Tencent npm mirror configuration, explicit and implicit port combinations, redirect status codes, multi-hop redirects, credential propagation, unsafe transitions, and invalid relative origins

## Testing
- `mvn -pl server -am -Dtest='HttpRemoteFetcherTest,NpmProxyServiceTest,HttpRemoteFetcherProxyTest,DockerRemoteRegistryClientTest' -Dsurefire.failIfNoSpecifiedTests=false test` (76 tests, 0 failures)
- `mvn -pl server -am test` (2262 server tests, 0 failures)

Fixes #194