### PR TITLE
Release kkRepo 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable public changes to kkrepo are documented in this file.
 
 This project follows a pragmatic early-stage release process. Until a stable `1.0.0` release is announced, minor versions may include behavior changes, but releases should call out migration impact, compatibility changes, and operational notes.
 
+## 0.8.0 - 2026-08-13
+
+### Added
+
+- Nexus-compatible Conda hosted, proxy, and group repositories with root and nested channels, `.tar.bz2` and `.conda` packages, compressed/current repodata, channeldata, ordered group resolution, migration, cleanup, scanning, and real Conda client coverage. (#186)
+- APT/Debian hosted and proxy repositories with validated `.deb` publication, canonical pool paths, signed and by-hash metadata, key rotation, durable asynchronous publication, proxy passthrough or re-signing, cleanup, migration, and Debian/Ubuntu client coverage. APT groups remain unsupported because signed metadata cannot be merged safely. (#188)
+- Complete Conan 2 hosted, proxy, and group support with Bearer authentication, recipe/package revisions, atomic publication, resumable uploads, Nexus-aligned Browse paths, migration, cleanup, security scanning, and real Conan client coverage. (#198)
+- Dedicated English and Chinese repository guides for all 19 implemented formats, organized under one discoverable documentation hierarchy. (#201)
+
+### Changed
+
+- The development deployment can run the exact merged revision as equal-weight JVM and Native replicas, with coordinated health checks and rollback, so runtime-specific and multi-replica regressions surface under normal traffic. (#192)
+- UI session restoration, authentication context loading, and repository permission loading are parallelized and cached safely, reducing first-page and login-state rendering from about ten seconds to below one second on repository-heavy installations. (#205)
+- Quickstart defaults, Dockerfile packaging, deployment documentation, and the Helm application version now use `0.8.0`; the optional scanner profile uses the matching `kkrepo-scanner:0.8.0` image.
+- AWS SDK, GraalVM Native Build Tools, the Conda setup action, and other workflow dependencies were refreshed. (#189, #190, #191)
+
+### Fixed
+
+- Shared proxy fetching now permits the safe same-host HTTP-to-HTTPS upgrade used by upstream mirrors while preserving redirect allowlists for cross-host, downgrade, and arbitrary-port transitions. (#195)
+- Development bootstrap preserves the Nginx bind-mounted configuration when enabling dual-runtime routing. (#193)
+- Native replicas now include the complete Spring Session serialization metadata needed for browser login and repeated JDBC-backed session reloads. (#203)
+- Conan Browse search is format-scoped, and sparse proxy observations no longer erase an existing package projection after `conaninfo.txt` has populated it. (#202, #204)
+
+### Compatibility And Validation
+
+- Conda, APT, and Conan include MySQL/PostgreSQL persistence contracts, multi-replica coordination, Nexus comparisons, migration coverage, protocol-aware cleanup/scanning, and real-client E2E validation. (#186, #188, #198)
+- The release includes targeted Native client validation for JDBC browser-session recovery and client E2E coverage for Conan proxy package downloads. (#203, #204)
+- CI no longer treats Conan test fixtures as C++ production sources during CodeQL language detection. (#200)
+
+### Upgrade Notes
+
+- Existing `0.7.0` MySQL and PostgreSQL deployments can upgrade in place through Flyway V41-V45. Back up the relational database and blob store together, allow the migrations to complete before serving traffic, and do not run mixed application versions after the new schema is applied.
+- V41 adds Conda registry, metadata, revision, lease, and migration state; V42-V44 add APT package, suite, signing, proxy, publication, retention, and supporting indexes; V45 adds Conan recipe/package revision, upload, source-binding, lease, and migration state.
+- The new repository formats are not created automatically. Configure signing keys before exposing an APT hosted repository, and validate proxy credentials, cleanup policies, and scanner scope before production activation.
+
 ## 0.7.0 - 2026-08-06
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:25-jre-jammy
 
 WORKDIR /app
 
-ARG JAR_FILE=server/target/kkrepo-server-0.7.0.jar
+ARG JAR_FILE=server/target/kkrepo-server-0.8.0.jar
 
 RUN groupadd --system kkrepo \
     && useradd --system --gid kkrepo --home-dir /app --shell /usr/sbin/nologin kkrepo

--- a/deploy/helm/kkrepo/Chart.yaml
+++ b/deploy/helm/kkrepo/Chart.yaml
@@ -3,5 +3,5 @@ name: kkrepo
 description: Multi-replica kkRepo artifact repository with an external MySQL or PostgreSQL database
 type: application
 version: 0.2.0
-appVersion: "0.7.0"
+appVersion: "0.8.0"
 kubeVersion: ">=1.27.0-0"

--- a/docker-compose.quickstart-postgresql.yml
+++ b/docker-compose.quickstart-postgresql.yml
@@ -28,7 +28,7 @@ services:
     network_mode: none
 
   kkrepo:
-    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.7.0}
+    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.8.0}
     depends_on:
       postgresql:
         condition: service_healthy
@@ -61,7 +61,7 @@ services:
     restart: unless-stopped
 
   scanner:
-    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.7.0}
+    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.8.0}
     profiles: ["security-scanning"]
     environment:
       KKREPO_SCANNER_SERVICE_CREDENTIAL: ${KKREPO_SECURITY_SCANNING_SERVICE_CREDENTIAL:-}
@@ -91,7 +91,7 @@ services:
     restart: unless-stopped
 
   scanner-database-updater:
-    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.7.0}
+    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.8.0}
     profiles: ["security-scanning"]
     entrypoint: ["/bin/sh", "-ec"]
     command:

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -29,7 +29,7 @@ services:
     network_mode: none
 
   kkrepo:
-    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.7.0}
+    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.8.0}
     depends_on:
       mysql:
         condition: service_healthy
@@ -62,7 +62,7 @@ services:
     restart: unless-stopped
 
   scanner:
-    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.7.0}
+    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.8.0}
     profiles: ["security-scanning"]
     environment:
       KKREPO_SCANNER_SERVICE_CREDENTIAL: ${KKREPO_SECURITY_SCANNING_SERVICE_CREDENTIAL:-}
@@ -92,7 +92,7 @@ services:
     restart: unless-stopped
 
   scanner-database-updater:
-    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.7.0}
+    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.8.0}
     profiles: ["security-scanning"]
     entrypoint: ["/bin/sh", "-ec"]
     command:

--- a/docs/en/build-deployment-guide.md
+++ b/docs/en/build-deployment-guide.md
@@ -40,7 +40,7 @@ curl -fsSL https://raw.githubusercontent.com/klboke/kkrepo/main/scripts/quicksta
   | KKREPO_RUNTIME=native KKREPO_DATABASE_TYPE=postgresql bash
 ```
 
-`KKREPO_RUNTIME=jvm` selects `ghcr.io/klboke/kkrepo:0.7.0`, while `KKREPO_RUNTIME=native` selects `ghcr.io/klboke/kkrepo:0.7.0-native`. Both are published for Linux `amd64` and `arm64`. An explicit `KKREPO_IMAGE_TAG` overrides the runtime's default tag.
+`KKREPO_RUNTIME=jvm` selects `ghcr.io/klboke/kkrepo:0.8.0`, while `KKREPO_RUNTIME=native` selects `ghcr.io/klboke/kkrepo:0.8.0-native`. Both are published for Linux `amd64` and `arm64`. An explicit `KKREPO_IMAGE_TAG` overrides the runtime's default tag.
 
 The script prints each step and:
 
@@ -61,7 +61,7 @@ bash quickstart.sh
 
 By default, it starts:
 
-- The JVM runtime from `ghcr.io/klboke/kkrepo:0.7.0`
+- The JVM runtime from `ghcr.io/klboke/kkrepo:0.8.0`
 - MySQL 8.0
 - Persistent MySQL and File blob storage volumes for local trials
 
@@ -153,7 +153,7 @@ Note: a normal `server` module jar does not contain a Spring Boot executable ent
 Pull the latest public release image:
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:0.7.0
+docker pull ghcr.io/klboke/kkrepo:0.8.0
 ```
 
 You can also use `latest` to follow the latest public release:
@@ -165,7 +165,7 @@ docker pull ghcr.io/klboke/kkrepo:latest
 The Native image is published separately:
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:0.7.0-native
+docker pull ghcr.io/klboke/kkrepo:0.8.0-native
 docker pull ghcr.io/klboke/kkrepo:native-latest
 ```
 

--- a/docs/zh/build-deployment-guide.md
+++ b/docs/zh/build-deployment-guide.md
@@ -40,7 +40,7 @@ curl -fsSL https://raw.githubusercontent.com/klboke/kkrepo/main/scripts/quicksta
   | KKREPO_RUNTIME=native KKREPO_DATABASE_TYPE=postgresql bash
 ```
 
-`KKREPO_RUNTIME=jvm` 选择 `ghcr.io/klboke/kkrepo:0.7.0`，`KKREPO_RUNTIME=native` 选择 `ghcr.io/klboke/kkrepo:0.7.0-native`。两种镜像均发布 Linux `amd64` 和 `arm64` 架构。显式设置 `KKREPO_IMAGE_TAG` 时，会覆盖对应运行时的默认 tag。
+`KKREPO_RUNTIME=jvm` 选择 `ghcr.io/klboke/kkrepo:0.8.0`，`KKREPO_RUNTIME=native` 选择 `ghcr.io/klboke/kkrepo:0.8.0-native`。两种镜像均发布 Linux `amd64` 和 `arm64` 架构。显式设置 `KKREPO_IMAGE_TAG` 时，会覆盖对应运行时的默认 tag。
 
 该脚本会逐步打印日志并执行：
 
@@ -61,7 +61,7 @@ bash quickstart.sh
 
 默认会启动：
 
-- `ghcr.io/klboke/kkrepo:0.7.0` 中的 JVM 运行时
+- `ghcr.io/klboke/kkrepo:0.8.0` 中的 JVM 运行时
 - MySQL 8.0
 - 用于本地试用的持久化 MySQL volume 和 File blob storage volume
 
@@ -153,7 +153,7 @@ server/target/kkrepo-server-<version>.jar
 拉取最新公开发行镜像：
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:0.7.0
+docker pull ghcr.io/klboke/kkrepo:0.8.0
 ```
 
 也可以使用 `latest` 跟随最新公开发行版本：
@@ -165,7 +165,7 @@ docker pull ghcr.io/klboke/kkrepo:latest
 Native 镜像使用独立 tag：
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:0.7.0-native
+docker pull ghcr.io/klboke/kkrepo:0.8.0-native
 docker pull ghcr.io/klboke/kkrepo:native-latest
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
   </modules>
 
   <properties>
-    <revision>0.7.0</revision>
+    <revision>0.8.0</revision>
     <java.version>25</java.version>
     <spring.boot.version>4.1.0</spring.boot.version>
     <native-build-tools-plugin.version>1.1.8</native-build-tools-plugin.version>

--- a/scripts/ci/test-quickstart-runtime.sh
+++ b/scripts/ci/test-quickstart-runtime.sh
@@ -58,22 +58,22 @@ run_quickstart() {
 
 run_quickstart default-jvm
 grep -qx 'KKREPO_RUNTIME=jvm' "$TMP_ROOT/default-jvm/.env"
-grep -qx 'KKREPO_IMAGE_TAG=0.7.0' "$TMP_ROOT/default-jvm/.env"
-grep -qx 'jvm|0.7.0' "$TMP_ROOT/default-jvm.log"
+grep -qx 'KKREPO_IMAGE_TAG=0.8.0' "$TMP_ROOT/default-jvm/.env"
+grep -qx 'jvm|0.8.0' "$TMP_ROOT/default-jvm.log"
 
 run_quickstart native KKREPO_RUNTIME=native
 grep -qx 'KKREPO_RUNTIME=native' "$TMP_ROOT/native/.env"
-grep -qx 'KKREPO_IMAGE_TAG=0.7.0-native' "$TMP_ROOT/native/.env"
-grep -qx 'native|0.7.0-native' "$TMP_ROOT/native.log"
+grep -qx 'KKREPO_IMAGE_TAG=0.8.0-native' "$TMP_ROOT/native/.env"
+grep -qx 'native|0.8.0-native' "$TMP_ROOT/native.log"
 
 mkdir -p "$TMP_ROOT/existing-jvm"
-# Simulate a persisted v0.6.0 JVM quickstart before explicitly switching runtimes.
+# Simulate a persisted v0.7.0 JVM quickstart before explicitly switching runtimes.
 cat >"$TMP_ROOT/existing-jvm/.env" <<'EOF'
 KKREPO_RUNTIME=jvm
-KKREPO_IMAGE_TAG=0.6.0
+KKREPO_IMAGE_TAG=0.7.0
 EOF
 run_quickstart existing-jvm KKREPO_RUNTIME=native
-grep -qx 'native|0.7.0-native' "$TMP_ROOT/existing-jvm.log"
+grep -qx 'native|0.8.0-native' "$TMP_ROOT/existing-jvm.log"
 
 run_quickstart custom-native \
   KKREPO_RUNTIME=native \

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -186,10 +186,10 @@ fi
 KKREPO_RUNTIME="${KKREPO_RUNTIME:-jvm}"
 case "$KKREPO_RUNTIME" in
   jvm)
-    DEFAULT_IMAGE_TAG="0.7.0"
+    DEFAULT_IMAGE_TAG="0.8.0"
     ;;
   native)
-    DEFAULT_IMAGE_TAG="0.7.0-native"
+    DEFAULT_IMAGE_TAG="0.8.0-native"
     ;;
   *)
     fail "KKREPO_RUNTIME must be jvm or native, got: $KKREPO_RUNTIME"


### PR DESCRIPTION
## Summary

- bump Maven, Dockerfile, JVM/Native quickstart defaults, scanner defaults, Helm app version, deployment documentation, and regression expectations to `0.8.0`
- add release notes for Conda, APT/Debian, Conan 2, bilingual repository guides, dual JVM/Native deployment, UI/session performance, and production fixes
- document the MySQL/PostgreSQL upgrade path through Flyway V41-V45

## Release scope

`0.8.0` adds complete Conda hosted/proxy/group support (#186), APT hosted/proxy support (#188), and Conan 2 hosted/proxy/group support (#198). It also includes equal-weight JVM/Native dev deployment (#192), complete bilingual repository guides (#201), safe same-host proxy upgrades (#195), Native JDBC session recovery (#203), Conan proxy fixes (#202, #204), and faster UI session restoration (#205).

Existing `0.7.0` MySQL and PostgreSQL deployments upgrade through Flyway V41-V45. The new repository formats are not created automatically; APT signing and repository activation remain explicit administrator operations.

## Validation

- `mvn -B -ntp -N validate` and project-version assertion for `0.8.0`
- `helm lint deploy/helm/kkrepo`
- MySQL and PostgreSQL quickstart Compose validation, with and without the security-scanning profile
- `scripts/ci/test-quickstart-runtime.sh`
- `bash scripts/ci/check-flyway-parity.sh` — V45
- shell syntax validation for quickstart scripts
- `git diff --check`

The `run-full-e2e` label is applied as the final pre-merge release gate.