### PR TITLE
docs: complete Nexus repository roadmap

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -196,6 +196,14 @@ AI agent 和贡献者的开发说明见 [AGENTS.md](AGENTS.md)。
 9. ✅ APT / Debian - 已实现 hosted/proxy、签名元数据、UI/API 上传、Browse/Search、多副本发布、真实 APT 客户端与 Nexus 黑盒验证、shape-gated 迁移和可复现的 Nexus 性能基线（[使用指南](docs/zh/apt-debian-guide.md)、[设计说明](docs/zh/dev/apt-debian-repository-design.md)、[性能基线](docs/zh/dev/apt-performance-baseline.md)）
 10. ✅ Conan 2 - 已实现 hosted/proxy/group、Conan bearer 认证、manifest-gated revision 发布、写入时 Nexus Browse 投影、UI/API 上传、Cleanup、复合 package 扫描、shape-gated 迁移、真实 Conan 客户端 E2E 和双数据库 Nexus 性能基线（[使用指南](docs/zh/conan-guide.md)、[设计说明](docs/zh/dev/conan-repository-design.md)、[性能基线](docs/zh/dev/conan-performance-baseline.md)）
 11. ohpm / HarmonyOS - 规划中，覆盖 hosted、proxy、group、导入和管理端能力（[设计说明](docs/zh/dev/ohpm-repository-design.md)）
+12. Go hosted 仓库 - 规划补齐 Nexus 兼容的内部 module 发布能力；proxy 和 group 仓库已支持。
+13. Helm group 仓库 - 规划补齐 Nexus 兼容的 hosted、proxy 与 group member 有序聚合能力。
+14. Alpine / APK - 规划 hosted、proxy 和 group 仓库，覆盖 APK 索引与仓库签名。
+15. R / CRAN - 规划 proxy、hosted 和 group 仓库；hosted 与 group 范围将对齐 Nexus 的 `.gz` package 支持。
+16. Git Large File Storage (LFS) - 规划 Nexus 兼容的 hosted 仓库，用于 Git 大文件制品存储。
+17. Hugging Face Models - 规划 Nexus 兼容的 proxy 仓库，覆盖模型 metadata 与大模型文件。
+18. Eclipse p2 - 规划 Nexus 兼容的 proxy 仓库，覆盖 Eclipse 与 Equinox update site。
+19. CocoaPods - 规划 Nexus 兼容的 proxy 仓库，用于代理 CocoaPods 依赖。
 
 用户和管理端 UI 已暴露的 token 类型包括协议专用 token（`NpmToken`、`CargoToken`、`PubToken`、`NuGetApiKey`、`RubyGemsApiKey`），以及面向 Terraform 服务 URL、Ansible Galaxy 客户端、CI、脚本和自定义 HTTP 客户端的 `GenericToken`；`GenericToken` 适用于能够发送已配置 API-key header 或 bearer token 的调用方。
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,14 @@ Repository format roadmap:
 9. ✅ APT / Debian - Hosted/proxy repositories, signed metadata, UI/API upload, Browse/Search, multi-replica publication, real APT client and Nexus black-box checks, shape-gated migration, and a reproducible Nexus performance baseline are implemented ([usage guide](docs/en/apt-debian-guide.md), [Chinese design notes](docs/zh/dev/apt-debian-repository-design.md), [performance baseline](docs/en/dev/apt-performance-baseline.md))
 10. ✅ Conan 2 - Hosted/proxy/group, Conan bearer authentication, manifest-gated revision publication, write-time Nexus Browse projection, UI/API upload, Cleanup, composite package scanning, shape-gated migration, real Conan client E2E, and dual-database Nexus performance baselines are implemented ([usage guide](docs/en/conan-guide.md), [Chinese design notes](docs/zh/dev/conan-repository-design.md), [performance baseline](docs/en/dev/conan-performance-baseline.md))
 11. ohpm / HarmonyOS - Planned with hosted, proxy, group, import, and admin capabilities ([Chinese design notes](docs/zh/dev/ohpm-repository-design.md))
+12. Go hosted repositories - Planned to complete Nexus-compatible Go coverage with internal module publication; proxy and group repositories are already supported.
+13. Helm group repositories - Planned to complete Nexus-compatible ordered aggregation across hosted, proxy, and group members.
+14. Alpine / APK - Planned with hosted, proxy, and group repositories, including APK indexes and repository signing.
+15. R / CRAN - Planned with proxy, hosted, and group repositories; hosted and group scope will follow Nexus `.gz` package support.
+16. Git Large File Storage (LFS) - Planned with Nexus-compatible hosted storage for large Git-managed assets.
+17. Hugging Face Models - Planned with Nexus-compatible proxy repositories for model metadata and large model assets.
+18. Eclipse p2 - Planned with Nexus-compatible proxy repositories for Eclipse and Equinox update sites.
+19. CocoaPods - Planned with Nexus-compatible proxy repositories for CocoaPods dependencies.
 
 Token types exposed in the user and admin UI include protocol-specific tokens (`NpmToken`, `CargoToken`, `PubToken`, `NuGetApiKey`, `RubyGemsApiKey`) plus `GenericToken` for Terraform service URLs, Ansible Galaxy clients, CI, scripts, and custom HTTP clients that can send the configured API-key header or bearer token.
 


### PR DESCRIPTION
## Summary

- add all current Nexus Repository format gaps to the English and Chinese repository roadmaps
- add the two remaining Nexus recipe gaps: Go hosted and Helm group
- keep each planned item scoped to the repository types Nexus currently exposes

## Nexus reference audit

| Gap | Nexus scope | kkRepo status before this PR |
| --- | --- | --- |
| Go | hosted / proxy / group | proxy / group implemented; hosted planned |
| Helm | hosted / proxy / group | hosted / proxy implemented; group planned |
| Alpine / APK | hosted / proxy / group | format not implemented |
| R / CRAN | hosted / proxy / group | format not implemented |
| Git LFS | hosted | format not implemented |
| Hugging Face Models | proxy | format not implemented |
| Eclipse p2 | proxy | format not implemented |
| CocoaPods | proxy | format not implemented |

The audit uses Sonatype's current [format matrix](https://help.sonatype.com/en/formats.html), plus the current [Go](https://help.sonatype.com/en/go-repositories.html) and [Helm](https://help.sonatype.com/en/create-a-helm-repository.html) recipe documentation. Bower is intentionally excluded: Sonatype marks it deprecated/no longer supported and the current format matrix exposes no repository type for it.

## Impact

Documentation only. No runtime behavior, repository recipe, migration, or CI matrix changes.

## Checks

- `git diff --check`
- verified both roadmap lists contain the same 19 sequential entries
