### PR TITLE
fix: restore Native JDBC browser sessions

### DIFF
--- a/scripts/ci/run-client-e2e.sh
+++ b/scripts/ci/run-client-e2e.sh
@@ -175,6 +175,46 @@ raise SystemExit(completed.returncode)
 PY
 }
 
+test_jdbc_browser_session() {
+  local directory="$WORK_DIR/jdbc-browser-session"
+  local cookie_jar="$directory/cookies.txt"
+  local login_body="$directory/login.body"
+  local session_body="$directory/session.body"
+  local login_status session_status attempt
+  mkdir -p "$directory"
+
+  login_status="$(curl -m 20 -sS -u "$KKREPO_AUTH" \
+    -c "$cookie_jar" -o "$login_body" -w '%{http_code}' \
+    "$KKREPO_URL/internal/security/basic/login?returnTo=%2Fbrowse%2F")"
+  if [[ "$login_status" != "302" ]]; then
+    log "JDBC browser-session login returned HTTP $login_status"
+    return 1
+  fi
+
+  # Read twice so a Native runtime must deserialize the SessionSubject written by
+  # the login request from the shared JDBC session store on subsequent requests.
+  for attempt in 1 2; do
+    session_status="$(curl -m 20 -sS -b "$cookie_jar" \
+      -o "$session_body" -w '%{http_code}' \
+      "$KKREPO_URL/internal/security/session")"
+    if [[ "$session_status" != "200" ]]; then
+      log "JDBC browser-session reload $attempt returned HTTP $session_status"
+      return 1
+    fi
+    python3 - "$session_body" "$KKREPO_USER" <<'PY'
+import json
+import pathlib
+import sys
+
+session = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if session.get("userId") != sys.argv[2]:
+    raise SystemExit(
+        f"JDBC browser session user mismatch: {session.get('userId')!r}")
+PY
+  done
+  log "JDBC browser session survived two reloads"
+}
+
 wait_for_ansible_import_task() {
   local label="$1"
   local publish_log="$2"
@@ -3239,6 +3279,7 @@ KKREPO_AUTH_URL="$(basic_auth_url)"
 add_redaction_value "$KKREPO_AUTH_URL"
 wait_for_http "kkrepo management health" "$KKREPO_MANAGEMENT_URL/actuator/health"
 
+test_jdbc_browser_session
 run_selected_tests
 
 log "real client E2E matrix completed"

--- a/server/src/main/java/com/github/klboke/kkrepo/server/KkRepoApplication.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/KkRepoApplication.java
@@ -4,6 +4,7 @@ import com.github.klboke.kkrepo.server.nativeimage.ApolloRuntimeHints;
 import com.github.klboke.kkrepo.server.nativeimage.CaffeineRuntimeHints;
 import com.github.klboke.kkrepo.server.nativeimage.JacksonRuntimeHints;
 import com.github.klboke.kkrepo.server.nativeimage.QuartzRuntimeHints;
+import com.github.klboke.kkrepo.server.nativeimage.SecuritySessionRuntimeHints;
 import java.util.Map;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -21,7 +22,8 @@ import org.springframework.scheduling.annotation.EnableScheduling;
     ApolloRuntimeHints.class,
     CaffeineRuntimeHints.class,
     JacksonRuntimeHints.class,
-    QuartzRuntimeHints.class
+    QuartzRuntimeHints.class,
+    SecuritySessionRuntimeHints.class
 })
 public class KkRepoApplication {
   private static final String APOLLO_CONFIG_IMPORT = "optional:apollo://";

--- a/server/src/main/java/com/github/klboke/kkrepo/server/nativeimage/SecuritySessionRuntimeHints.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/nativeimage/SecuritySessionRuntimeHints.java
@@ -1,0 +1,18 @@
+package com.github.klboke.kkrepo.server.nativeimage;
+
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.aot.hint.TypeReference;
+
+/** Java serialization metadata for security attributes stored in shared JDBC sessions. */
+public final class SecuritySessionRuntimeHints implements RuntimeHintsRegistrar {
+  static final TypeReference SESSION_SUBJECT = TypeReference.of(
+      "com.github.klboke.kkrepo.server.security.SecurityAuthenticationService$SessionSubject");
+
+  @Override
+  public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+    hints.reflection().registerType(
+        SESSION_SUBJECT,
+        typeHint -> typeHint.withJavaSerialization(true));
+  }
+}

--- a/server/src/main/java/com/github/klboke/kkrepo/server/nativeimage/SecuritySessionRuntimeHints.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/nativeimage/SecuritySessionRuntimeHints.java
@@ -1,5 +1,8 @@
 package com.github.klboke.kkrepo.server.nativeimage;
 
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
 import org.springframework.aot.hint.TypeReference;
@@ -8,11 +11,18 @@ import org.springframework.aot.hint.TypeReference;
 public final class SecuritySessionRuntimeHints implements RuntimeHintsRegistrar {
   static final TypeReference SESSION_SUBJECT = TypeReference.of(
       "com.github.klboke.kkrepo.server.security.SecurityAuthenticationService$SessionSubject");
+  static final List<TypeReference> JAVA_SERIALIZATION_TYPES = List.of(
+      SESSION_SUBJECT,
+      TypeReference.of(LinkedHashSet.class),
+      TypeReference.of(HashSet.class));
 
   @Override
   public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
-    hints.reflection().registerType(
-        SESSION_SUBJECT,
-        typeHint -> typeHint.withJavaSerialization(true));
+    // SessionSubject deliberately stores role IDs in a LinkedHashSet. GraalVM requires
+    // explicit serialization metadata for both the runtime collection and its HashSet
+    // superclass because HashSet implements custom writeObject/readObject methods.
+    JAVA_SERIALIZATION_TYPES.forEach(type -> hints.reflection().registerType(
+        type,
+        typeHint -> typeHint.withJavaSerialization(true)));
   }
 }

--- a/server/src/test/java/com/github/klboke/kkrepo/server/nativeimage/SecuritySessionRuntimeHintsTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/nativeimage/SecuritySessionRuntimeHintsTest.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -20,19 +22,23 @@ class SecuritySessionRuntimeHintsTest {
     RuntimeHints hints = new RuntimeHints();
     new SecuritySessionRuntimeHints().registerHints(hints, getClass().getClassLoader());
 
-    assertTrue(RuntimeHintsPredicates.reflection()
-        .onJavaSerialization(SecuritySessionRuntimeHints.SESSION_SUBJECT, true)
-        .test(hints));
+    SecuritySessionRuntimeHints.JAVA_SERIALIZATION_TYPES.forEach(type -> assertTrue(
+        RuntimeHintsPredicates.reflection()
+            .onJavaSerialization(type, true)
+            .test(hints),
+        () -> "Missing Java serialization hints for " + type.getName()));
 
     new FileNativeConfigurationWriter(output).write(hints);
     JsonNode metadata = new ObjectMapper().readTree(Files.readString(
         output.resolve("META-INF/native-image/reachability-metadata.json")));
-    JsonNode sessionSubject = StreamSupport.stream(metadata.path("reflection").spliterator(), false)
-        .filter(entry -> SecuritySessionRuntimeHints.SESSION_SUBJECT.getName()
-            .equals(entry.path("type").asText()))
-        .findFirst()
-        .orElseThrow();
+    Set<String> serializableTypes = StreamSupport.stream(
+            metadata.path("reflection").spliterator(), false)
+        .filter(entry -> entry.path("serializable").asBoolean())
+        .map(entry -> entry.path("type").asText())
+        .collect(Collectors.toSet());
 
-    assertTrue(sessionSubject.path("serializable").asBoolean());
+    SecuritySessionRuntimeHints.JAVA_SERIALIZATION_TYPES.forEach(type -> assertTrue(
+        serializableTypes.contains(type.getName()),
+        () -> "Generated metadata is missing serializable type " + type.getName()));
   }
 }

--- a/server/src/test/java/com/github/klboke/kkrepo/server/nativeimage/SecuritySessionRuntimeHintsTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/nativeimage/SecuritySessionRuntimeHintsTest.java
@@ -1,0 +1,38 @@
+package com.github.klboke.kkrepo.server.nativeimage;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.StreamSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+import org.springframework.aot.nativex.FileNativeConfigurationWriter;
+
+class SecuritySessionRuntimeHintsTest {
+  @Test
+  void registersJdbcSessionSubjectForNativeJavaSerialization(@TempDir Path output)
+      throws Exception {
+    RuntimeHints hints = new RuntimeHints();
+    new SecuritySessionRuntimeHints().registerHints(hints, getClass().getClassLoader());
+
+    assertTrue(RuntimeHintsPredicates.reflection()
+        .onJavaSerialization(SecuritySessionRuntimeHints.SESSION_SUBJECT, true)
+        .test(hints));
+
+    new FileNativeConfigurationWriter(output).write(hints);
+    JsonNode metadata = new ObjectMapper().readTree(Files.readString(
+        output.resolve("META-INF/native-image/reachability-metadata.json")));
+    JsonNode sessionSubject = StreamSupport.stream(metadata.path("reflection").spliterator(), false)
+        .filter(entry -> SecuritySessionRuntimeHints.SESSION_SUBJECT.getName()
+            .equals(entry.path("type").asText()))
+        .findFirst()
+        .orElseThrow();
+
+    assertTrue(sessionSubject.path("serializable").asBoolean());
+  }
+}


### PR DESCRIPTION
## Summary

- Register GraalVM Java-serialization metadata for the complete browser-session value graph: `SecurityAuthenticationService.SessionSubject`, `LinkedHashSet`, and `HashSet`.
- Add a focused RuntimeHints regression test that verifies all three types are emitted with `"serializable": true`.
- Add login plus two authenticated session reloads to the existing client E2E runner, so the current Native MySQL/PostgreSQL lanes cover this regression without a separate matrix.

## Root cause and impact

A Native replica did not contain complete reachability metadata for the authenticated subject stored by Spring Session JDBC:

- Reading an existing session could fail on the `SessionSubject` record components with `UnsupportedFeatureError`.
- Writing a newly authenticated session traverses its `LinkedHashSet` role collection and `HashSet` custom serialization path; without unconditional metadata for that hierarchy, Native failed with `MissingReflectionRegistrationError` on `HashSet.serialVersionUID`.

Requests routed to a Native replica therefore surfaced intermittent HTTP 500 responses and made browser login appear unstable. The JVM replicas, shared database, and database-backed session topology were healthy.

This change completes the Native serialization metadata. It does not change the database schema, stored session format, authentication behavior, or repository protocol behavior.

## Validation

- [x] `mvn -pl server -am test` — [CI run 31610642933](https://github.com/klboke/kkRepo/actions/runs/31610642933)
- [x] Non-live compatibility tests — covered by [CI run 31610642933](https://github.com/klboke/kkRepo/actions/runs/31610642933)
- [x] Full E2E with the `run-full-e2e` label for changes that need every E2E dimension, or targeted labels below, or not applicable. Not applicable; the targeted Native client matrix covers this runtime/session path.
- [x] Live compatibility workflow with the `run-live-compat` label, or `scripts/ci/run-live-compat.sh smoke` for protocol/admin API changes, or not applicable. Not applicable; no protocol/admin API contract changes.
- [x] Real client E2E with the `run-client-e2e` label, or `scripts/ci/run-live-compat.sh client-e2e` for package-client publish/download/resolve changes, or not applicable. Covered by the Native real-client E2E below.
- [x] Native real client E2E with the `run-native-client-e2e` label — [run 31610643593](https://github.com/klboke/kkRepo/actions/runs/31610643593)
  - MySQL: passed; log contains `JDBC browser session survived two reloads`.
  - PostgreSQL: passed; log contains `JDBC browser session survived two reloads`.
- [x] Other:
  - `mvn -B -ntp -pl server -am -Dtest=SecuritySessionRuntimeHintsTest -Dsurefire.failIfNoSpecifiedTests=false test`
  - `mvn -B -ntp -Pnative -pl server -am -DskipTests -DskipNativeBuild=true package`
  - verified generated AOT metadata contains `SessionSubject`, `LinkedHashSet`, and `HashSet` with `"serializable": true`
  - `bash -n scripts/ci/run-client-e2e.sh`
  - `git diff --check`
  - production JVM session smoke: login plus two session reloads returned 302/200/200

## Compatibility and design checklist

- [x] Protocol behavior changes were compared with the official protocol and Nexus behavior, or this PR does not change protocol behavior.
- [x] Protocol behavior changes include or update compatibility tests under `compat-test`, or the reason is explained.
- [x] State, cache, locking, session, background task, upload/delete, metadata, and permission changes describe their multi-replica behavior, or this PR does not touch those areas.
- [x] Migration changes are idempotent and consider dry-run, resume, checksum validation, and reporting, or this PR does not touch migration.

## Notes for reviewers

- The production Native upstream remains isolated from user traffic until this change is merged, deployed, and the repaired Native session path is verified.
- The E2E assertion is intentionally part of the existing client runner and exercises the database-backed session path in both existing Native database lanes.
