### PR TITLE
ci: prevent false C++ CodeQL detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Conan client fixture headers are packaged test data, not C/C++ project sources.
+compat-test/src/test/resources/conan/fixture/include/*.h -linguist-detectable


### PR DESCRIPTION
## Summary

- mark Conan client fixture headers as non-detectable for GitHub Linguist
- preserve the real `.h` fixture and its Conan client behavior
- prevent CodeQL default setup from treating packaged test data as a C/C++ project

## Root cause

The Conan implementation added the repository's only `.h` file under test resources. GitHub language detection classified those 59 bytes as C and launched an automatic `c-cpp` CodeQL trial. The failing job found zero C/C++ source files and one header, then stopped with `Extraction failed: No source files found`.

Failed job: https://github.com/klboke/kkRepo/actions/runs/31563808504/job/94011415536

## Impact

CI metadata only. Runtime behavior, Conan fixture contents, client E2E behavior, and the existing CodeQL coverage for real project languages are unchanged.

## Validation

- `git diff --check`
- `git check-attr linguist-detectable -- compat-test/src/test/resources/conan/fixture/include/kkrepo_conan_fixture.h` returns `unset`
- GitHub Linguist official container reports Java, JavaScript, CSS, HTML, Shell, Python, Smarty, PLpgSQL, and Dockerfile, with no C/C++ language entry
