### PR TITLE
test: stabilize Ansible lease loss assertion

### DIFF
--- a/cache/src/test/java/com/github/klboke/kkrepo/cache/InMemorySharedCacheTest.java
+++ b/cache/src/test/java/com/github/klboke/kkrepo/cache/InMemorySharedCacheTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -62,6 +63,23 @@ class InMemorySharedCacheTest {
     assertFalse(cache.getString("ns", "repo/two").isPresent());
     assertEquals("3", cache.getString("ns", "other").orElseThrow());
     assertEquals("4", cache.getString("other", "repo/one").orElseThrow());
+  }
+
+  @Test
+  void evictByPrefixRecordsTheNumberOfDeletedKeys() {
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    InMemorySharedCache meteredCache =
+        new InMemorySharedCache(new ObjectMapper(), 100, meterRegistry, clock);
+    meteredCache.putString("ns", "repo/one", "1", Duration.ZERO);
+    meteredCache.putString("ns", "repo/two", "2", Duration.ZERO);
+    meteredCache.putString("ns", "other", "3", Duration.ZERO);
+
+    meteredCache.evictByPrefix("ns", "repo/");
+
+    assertEquals(2.0, meterRegistry.get("kkrepo_cache_scan_deleted_keys_total")
+        .tag("namespace", "ns")
+        .counter()
+        .count());
   }
 
   @Test

--- a/server/src/test/java/com/github/klboke/kkrepo/server/ansible/AnsibleImportTaskLeaseManagerTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/ansible/AnsibleImportTaskLeaseManagerTest.java
@@ -16,9 +16,13 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
 import org.junit.jupiter.api.Test;
 
 class AnsibleImportTaskLeaseManagerTest {
+  private static final Duration ASYNC_ASSERTION_TIMEOUT = Duration.ofSeconds(5);
+  private static final Duration ASYNC_ASSERTION_POLL_INTERVAL = Duration.ofMillis(1);
+
   @Test
   void renewsTheFencedTaskLeaseUntilClosed() throws Exception {
     AnsibleGalaxyRegistryDao registry = mock(AnsibleGalaxyRegistryDao.class);
@@ -42,20 +46,15 @@ class AnsibleImportTaskLeaseManagerTest {
   }
 
   @Test
-  void rejectsCompletionAfterTheFencingLeaseIsLost() throws Exception {
+  void rejectsCompletionAfterTheFencingLeaseIsLost() {
     AnsibleGalaxyRegistryDao registry = mock(AnsibleGalaxyRegistryDao.class);
-    CountDownLatch attempted = new CountDownLatch(1);
     when(registry.renewTaskLease(eq("task"), eq("owner"), eq(7L), any()))
-        .thenAnswer(invocation -> {
-          attempted.countDown();
-          return false;
-        });
+        .thenReturn(false);
     AnsibleImportTaskLeaseManager manager = new AnsibleImportTaskLeaseManager(registry);
 
     try (AnsibleImportTaskLeaseManager.Lease lease = manager.monitor(
-        task(Instant.now().plusSeconds(1)), Duration.ofMillis(90))) {
-      assertTrue(attempted.await(1, TimeUnit.SECONDS));
-      assertThrows(AnsibleGalaxyExceptions.ServiceUnavailable.class, lease::assertHeld);
+        task(Instant.now().plus(Duration.ofMinutes(1))), Duration.ofMillis(90))) {
+      assertEventuallyLeaseLost(lease);
     }
   }
 
@@ -90,6 +89,20 @@ class AnsibleImportTaskLeaseManagerTest {
 
     assertThrows(IllegalArgumentException.class,
         () -> manager.monitor(unclaimed, Duration.ofMinutes(5)));
+  }
+
+  private static void assertEventuallyLeaseLost(AnsibleImportTaskLeaseManager.Lease lease) {
+    long deadline = System.nanoTime() + ASYNC_ASSERTION_TIMEOUT.toNanos();
+    do {
+      try {
+        lease.assertHeld();
+      } catch (AnsibleGalaxyExceptions.ServiceUnavailable expected) {
+        return;
+      }
+      LockSupport.parkNanos(ASYNC_ASSERTION_POLL_INTERVAL.toNanos());
+    } while (System.nanoTime() < deadline);
+
+    assertThrows(AnsibleGalaxyExceptions.ServiceUnavailable.class, lease::assertHeld);
   }
 
   private static AnsibleGalaxyRegistryDao.ImportTask task(Instant expiresAt) {


### PR DESCRIPTION
## Summary

- replace the lease-renewal invocation latch with a bounded eventual state assertion
- keep the initial lease expiry outside the assertion window so the test cannot pass through natural expiry
- add deterministic coverage for cache prefix-eviction metrics after the first PR run exposed an unrelated six-line coverage fluctuation
- leave production behavior unchanged

## Root cause

The mock counted down its latch before returning `false`. The test thread could resume and call `assertHeld()` before the renewal thread processed the return value and set the lease's `lost` flag, producing the flaky failure seen in [CI run 31466858830](https://github.com/klboke/kkRepo/actions/runs/31466858830/job/93701445454).

The first PR run then passed every GitHub Actions job but Codecov reported six fewer covered lines. Codecov's file-level report showed that all six were the existing `InMemorySharedCache.recordDeletedKeys` metric path, not the modified lease code. The added meter-registry assertion now executes that path directly instead of relying on incidental suite coverage.

## Validation

- `mvn -pl server -am -Dtest='AnsibleImportTaskLeaseManagerTest#rejectsCompletionAfterTheFencingLeaseIsLost' -Dsurefire.failIfNoSpecifiedTests=false test`
- temporary 200-repeat stress run: 200 tests, 0 failures (repeat annotation removed before commit)
- `mvn -pl cache -am -Dtest=InMemorySharedCacheTest -Dsurefire.failIfNoSpecifiedTests=false verify`: 7 tests, 0 failures
- `mvn -pl server -am test`: 2,262 server tests, 0 failures; all 30 reactor modules succeeded
- [PR CI run 31475045909](https://github.com/klboke/kkRepo/actions/runs/31475045909): all 9 jobs passed; CodeQL and both Codecov checks passed
- `git diff --check`
