### PR TITLE
fix: align quickstart data permissions with selected runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,7 @@ jobs:
           bash -n scripts/ci/prepare-swift-e2e-tls.sh
           bash -n scripts/ci/setup-swift-e2e-wrappers.sh
           bash -n scripts/ci/test-e2e-image-artifact.sh
+          bash -n scripts/ci/test-quickstart-data-permissions.sh
           bash -n scripts/ci/test-quickstart-runtime.sh
           bash -n scripts/ci/test-swift-e2e-wrappers.sh
           bash -n scripts/ci/test-dist-launcher.sh
@@ -175,6 +176,7 @@ jobs:
           scripts/ci/test-dev-nginx-bind-mount.sh
           scripts/ci/check-dev-dual-runtime-deploy.sh
           scripts/ci/test-e2e-image-artifact.sh
+          scripts/ci/test-quickstart-data-permissions.sh
           scripts/ci/test-quickstart-runtime.sh
           scripts/ci/test-swift-e2e-wrappers.sh
           scripts/ci/test-dist-launcher.sh

--- a/docker-compose.quickstart-postgresql.yml
+++ b/docker-compose.quickstart-postgresql.yml
@@ -22,9 +22,22 @@ services:
   app-data-perms:
     image: alpine:3.20
     user: root
+    environment:
+      KKREPO_RUNTIME: ${KKREPO_RUNTIME:-jvm}
     volumes:
       - kkrepo-data:/data
-    command: ["sh", "-c", "mkdir -p /data/blobs && chown -R 999:999 /data"]
+    command:
+      - sh
+      - -ec
+      - |
+        # Published JVM and Native images run as 999:999 and 1002:1001 respectively.
+        case "$${KKREPO_RUNTIME}" in
+          jvm) owner="999:999" ;;
+          native) owner="1002:1001" ;;
+          *) echo "Unsupported KKREPO_RUNTIME for data permissions: $${KKREPO_RUNTIME}" >&2; exit 1 ;;
+        esac
+        mkdir -p /data/blobs
+        chown -R "$${owner}" /data
     network_mode: none
 
   kkrepo:

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -23,9 +23,22 @@ services:
   app-data-perms:
     image: alpine:3.20
     user: root
+    environment:
+      KKREPO_RUNTIME: ${KKREPO_RUNTIME:-jvm}
     volumes:
       - kkrepo-data:/data
-    command: ["sh", "-c", "mkdir -p /data/blobs && chown -R 999:999 /data"]
+    command:
+      - sh
+      - -ec
+      - |
+        # Published JVM and Native images run as 999:999 and 1002:1001 respectively.
+        case "$${KKREPO_RUNTIME}" in
+          jvm) owner="999:999" ;;
+          native) owner="1002:1001" ;;
+          *) echo "Unsupported KKREPO_RUNTIME for data permissions: $${KKREPO_RUNTIME}" >&2; exit 1 ;;
+        esac
+        mkdir -p /data/blobs
+        chown -R "$${owner}" /data
     network_mode: none
 
   kkrepo:

--- a/scripts/ci/test-quickstart-data-permissions.sh
+++ b/scripts/ci/test-quickstart-data-permissions.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUN_ID="${RANDOM}-$$"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/kkrepo-quickstart-permissions.XXXXXX")"
+ACTIVE_PROJECTS=()
+
+cleanup() {
+  local project compose_file
+  for entry in "${ACTIVE_PROJECTS[@]:-}"; do
+    project="${entry%%|*}"
+    compose_file="${entry#*|}"
+    docker compose -p "$project" -f "$compose_file" down -v --remove-orphans >/dev/null 2>&1 || true
+  done
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+verify_owner() {
+  local compose_file=$1
+  local runtime=$2
+  local expected_owner=$3
+  local label=$4
+  local project="kkrepo-perms-${label}-${runtime}-${RUN_ID}"
+  local output_file="$TMP_ROOT/${project}.log"
+  local owners
+
+  ACTIVE_PROJECTS+=("${project}|${compose_file}")
+  if ! KKREPO_RUNTIME="$runtime" docker compose -p "$project" -f "$compose_file" \
+      run --rm --no-deps app-data-perms >"$output_file" 2>&1; then
+    cat "$output_file" >&2
+    return 1
+  fi
+
+  owners="$(KKREPO_RUNTIME="$runtime" docker compose -p "$project" -f "$compose_file" \
+    run --rm --no-deps app-data-perms stat -c '%u:%g' /data /data/blobs)"
+  if [[ "$owners" != "${expected_owner}"$'\n'"${expected_owner}" ]]; then
+    printf 'unexpected %s %s data owners: expected %s, got:\n%s\n' \
+      "$label" "$runtime" "$expected_owner" "$owners" >&2
+    return 1
+  fi
+
+  docker compose -p "$project" -f "$compose_file" down -v --remove-orphans >/dev/null
+  rm -f "$output_file"
+}
+
+verify_invalid_runtime() {
+  local compose_file=$1
+  local project="kkrepo-perms-invalid-${RUN_ID}"
+  local output_file="$TMP_ROOT/${project}.log"
+
+  ACTIVE_PROJECTS+=("${project}|${compose_file}")
+  if KKREPO_RUNTIME=invalid docker compose -p "$project" -f "$compose_file" \
+      run --rm --no-deps app-data-perms >"$output_file" 2>&1; then
+    echo "invalid quickstart runtime unexpectedly initialized the data volume" >&2
+    return 1
+  fi
+  grep -q 'Unsupported KKREPO_RUNTIME for data permissions: invalid' "$output_file"
+  docker compose -p "$project" -f "$compose_file" down -v --remove-orphans >/dev/null
+  rm -f "$output_file"
+}
+
+verify_owner "$ROOT/docker-compose.quickstart.yml" jvm 999:999 mysql
+verify_owner "$ROOT/docker-compose.quickstart.yml" native 1002:1001 mysql
+verify_owner "$ROOT/docker-compose.quickstart-postgresql.yml" jvm 999:999 postgresql
+verify_owner "$ROOT/docker-compose.quickstart-postgresql.yml" native 1002:1001 postgresql
+verify_invalid_runtime "$ROOT/docker-compose.quickstart.yml"
+
+echo "[test] quickstart data permissions passed"

--- a/server/src/main/java/com/github/klboke/kkrepo/server/BlobStoresController.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/BlobStoresController.java
@@ -15,7 +15,6 @@ import com.github.klboke.kkrepo.storage.s3.admin.S3BlobStoreAdmin;
 import com.github.klboke.kkrepo.storage.s3.admin.S3BucketSummary;
 import com.github.klboke.kkrepo.storage.s3.admin.S3ProbeResult;
 import com.github.klboke.kkrepo.storage.s3.config.S3StorageProperties;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -23,6 +22,8 @@ import java.util.Locale;
 import java.util.Map;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -126,6 +127,15 @@ public class BlobStoresController {
     return toProbeResult(s3BlobStoreAdmin.probeReadWrite(toS3Config(record)));
   }
 
+  @ExceptionHandler(ResponseStatusException.class)
+  public ResponseEntity<Map<String, String>> handleResponseStatus(ResponseStatusException error) {
+    String message = error.getReason();
+    if (message == null || message.isBlank()) {
+      message = error.getStatusCode().toString();
+    }
+    return ResponseEntity.status(error.getStatusCode()).body(Map.of("message", message));
+  }
+
   private BlobStoreRecord toCreateRecord(String name, BlobStoreRequest request) {
     if (isFileRequest(request, null)) {
       return new BlobStoreRecord(
@@ -221,8 +231,6 @@ public class BlobStoresController {
           .toList();
       filePathValidator.validate(config, existing);
     } catch (IllegalArgumentException e) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
-    } catch (UncheckedIOException e) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
     }
   }

--- a/server/src/test/java/com/github/klboke/kkrepo/server/BlobStoresControllerTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/BlobStoresControllerTest.java
@@ -228,6 +228,29 @@ class BlobStoresControllerTest {
     assertTrue(responseBody.contains("default"));
   }
 
+  @Test
+  void fallsBackToStatusTextWhenResponseStatusReasonIsMissingOrBlank() {
+    BlobStoresController controller = new BlobStoresController(
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null);
+
+    var missingReason = controller.handleResponseStatus(
+        new ResponseStatusException(HttpStatus.BAD_REQUEST));
+    var blankReason = controller.handleResponseStatus(
+        new ResponseStatusException(HttpStatus.BAD_REQUEST, " "));
+
+    assertEquals(HttpStatus.BAD_REQUEST, missingReason.getStatusCode());
+    assertEquals(Map.of("message", "400 BAD_REQUEST"), missingReason.getBody());
+    assertEquals(HttpStatus.BAD_REQUEST, blankReason.getStatusCode());
+    assertEquals(Map.of("message", "400 BAD_REQUEST"), blankReason.getBody());
+  }
+
   private static BlobStoresController.BlobStoreRequest fileRequest(String name, String path) {
     return new BlobStoresController.BlobStoreRequest(
         name,

--- a/server/src/test/java/com/github/klboke/kkrepo/server/BlobStoresControllerTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/BlobStoresControllerTest.java
@@ -3,6 +3,8 @@ package com.github.klboke.kkrepo.server;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.github.klboke.kkrepo.persistence.jdbc.api.BlobStoreDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.BlobStoreRecord;
@@ -22,7 +24,9 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.server.ResponseStatusException;
 
 class BlobStoresControllerTest {
@@ -190,6 +194,38 @@ class BlobStoresControllerTest {
     BlobStoresController.BlobStoreView created = controller.create(fileRequest("disk", "hosted"));
 
     assertEquals("file", created.type());
+  }
+
+  @Test
+  void rendersBlobStoreValidationReasonForTheAdminUi() throws Exception {
+    Path blockingFile = tempDir.resolve("blocking-file");
+    Files.writeString(blockingFile, "not a directory");
+    FileStorageProperties fileProperties = new FileStorageProperties();
+    fileProperties.setBaseDir(blockingFile.toString());
+    FileBlobStorageFactory fileFactory = new FileBlobStorageFactory(fileProperties);
+    FileBlobStorePathValidator pathValidator = new FileBlobStorePathValidator();
+    BlobStoresController controller = new BlobStoresController(
+        new InMemoryBlobStoreDao(),
+        null,
+        null,
+        fileFactory,
+        pathValidator,
+        new S3StorageProperties(),
+        null,
+        new MockEnvironment());
+
+    var result = MockMvcBuilders.standaloneSetup(controller).build()
+        .perform(post("/internal/blob-stores")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("""
+                {"name":"disk","type":"file","engine":"file","path":"default"}
+                """))
+        .andExpect(status().isBadRequest())
+        .andReturn();
+
+    String responseBody = result.getResponse().getContentAsString();
+    assertTrue(responseBody.contains("\"message\":\"File blob store path cannot be created or written:"));
+    assertTrue(responseBody.contains("default"));
   }
 
   private static BlobStoresController.BlobStoreRequest fileRequest(String name, String path) {

--- a/storage-file/src/main/java/com/github/klboke/kkrepo/storage/file/FileBlobStorePathValidator.java
+++ b/storage-file/src/main/java/com/github/klboke/kkrepo/storage/file/FileBlobStorePathValidator.java
@@ -1,7 +1,6 @@
 package com.github.klboke.kkrepo.storage.file;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -24,7 +23,11 @@ public class FileBlobStorePathValidator {
         throw new IllegalArgumentException("File blob store path is not writable: " + root);
       }
     } catch (IOException e) {
-      throw new UncheckedIOException(e);
+      String detail = e.getMessage();
+      String suffix = detail == null || detail.isBlank() ? "" : " (" + detail + ")";
+      throw new IllegalArgumentException(
+          "File blob store path cannot be created or written: " + root + suffix,
+          e);
     }
   }
 

--- a/storage-file/src/test/java/com/github/klboke/kkrepo/storage/file/FileBlobStorePathValidatorTest.java
+++ b/storage-file/src/test/java/com/github/klboke/kkrepo/storage/file/FileBlobStorePathValidatorTest.java
@@ -1,0 +1,31 @@
+package com.github.klboke.kkrepo.storage.file;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FileBlobStorePathValidatorTest {
+  @TempDir
+  Path tempDir;
+
+  @Test
+  void explainsWhenBlobStoreDirectoryCannotBeCreated() throws IOException {
+    Path blockingFile = tempDir.resolve("blocking-file");
+    Files.writeString(blockingFile, "not a directory");
+    Path blobStorePath = blockingFile.resolve("default");
+
+    IllegalArgumentException error = assertThrows(
+        IllegalArgumentException.class,
+        () -> new FileBlobStorePathValidator().validateWritableDirectory(blobStorePath));
+
+    assertTrue(error.getMessage().contains("cannot be created or written"));
+    assertTrue(error.getMessage().contains(blobStorePath.toString()));
+    assertInstanceOf(IOException.class, error.getCause());
+  }
+}


### PR DESCRIPTION
## Summary

- initialize the quickstart data volume with the UID/GID used by the selected JVM or Native runtime
- cover JVM and Native ownership for both MySQL and PostgreSQL quickstarts in CI
- return the actionable File blob store path validation reason to the admin UI instead of a generic bad-request message

## Root cause

The quickstart `app-data-perms` service always changed `/data` to `999:999`, which matches the JVM image. The published Native image runs as `1002:1001`, so a fresh Native quickstart could not create a directory under `/var/lib/kkrepo/blobs`; creating a File blob store therefore returned HTTP 400.

## Validation

- `mvn -B -ntp -pl server -am -Dsurefire.failIfNoSpecifiedTests=false test` (31-module reactor success; 2,374 server tests passed)
- `scripts/ci/test-quickstart-data-permissions.sh`
- `scripts/ci/test-quickstart-runtime.sh`
- Compose config validation for JVM and Native with both database variants
- clean run of `ghcr.io/klboke/kkrepo:0.8.0-native`: `/data` and `/data/blobs` were initialized as `1002:1001`, and the File blob store create request returned HTTP 200

Fixes #208
