### PR TITLE
fix: filter Conan browse search by format

### DIFF
--- a/server/src/main/java/com/github/klboke/kkrepo/server/browse/ComponentSearchController.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/browse/ComponentSearchController.java
@@ -281,29 +281,22 @@ public class ComponentSearchController {
   }
 
   private static RepositoryFormat parseFormat(String value) {
-    if (value == null || value.isBlank() || "custom".equalsIgnoreCase(value)) {
+    if (value == null || value.isBlank()) {
       return null;
     }
-    return switch (value.trim().toLowerCase(Locale.ROOT)) {
-      case "maven2" -> RepositoryFormat.MAVEN2;
-      case "npm" -> RepositoryFormat.NPM;
-      case "cargo" -> RepositoryFormat.CARGO;
-      case "nuget" -> RepositoryFormat.NUGET;
-      case "pypi" -> RepositoryFormat.PYPI;
-      case "rubygems" -> RepositoryFormat.RUBYGEMS;
-      case "yum" -> RepositoryFormat.YUM;
-      case "helm" -> RepositoryFormat.HELM;
-      case "go" -> RepositoryFormat.GO;
-      case "pub" -> RepositoryFormat.PUB;
-      case "composer" -> RepositoryFormat.COMPOSER;
-      case "terraform" -> RepositoryFormat.TERRAFORM;
-      case "swift" -> RepositoryFormat.SWIFT;
-      case "ansiblegalaxy", "ansible" -> RepositoryFormat.ANSIBLEGALAXY;
-      case "conda" -> RepositoryFormat.CONDA;
-      case "apt" -> RepositoryFormat.APT;
-      case "raw" -> RepositoryFormat.RAW;
-      default -> null;
-    };
+    String normalized = value.trim().toLowerCase(Locale.ROOT);
+    if ("custom".equals(normalized)) {
+      return null;
+    }
+    if ("ansible".equals(normalized)) {
+      return RepositoryFormat.ANSIBLEGALAXY;
+    }
+    try {
+      return RepositoryFormat.fromJson(normalized);
+    } catch (IllegalArgumentException exception) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Unsupported repository format: " + normalized, exception);
+    }
   }
 
   private static String formatLabel(RepositoryFormat format) {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/browse/ComponentSearchControllerSecurityTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/browse/ComponentSearchControllerSecurityTest.java
@@ -167,25 +167,35 @@ class ComponentSearchControllerSecurityTest {
   }
 
   @Test
-  void searchParsesNugetPubRubygemsYumTerraformAndSwiftFormats() {
+  void searchParsesEveryRepositoryFormatIncludingConan() {
     StubComponentDao components = new StubComponentDao();
     RecordingSecurityService security = new RecordingSecurityService(permission -> AccessDecision.allow());
     ComponentSearchController controller = controller(components, subject("alice"), null, security);
 
-    controller.search(null, "nuget", null, request("GET", "/internal/search/components"));
-    controller.search(null, "pub", null, request("GET", "/internal/search/components"));
-    controller.search(null, "rubygems", null, request("GET", "/internal/search/components"));
-    controller.search(null, "yum", null, request("GET", "/internal/search/components"));
-    controller.search(null, "terraform", null, request("GET", "/internal/search/components"));
-    controller.search(null, "swift", null, request("GET", "/internal/search/components"));
+    List<String> expectedCalls = new ArrayList<>();
+    for (RepositoryFormat format : RepositoryFormat.values()) {
+      controller.search(null, format.id(), null, request("GET", "/internal/search/components"));
+      expectedCalls.add("|" + format.id() + "|300");
+    }
     controller.search(null, "ansible", null, request("GET", "/internal/search/components"));
-    controller.search(null, "ansiblegalaxy", null, request("GET", "/internal/search/components"));
+    expectedCalls.add("|ansiblegalaxy|300");
 
-    assertEquals(
-        List.of(
-            "|nuget|300", "|pub|300", "|rubygems|300", "|yum|300", "|terraform|300", "|swift|300",
-            "|ansiblegalaxy|300", "|ansiblegalaxy|300"),
-        components.calls);
+    assertEquals(expectedCalls, components.calls);
+  }
+
+  @Test
+  void searchRejectsUnknownFormatsInsteadOfFallingBackToAllFormats() {
+    StubComponentDao components = new StubComponentDao();
+    RecordingSecurityService security = new RecordingSecurityService(permission -> AccessDecision.allow());
+    ComponentSearchController controller = controller(components, subject("alice"), null, security);
+
+    ResponseStatusException thrown = assertThrows(ResponseStatusException.class, () ->
+        controller.search(null, "not-a-format", null,
+            request("GET", "/internal/search/components")));
+
+    assertEquals(HttpStatus.BAD_REQUEST, thrown.getStatusCode());
+    assertEquals("Unsupported repository format: not-a-format", thrown.getReason());
+    assertEquals(List.of(), components.calls);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- parse Browse component-search formats from `RepositoryFormat`, so `format=conan` reaches persistence as `RepositoryFormat.CONAN`
- preserve the intentional `custom` all-format search while rejecting unsupported non-empty formats with HTTP 400
- add regression coverage for every repository format and the unknown-format failure path

## Root cause

The Browse UI correctly sent `format=conan`, but `ComponentSearchController` used a manually maintained format switch that did not include Conan. Its default branch returned `null`, which the DAO interprets as no format filter, so recent Maven components could appear in the Conan search view.

## Impact

Conan component search is now isolated to Conan rows and continues to use the existing indexed `component.format` query. Upload, download, repository browsing, and Conan client protocol behavior are unchanged. Future `RepositoryFormat` additions no longer require a second controller whitelist update.

## Validation

- `mvn -pl server -am -Dtest=ComponentSearchControllerSecurityTest -Dsurefire.failIfNoSpecifiedTests=false test` — 12 tests passed; reactor build succeeded
- `git diff --check`