### PR TITLE
fix: preserve Conan proxy package projections

### DIFF
--- a/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/JdbcConanRegistryDao.java
+++ b/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/JdbcConanRegistryDao.java
@@ -1099,9 +1099,11 @@ public class JdbcConanRegistryDao implements ConanRegistryDao {
     Optional<Package> existing = findPackage(recipeRevisionId, commit.packageId());
     if (existing.isPresent()) {
       Package value = existing.orElseThrow();
-      if (value.settings().isEmpty() && value.options().isEmpty() && value.requires().isEmpty()
-          && (!commit.settings().isEmpty() || !commit.options().isEmpty()
-              || !commit.requires().isEmpty())) {
+      boolean storedProjectionEmpty = conanInfoProjectionEmpty(
+          value.settings(), value.options(), value.requires());
+      boolean observedProjectionEmpty = conanInfoProjectionEmpty(
+          commit.settings(), commit.options(), commit.requires());
+      if (storedProjectionEmpty && !observedProjectionEmpty) {
         jdbc.update("""
             UPDATE conan_package
             SET settings_json = ?, options_json = ?, requires_json = ?,
@@ -1117,6 +1119,13 @@ public class JdbcConanRegistryDao implements ConanRegistryDao {
             commit.settings().get("compiler"), commit.settings().get("compiler.version"),
             commit.settings().get("build_type"), value.id());
         return findPackage(recipeRevisionId, commit.packageId()).orElseThrow();
+      }
+      if (!storedProjectionEmpty && observedProjectionEmpty
+          && SOURCE_PROXY.equals(commit.sourceKind())
+          && STATUS_DISCOVERED.equals(commit.status())) {
+        // Proxy files are fetched independently. Only conaninfo.txt carries this projection, so
+        // a later archive/manifest observation must not erase or conflict with known conaninfo.
+        return value;
       }
       if (!value.settings().equals(commit.settings())
           || !value.options().equals(commit.options())
@@ -1140,6 +1149,13 @@ public class JdbcConanRegistryDao implements ConanRegistryDao {
         commit.settings().get("compiler"), commit.settings().get("compiler.version"),
         commit.settings().get("build_type"));
     return findPackage(recipeRevisionId, commit.packageId()).orElseThrow();
+  }
+
+  private static boolean conanInfoProjectionEmpty(
+      Map<String, String> settings,
+      Map<String, String> options,
+      Map<String, String> requires) {
+    return settings.isEmpty() && options.isEmpty() && requires.isEmpty();
   }
 
   private void insertPackageRevision(

--- a/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/ConanRegistryDaoMySqlIntegrationTest.java
+++ b/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/ConanRegistryDaoMySqlIntegrationTest.java
@@ -156,6 +156,10 @@ class ConanRegistryDaoMySqlIntegrationTest extends MySqlIntegrationTestSupport {
     assertTrue(inTransaction(() -> dao.recordDiscoveredRevision(enrichedPackage)).idempotent());
     assertEquals("Linux", dao.findPackage(
         proxy.recipeRevisionId(), "proxy-package").orElseThrow().settings().get("os"));
+    assertTrue(inTransaction(() -> dao.recordDiscoveredRevision(discoveredPackage)).idempotent(),
+        "an archive observed after conaninfo must preserve the known projection");
+    assertEquals(Map.of("os", "Linux"), dao.findPackage(
+        proxy.recipeRevisionId(), "proxy-package").orElseThrow().settings());
     assertThrows(IllegalStateException.class, () -> inTransaction(() ->
         dao.recordDiscoveredRevision(revisionCommit(
             proxyCoordinate, ConanRegistryDao.OWNER_PACKAGE, RREV_TWO,

--- a/persistence-postgresql/src/test/java/com/github/klboke/kkrepo/persistence/postgresql/ConanRegistryDaoPostgreSqlIntegrationTest.java
+++ b/persistence-postgresql/src/test/java/com/github/klboke/kkrepo/persistence/postgresql/ConanRegistryDaoPostgreSqlIntegrationTest.java
@@ -101,6 +101,27 @@ class ConanRegistryDaoPostgreSqlIntegrationTest extends PostgreSqlIntegrationTes
   }
 
   @Test
+  void proxySparseFileDiscoveryPreservesKnownConanInfoProjection() {
+    long repositoryId = insertRepository("conan-proxy-projection", "proxy");
+    ConanRegistryDao dao = stores().conanRegistry();
+    ConanRegistryDao.RecipeCoordinate coordinate = coordinate(repositoryId, "proxy-kit");
+    ConanRegistryDao.RevisionCommit enriched = proxyPackageDiscovery(
+        coordinate, Map.of("os", "Linux", "arch", "x86_64"));
+
+    ConanRegistryDao.CommittedRevision discovered = inTransaction(
+        () -> dao.recordDiscoveredRevision(enriched));
+    assertFalse(discovered.idempotent());
+    assertTrue(inTransaction(() -> dao.recordDiscoveredRevision(
+        proxyPackageDiscovery(coordinate, Map.of()))).idempotent(),
+        "an archive observed after conaninfo must preserve the known projection");
+    assertEquals(enriched.settings(), dao.findPackage(
+        discovered.recipeRevisionId(), PACKAGE_ID).orElseThrow().settings());
+    assertThrows(IllegalStateException.class, () -> inTransaction(() ->
+        dao.recordDiscoveredRevision(proxyPackageDiscovery(
+            coordinate, Map.of("os", "Windows", "arch", "x86_64")))));
+  }
+
+  @Test
   void accessShapesHaveDeclaredIndexesAndUseThemWhenSequentialScansAreDisabled() {
     assertEquals(
         "CREATE UNIQUE INDEX uk_conan_recipe_coordinate ON public.conan_recipe "
@@ -218,6 +239,15 @@ class ConanRegistryDaoPostgreSqlIntegrationTest extends PostgreSqlIntegrationTes
             file("conan_package.tzst", archiveId, "3"),
             file("conaninfo.txt", infoId, "4"),
             file("conanmanifest.txt", manifestId, "5")));
+  }
+
+  private static ConanRegistryDao.RevisionCommit proxyPackageDiscovery(
+      ConanRegistryDao.RecipeCoordinate coordinate,
+      Map<String, String> settings) {
+    return new ConanRegistryDao.RevisionCommit(
+        coordinate, null, ConanRegistryDao.OWNER_PACKAGE, RREV, PACKAGE_ID, PREV,
+        settings, Map.of(), Map.of(), null, ConanRegistryDao.SOURCE_PROXY,
+        ConanRegistryDao.STATUS_DISCOVERED, NOW, List.of());
   }
 
   private static ConanRegistryDao.FileCommit file(String path, long assetId, String seed) {

--- a/scripts/ci/run-client-e2e.sh
+++ b/scripts/ci/run-client-e2e.sh
@@ -25,6 +25,8 @@ APT_HOSTED_REPOSITORY="${APT_E2E_HOSTED_REPOSITORY:-apt-hosted}"
 APT_CLIENT_IMAGES="${APT_E2E_IMAGES:-debian12=debian:12-slim,ubuntu24=ubuntu:24.04,current=debian:testing-slim}"
 CONAN_BIN="${CONAN_E2E_BIN:-conan}"
 CONAN_HOSTED_REPOSITORY="${CONAN_E2E_HOSTED_REPOSITORY:-conan-hosted}"
+CONAN_PROXY_REPOSITORY="${CONAN_E2E_PROXY_REPOSITORY:-conan-proxy}"
+CONAN_PROXY_REFERENCE="${CONAN_E2E_PROXY_REFERENCE:-zlib/1.3.1}"
 CONAN_GROUP_REPOSITORY="${CONAN_E2E_GROUP_REPOSITORY:-conan-group}"
 KKREPO_AUTH_URL=""
 REDACTION_VALUES=("$KKREPO_PASSWORD" "$KKREPO_AUTH")
@@ -1312,10 +1314,13 @@ test_conan() {
   local dir="$WORK_DIR/conan"
   local publish_home="$dir/publish-home"
   local consume_home="$dir/consume-home"
+  local proxy_home="$dir/proxy-home"
   local name="kkrepo_conan_e2e_${STAMP}"
   local reference="$name/1.0.0@kkrepo/stable"
   local list_json="$ARTIFACT_DIR/conan-group-list.json"
+  local proxy_list_json="$ARTIFACT_DIR/conan-proxy-list.json"
   local removed_json="$ARTIFACT_DIR/conan-hosted-after-remove.json"
+  local proxy_exact_reference proxy_info_path
   mkdir -p "$dir/include" "$publish_home" "$consume_home"
   cat >"$dir/conanfile.py" <<'PY'
 from conan import ConanFile
@@ -1372,6 +1377,64 @@ PY
     "$CONAN_BIN" download "$reference:*" --remote=kkrepo-group
   run_logged conan-install env CONAN_HOME="$consume_home" \
     "$CONAN_BIN" install --requires="$reference" --remote=kkrepo-group --build=never
+
+  run_logged conan-proxy-remote env CONAN_HOME="$proxy_home" \
+    "$CONAN_BIN" remote add kkrepo-proxy \
+    "$KKREPO_URL/repository/$CONAN_PROXY_REPOSITORY" --force
+  run_logged conan-proxy-login env CONAN_HOME="$proxy_home" \
+    "$CONAN_BIN" remote login kkrepo-proxy "$KKREPO_USER" -p "$KKREPO_PASSWORD"
+  run_logged_output conan-proxy-list "$proxy_list_json" env CONAN_HOME="$proxy_home" \
+    "$CONAN_BIN" list "$CONAN_PROXY_REFERENCE#*:*#*" \
+    --remote=kkrepo-proxy --format=json
+  IFS=$'\t' read -r proxy_exact_reference proxy_info_path < <(
+    python3 - "$proxy_list_json" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+remote = payload.get("kkrepo-proxy") or {}
+if not remote:
+    raise SystemExit(f"Conan proxy returned no recipes: {payload}")
+recipe, recipe_value = next(iter(remote.items()))
+revisions = recipe_value.get("revisions") or {}
+if not revisions:
+    raise SystemExit(f"Conan proxy returned no recipe revisions: {payload}")
+rrev, revision_value = max(
+    revisions.items(), key=lambda item: item[1].get("timestamp") or 0)
+packages = revision_value.get("packages") or {}
+if not packages:
+    raise SystemExit(f"Conan proxy returned no packages: {payload}")
+preferred = [
+    item for item in packages.items()
+    if item[1].get("info", {}).get("settings", {}).get("os") == "Linux"
+    and item[1].get("info", {}).get("settings", {}).get("arch") == "x86_64"
+]
+package_id, package_value = (preferred or list(packages.items()))[0]
+package_revisions = package_value.get("revisions") or {}
+if not package_revisions:
+    raise SystemExit(f"Conan proxy returned no package revisions: {payload}")
+prev, _ = max(
+    package_revisions.items(), key=lambda item: item[1].get("timestamp") or 0)
+base, separator, owner = recipe.partition("@")
+name, version = base.split("/", 1)
+user, channel = owner.split("/", 1) if separator else ("_", "_")
+print(
+    f"{recipe}#{rrev}:{package_id}#{prev}\t"
+    f"{name}/{version}/{user}/{channel}/revisions/{rrev}/packages/"
+    f"{package_id}/revisions/{prev}"
+)
+PY
+  )
+  [[ -n "$proxy_exact_reference" && -n "$proxy_info_path" ]] || {
+    log "Conan proxy selection did not produce an exact package revision"
+    return 1
+  }
+  run_logged_output conan-proxy-info "$ARTIFACT_DIR/conan-proxy-conaninfo.txt" \
+    curl -m 60 --fail-with-body -sS -u "$KKREPO_AUTH" \
+    "$KKREPO_URL/repository/$CONAN_PROXY_REPOSITORY/v2/conans/$proxy_info_path/files/conaninfo.txt"
+  run_logged conan-proxy-download env CONAN_HOME="$proxy_home" \
+    "$CONAN_BIN" download "$proxy_exact_reference" --remote=kkrepo-proxy
 
   run_logged conan-remove-package-revisions env CONAN_HOME="$publish_home" \
     "$CONAN_BIN" remove "$reference:*" --remote=kkrepo-hosted --confirm


### PR DESCRIPTION
## Summary

- preserve an existing Conan package projection when a later sparse proxy file observation has no `conaninfo.txt` metadata
- keep hosted package immutability and non-empty projection conflict detection strict
- cover the regression on MySQL and PostgreSQL and exercise a real Conan proxy binary download in the existing client E2E flow

## Root cause

Conan proxy files are fetched and persisted independently. `conaninfo.txt` carries package settings, options, and requirements, while package archives and manifests do not. After `conaninfo.txt` populated a package projection, a later archive or manifest observation supplied empty maps. The DAO interpreted those empty maps as a different projection and threw `Conan package id was reused with different conaninfo projection`, returning HTTP 500.

Empty metadata from a proxy `DISCOVERED` observation means "unknown", not "replace the known projection". The DAO now preserves the stored projection for that case while continuing to reject two different non-empty projections.

## Impact

- fixes full Conan 2 proxy binary downloads after `conaninfo.txt` has been discovered
- applies equally to JVM and Native runtimes because the failure was in the shared JDBC DAO
- introduces no schema or migration changes; package lookup continues to use the existing unique key/index
- extends the existing Conan client E2E case rather than adding another CI matrix

## Validation

- `mvn -B -ntp -pl persistence-jdbc -am -DskipTests package`
- `mvn -B -ntp -pl persistence-mysql,persistence-postgresql -am -Dtest=ConanRegistryDaoMySqlIntegrationTest,ConanRegistryDaoPostgreSqlIntegrationTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -B -ntp -pl server -am -Dtest=ConanServiceTest -Dsurefire.failIfNoSpecifiedTests=false test` (27 tests)
- `bash -n scripts/ci/run-client-e2e.sh`
- `git diff --check`
