### PR TITLE
feat: add permission-aware global component search

### DIFF
--- a/admin-ui/src/main/resources/META-INF/resources/admin/index.html
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/index.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="/browse/assets/format-icons.css?v=20260811-conan-1">
     <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260728-security-advisory-link-1">
     <link rel="stylesheet" href="./assets/admin.css?v=20260805-cleanup-policy-31">
+    <link rel="stylesheet" href="/browse/assets/global-component-search.css?v=20260817-global-search-3">
   </head>
   <body>
     <div class="nx-shell">
@@ -24,6 +25,11 @@
           <a class="workspace-tab is-active" href="/admin/#admin/repository/repositories" aria-current="page">Admin</a>
         </nav>
         <div class="top-spacer"></div>
+        <form class="global-component-search" data-global-component-search action="/browse/" method="get" role="search">
+          <label class="global-component-search-label" for="global-component-search-input">Search components</label>
+          <span class="global-component-search-icon lucide-icon icon-search" aria-hidden="true"></span>
+          <input id="global-component-search-input" name="q" type="search" placeholder="Search components" autocomplete="off">
+        </form>
         <div class="user-menu" id="user-menu" hidden>
           <button class="user-menu-trigger" id="user-menu-trigger" type="button" aria-haspopup="menu" aria-expanded="false">
             <span class="user-pill" id="current-user-pill" title="Current user"></span>
@@ -1673,8 +1679,9 @@
       </main>
     </div>
 
-    <script src="/login/assets/ui-i18n.js?v=20260625-ui-i18n-5"></script>
+    <script src="/login/assets/ui-i18n.js?v=20260817-global-search-1"></script>
     <script src="./assets/admin-filter.js?v=20260706-wildcard-filter-1"></script>
+    <script src="/browse/assets/global-component-search.js?v=20260817-global-search-2"></script>
     <script src="./assets/admin.js?v=20260812-session-hydration-1"></script>
   </body>
 </html>

--- a/admin-ui/src/main/resources/META-INF/resources/login/assets/ui-i18n.js
+++ b/admin-ui/src/main/resources/META-INF/resources/login/assets/ui-i18n.js
@@ -26,6 +26,8 @@
     "Browse navigation": "浏览导航",
     "Browse": "浏览",
     "Admin": "管理",
+    "Search components": "搜索组件",
+    "All formats": "全部格式",
     "Repository": "仓库",
     "Repositories": "仓库",
     "Manage repositories": "管理仓库",

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminGlobalComponentSearchContractTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminGlobalComponentSearchContractTest.java
@@ -1,0 +1,35 @@
+package com.github.klboke.kkrepo.admin.ui;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import org.junit.jupiter.api.Test;
+
+class AdminGlobalComponentSearchContractTest {
+
+  @Test
+  void administrationExposesTheSharedGlobalSearch() throws IOException {
+    String index = resource("/META-INF/resources/admin/index.html");
+    String translations = resource("/META-INF/resources/login/assets/ui-i18n.js");
+
+    assertTrue(index.contains("data-global-component-search action=\"/browse/\""));
+    assertTrue(index.indexOf("class=\"top-spacer\"")
+        < index.indexOf("<form class=\"global-component-search\""));
+    assertTrue(index.contains("placeholder=\"Search components\""));
+    assertFalse(index.contains("<button type=\"submit\">Search</button>"));
+    assertTrue(index.contains("/browse/assets/global-component-search.css"));
+    assertTrue(index.contains("/browse/assets/global-component-search.js"));
+    assertTrue(translations.contains("\"Search components\": \"搜索组件\""));
+    assertTrue(translations.contains("\"All formats\": \"全部格式\""));
+  }
+
+  private String resource(String path) throws IOException {
+    try (InputStream stream = getClass().getResourceAsStream(path)) {
+      return new String(Objects.requireNonNull(stream).readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+}

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.js
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.js
@@ -37,6 +37,7 @@ const AUTH_SNAPSHOT_KEY = "nexusPlus.authSnapshot";
 const AUTH_SNAPSHOT_MAX_AGE_MS = 10 * 60 * 1000;
 let pendingLoginReturnTo = readPendingLoginReturnTo();
 const SEARCH_ROUTE_FORMAT = {
+  custom: "custom",
   cargo: "cargo",
   go: "go",
   helm: "helm",
@@ -57,6 +58,7 @@ const SEARCH_ROUTE_FORMAT = {
   npm: "npm",
 };
 const FORMAT_ROUTE_SEGMENT = {
+  custom: "custom",
   cargo: "cargo",
   go: "go",
   helm: "helm",
@@ -74,6 +76,27 @@ const FORMAT_ROUTE_SEGMENT = {
   pypi: "pypi",
   rubygems: "rubygems",
   yum: "yum",
+  npm: "npm",
+};
+const SEARCH_FORMAT_LABEL = {
+  custom: "All formats",
+  cargo: "Cargo",
+  go: "Go",
+  helm: "Helm",
+  maven2: "Maven",
+  nuget: "NuGet",
+  pub: "Pub",
+  composer: "Composer",
+  terraform: "Terraform",
+  swift: "Swift",
+  ansiblegalaxy: "Ansible Galaxy",
+  conda: "Conda",
+  conan: "Conan 2",
+  apt: "APT / Debian",
+  alpine: "Alpine / APK",
+  pypi: "PyPI",
+  rubygems: "RubyGems",
+  yum: "Yum",
   npm: "npm",
 };
 
@@ -120,9 +143,15 @@ function normalizeSearchFormat(format) {
   return SEARCH_ROUTE_FORMAT[format] || DEFAULT_SEARCH_FORMAT;
 }
 
-function searchHash(format) {
+function searchFormatLabel(format) {
+  return SEARCH_FORMAT_LABEL[normalizeSearchFormat(format)];
+}
+
+function searchHash(format, keyword = "") {
   const normalized = normalizeSearchFormat(format);
-  return `#${APP_HASH_PREFIX}/search/${FORMAT_ROUTE_SEGMENT[normalized]}`;
+  const base = `#${APP_HASH_PREFIX}/search/${FORMAT_ROUTE_SEGMENT[normalized]}`;
+  const q = String(keyword || "").trim();
+  return q ? `${base}?${new URLSearchParams({ q }).toString()}` : base;
 }
 
 function repositoryBrowseHash(repoName, path = "") {
@@ -191,10 +220,19 @@ function parseBrowseHash() {
   if (hash === `${APP_HASH_PREFIX}/welcome`) return { view: "welcome" };
   if (hash === `${APP_HASH_PREFIX}/upload`) return { view: "upload" };
   if (hash === `${APP_HASH_PREFIX}/my-token`) return { view: "my-token" };
-  if (hash === `${APP_HASH_PREFIX}/search`) return { view: "search", searchFormat: DEFAULT_SEARCH_FORMAT };
+  if (hash === `${APP_HASH_PREFIX}/search`) {
+    return { view: "search", searchFormat: DEFAULT_SEARCH_FORMAT, keyword: "" };
+  }
   if (hash.startsWith(`${APP_HASH_PREFIX}/search/`)) {
-    const rawFormat = hash.slice(`${APP_HASH_PREFIX}/search/`.length);
-    return { view: "search", searchFormat: normalizeSearchFormat(rawFormat) };
+    const routeValue = hash.slice(`${APP_HASH_PREFIX}/search/`.length);
+    const separator = routeValue.indexOf("?");
+    const rawFormat = separator === -1 ? routeValue : routeValue.slice(0, separator);
+    const query = separator === -1 ? "" : routeValue.slice(separator + 1);
+    return {
+      view: "search",
+      searchFormat: normalizeSearchFormat(rawFormat),
+      keyword: new URLSearchParams(query).get("q") || "",
+    };
   }
   const prefix = `${BROWSE_HASH}:`;
   if (!hash.startsWith(prefix)) return null;
@@ -637,12 +675,18 @@ async function fetchChildren(repo, path) {
   return data.entries;
 }
 
-async function fetchSearchComponents(format, keyword) {
+function componentSearchParams(format, keyword) {
   const params = new URLSearchParams();
   const q = (keyword || "").trim();
   if (q) params.set("q", q);
-  params.set("format", normalizeSearchFormat(format));
+  const normalizedFormat = normalizeSearchFormat(format);
+  if (normalizedFormat !== "custom") params.set("format", normalizedFormat);
   params.set("limit", String(COMPONENT_SEARCH_LIMIT));
+  return params;
+}
+
+async function fetchSearchComponents(format, keyword) {
+  const params = componentSearchParams(format, keyword);
   const res = await fetch(`/internal/search/components?${params.toString()}`, {
     headers: { Accept: "application/json" },
     cache: "no-store",
@@ -1145,7 +1189,8 @@ function activateSearch(format = DEFAULT_SEARCH_FORMAT, syncHash = true) {
   return normalized;
 }
 
-function showSearch(format = DEFAULT_SEARCH_FORMAT, syncHash = true) {
+function showSearch(format = DEFAULT_SEARCH_FORMAT, syncHash = true, keyword = null) {
+  if (keyword !== null) document.getElementById("component-keyword").value = keyword;
   renderSearch(activateSearch(format, syncHash));
 }
 
@@ -3682,6 +3727,10 @@ async function uploadError(response) {
 async function renderSearch(format = DEFAULT_SEARCH_FORMAT) {
   const seq = ++searchRequestSeq;
   const keyword = document.getElementById("component-keyword").value.trim().toLowerCase();
+  const target = `/browse/${searchHash(format, keyword)}`;
+  const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  if (current !== target) window.history.replaceState(null, "", target);
+  window.kkrepoGlobalComponentSearch?.setKeyword(document, keyword);
   document.getElementById("component-table").innerHTML =
     '<tr><td colspan="7" class="muted-row">Searching...</td></tr>';
   let payload;
@@ -3767,6 +3816,8 @@ function clearSearchFormatSelection() {
 
 function selectSearchFormat(format) {
   activeSearchFormat = normalizeSearchFormat(format);
+  document.getElementById("component-search-format").textContent =
+    searchFormatLabel(activeSearchFormat);
   document.querySelectorAll(".side-subitem").forEach((entry) => {
     entry.classList.toggle("is-active", entry.dataset.searchFormat === activeSearchFormat);
   });
@@ -3791,8 +3842,7 @@ function applyHashRoute() {
     return true;
   }
   if (route.view === "search") {
-    showSearch(route.searchFormat, false);
-    window.history.replaceState(null, "", `/browse/${searchHash(route.searchFormat)}`);
+    showSearch(route.searchFormat, false, route.keyword);
     return true;
   }
   switchView("browse");
@@ -3918,7 +3968,10 @@ document.getElementById("upload-repository").addEventListener("change", () => {
 });
 document.getElementById("upload-fields").addEventListener("input", updateUploadPath);
 document.getElementById("upload-fields").addEventListener("change", updateUploadPath);
-document.getElementById("component-search-button").addEventListener("click", () => renderSearch(activeSearchFormat));
+document.getElementById("component-search-form").addEventListener("submit", (event) => {
+  event.preventDefault();
+  renderSearch(activeSearchFormat);
+});
 document.getElementById("upload-form").addEventListener("submit", uploadSelectedAsset);
 document.getElementById("my-token-form").addEventListener("submit", createCurrentApiKey);
 document.getElementById("my-token-display-name").addEventListener("input", (event) => {

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/global-component-search.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/global-component-search.css
@@ -1,0 +1,72 @@
+.global-component-search {
+  position: relative;
+  display: flex;
+  flex: 0 1 360px;
+  align-items: center;
+  width: clamp(220px, 30vw, 360px);
+  min-width: 180px;
+  height: 34px;
+  margin: 0 12px 0 24px;
+  color: var(--topbar-muted);
+}
+
+.global-component-search-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+.global-component-search-icon {
+  position: absolute;
+  left: 11px;
+  z-index: 1;
+  width: 17px;
+  height: 17px;
+  pointer-events: none;
+}
+
+.global-component-search input {
+  width: 100%;
+  height: 34px;
+  min-width: 0;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: var(--r-sm);
+  outline: 0;
+  background: rgba(255, 255, 255, 0.09);
+  color: var(--topbar-ink);
+  padding: 0 12px 0 36px;
+}
+
+.global-component-search input::placeholder {
+  color: var(--topbar-muted);
+  opacity: 0.9;
+}
+
+.global-component-search input:hover {
+  border-color: rgba(255, 255, 255, 0.36);
+}
+
+.global-component-search input:focus-visible {
+  border-color: var(--brand-bright);
+  box-shadow: 0 0 0 3px rgba(47, 191, 164, 0.24);
+}
+
+.side-subitem .search-all-icon {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+}
+
+@media (max-width: 760px) {
+  .global-component-search {
+    order: 2;
+    flex: 1 1 calc(100% - 24px);
+    width: calc(100% - 24px);
+    max-width: none;
+    margin: 0 12px 8px;
+  }
+}

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/global-component-search.js
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/global-component-search.js
@@ -1,0 +1,49 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === "object" && module.exports) module.exports = api;
+  root.kkrepoGlobalComponentSearch = api;
+  if (root.document && root.location) api.bind(root.document, root.location);
+}(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  const SEARCH_ROUTE = "/browse/#browse/search/custom";
+
+  function normalizeKeyword(value) {
+    return String(value || "").trim();
+  }
+
+  function target(keyword) {
+    const normalized = normalizeKeyword(keyword);
+    if (!normalized) return null;
+    return `${SEARCH_ROUTE}?${new URLSearchParams({ q: normalized }).toString()}`;
+  }
+
+  function keywordFromHash(hash) {
+    const value = String(hash || "").replace(/^#/, "");
+    const separator = value.indexOf("?");
+    if (separator === -1) return "";
+    return normalizeKeyword(new URLSearchParams(value.slice(separator + 1)).get("q"));
+  }
+
+  function setKeyword(documentRef, keyword) {
+    const input = documentRef.querySelector("[data-global-component-search] input[name='q']");
+    if (input) input.value = normalizeKeyword(keyword);
+  }
+
+  function bind(documentRef, locationRef) {
+    const form = documentRef.querySelector("[data-global-component-search]");
+    const input = form?.querySelector("input[name='q']");
+    if (!form || !input) return;
+    const initialKeyword = keywordFromHash(locationRef.hash);
+    if (initialKeyword) input.value = initialKeyword;
+    form.addEventListener("submit", (event) => {
+      const destination = target(input.value);
+      event.preventDefault();
+      if (!destination) {
+        input.focus();
+        return;
+      }
+      locationRef.assign(destination);
+    });
+  }
+
+  return { bind, keywordFromHash, normalizeKeyword, setKeyword, target };
+}));

--- a/browse-ui/src/main/resources/META-INF/resources/browse/index.html
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/index.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="/browse/assets/format-icons.css?v=20260811-conan-1">
     <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260816-alpine-apk-1">
     <link rel="stylesheet" href="/browse/assets/browse.css?v=20260816-alpine-apk-1">
+    <link rel="stylesheet" href="/browse/assets/global-component-search.css?v=20260817-global-search-3">
     <link rel="stylesheet" href="/login/assets/login-modal.css?v=20260724-visual-upgrade-1">
   </head>
   <body>
@@ -25,6 +26,11 @@
           <a class="workspace-tab" id="admin-workspace-link" href="/admin/#admin/repository/repositories" hidden>Admin</a>
         </nav>
         <div class="top-spacer"></div>
+        <form class="global-component-search" data-global-component-search action="/browse/" method="get" role="search">
+          <label class="global-component-search-label" for="global-component-search-input">Search components</label>
+          <span class="global-component-search-icon lucide-icon icon-search" aria-hidden="true"></span>
+          <input id="global-component-search-input" name="q" type="search" placeholder="Search components" autocomplete="off">
+        </form>
         <button class="signout" id="login-button" type="button">Sign in</button>
         <div class="user-menu" id="user-menu" hidden>
           <button class="user-menu-trigger" id="user-menu-trigger" type="button" aria-haspopup="menu" aria-expanded="false">
@@ -50,6 +56,7 @@
             <span class="side-caret lucide-icon icon-chevron-down" aria-hidden="true"></span>
           </button>
           <div class="search-subnav" id="search-subnav" hidden>
+            <button class="side-subitem" data-search-format="custom" type="button"><span class="search-all-icon lucide-icon icon-package-search" aria-hidden="true"></span><span>All formats</span></button>
             <button class="side-subitem" data-search-format="cargo" type="button"><span class="format-logo format-logo-cargo" aria-hidden="true"></span><span>Cargo</span></button>
             <button class="side-subitem" data-search-format="go" type="button"><span class="format-logo format-logo-go" aria-hidden="true"></span><span>Go</span></button>
             <button class="side-subitem" data-search-format="helm" type="button"><span class="format-logo format-logo-helm" aria-hidden="true"></span><span>Helm</span></button>
@@ -316,16 +323,16 @@
         <section class="view" id="search-view">
           <div class="page-heading">
             <span class="heading-icon"><span class="lucide-icon icon-search" aria-hidden="true"></span></span>
-            <h1>Search</h1>
+            <h1><span>Search</span> <span id="component-search-format">Maven</span></h1>
             <span class="heading-copy">Search for components by attribute</span>
           </div>
-          <div class="search-form">
+          <form class="search-form" id="component-search-form">
             <label>
               <span>Keyword</span>
               <input id="component-keyword" type="search" placeholder="Any">
             </label>
-            <button class="criteria-button" id="component-search-button" type="button">Search</button>
-          </div>
+            <button class="criteria-button" id="component-search-button" type="submit">Search</button>
+          </form>
           <div class="result-note"><span class="lucide-icon icon-info" aria-hidden="true"></span> Only showing the first 20 of <span id="component-total">0</span> results</div>
           <div class="nx-table-frame">
             <table class="nx-table">
@@ -427,8 +434,9 @@
       </main>
     </div>
 
-    <script src="/login/assets/ui-i18n.js?v=20260710-anonymous-bootstrap-2"></script>
+    <script src="/login/assets/ui-i18n.js?v=20260817-global-search-1"></script>
     <script src="/login/assets/login-modal.js?v=20260812-login-no-reload-1"></script>
-    <script src="/browse/assets/browse.js?v=20260816-alpine-apk-1"></script>
+    <script src="/browse/assets/global-component-search.js?v=20260817-global-search-2"></script>
+    <script src="/browse/assets/browse.js?v=20260817-global-search-2"></script>
   </body>
 </html>

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseGlobalComponentSearchContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseGlobalComponentSearchContractTest.java
@@ -1,0 +1,54 @@
+package com.github.klboke.kkrepo.browse.ui;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import org.junit.jupiter.api.Test;
+
+class BrowseGlobalComponentSearchContractTest {
+
+  @Test
+  void browseExposesGlobalAndAllFormatSearch() throws IOException {
+    String index = resource("/META-INF/resources/browse/index.html");
+    String javascript = resource("/META-INF/resources/browse/assets/browse.js");
+    String sharedJavascript =
+        resource("/META-INF/resources/browse/assets/global-component-search.js");
+    String sharedStylesheet =
+        resource("/META-INF/resources/browse/assets/global-component-search.css");
+
+    assertTrue(index.contains("data-global-component-search action=\"/browse/\""));
+    assertTrue(index.indexOf("class=\"top-spacer\"")
+        < index.indexOf("<form class=\"global-component-search\""));
+    assertTrue(index.contains("placeholder=\"Search components\""));
+    assertFalse(index.contains("<button type=\"submit\">Search</button>"));
+    assertTrue(index.contains("data-search-format=\"custom\""));
+    assertTrue(index.contains("<span>All formats</span>"));
+    assertTrue(index.contains("<form class=\"search-form\" id=\"component-search-form\">"));
+    assertTrue(index.contains("<span id=\"component-search-format\">Maven</span>"));
+    assertTrue(index.contains("/browse/assets/global-component-search.css"));
+    assertTrue(index.contains("/browse/assets/global-component-search.js"));
+
+    assertTrue(javascript.contains("custom: \"custom\""));
+    assertTrue(javascript.contains("if (normalizedFormat !== \"custom\")"));
+    assertTrue(javascript.contains("keyword: new URLSearchParams(query).get(\"q\") || \"\""));
+    assertTrue(javascript.contains("showSearch(route.searchFormat, false, route.keyword)"));
+    assertTrue(javascript.contains("document.getElementById(\"component-search-form\")"));
+    assertTrue(javascript.contains("searchFormatLabel(activeSearchFormat)"));
+
+    assertTrue(sharedJavascript.contains("/browse/#browse/search/custom"));
+    assertTrue(sharedJavascript.contains("locationRef.assign(destination)"));
+    assertTrue(sharedStylesheet.contains(".global-component-search input:focus-visible"));
+    assertTrue(sharedStylesheet.contains("margin: 0 12px 0 24px"));
+    assertTrue(sharedStylesheet.contains("@media (max-width: 760px)"));
+  }
+
+  private String resource(String path) throws IOException {
+    try (InputStream stream = getClass().getResourceAsStream(path)) {
+      return new String(Objects.requireNonNull(stream).readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+}

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseTerraformUploadContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseTerraformUploadContractTest.java
@@ -39,7 +39,7 @@ class BrowseTerraformUploadContractTest {
     assertTrue(javascript.contains("const repoUrl = repositoryBaseUrl().replace(/\\/+$/, \"\")"));
     assertTrue(javascript.contains("crumbIcon: repositoryFormatIcon()"));
     assertTrue(javascript.contains("await activateTreeBranch(entry, toggleExpand)"));
-    assertTrue(index.contains("/browse/assets/browse.js?v=20260816-alpine-apk-1"));
+    assertTrue(index.contains("/browse/assets/browse.js?v=20260817-global-search-2"));
   }
 
   private String resource(String path) throws IOException {

--- a/browse-ui/src/test/js/global-component-search.test.js
+++ b/browse-ui/src/test/js/global-component-search.test.js
@@ -1,0 +1,126 @@
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const { resolve } = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const globalSearch = require(resolve(
+  __dirname,
+  "../../main/resources/META-INF/resources/browse/assets/global-component-search.js",
+));
+
+function loadBrowseSearchHelpers() {
+  const source = readFileSync(resolve(
+    __dirname,
+    "../../main/resources/META-INF/resources/browse/assets/browse.js",
+  ), "utf8");
+  const constantsStart = source.indexOf("const APP_HASH_PREFIX");
+  const constantsEnd = source.indexOf("function installCsrfFetch", constantsStart);
+  const routeStart = source.indexOf("function normalizeSearchFormat");
+  const routeEnd = source.indexOf("function repositoryBrowseHash", routeStart);
+  const parseStart = source.indexOf("function parseBrowseHash");
+  const parseEnd = source.indexOf("function pushBrowseRoute", parseStart);
+  const paramsStart = source.indexOf("function componentSearchParams");
+  const paramsEnd = source.indexOf("async function fetchSearchComponents", paramsStart);
+  for (const boundary of [constantsStart, constantsEnd, routeStart, routeEnd,
+    parseStart, parseEnd, paramsStart, paramsEnd]) {
+    assert.notEqual(boundary, -1, "browse search helper boundary should exist");
+  }
+  const context = vm.createContext({
+    URLSearchParams,
+    readPendingLoginReturnTo: () => null,
+    window: { location: { hash: "" } },
+  });
+  vm.runInContext(`
+    ${source.slice(constantsStart, constantsEnd)}
+    ${source.slice(routeStart, routeEnd)}
+    ${source.slice(parseStart, parseEnd)}
+    ${source.slice(paramsStart, paramsEnd)}
+    globalThis.searchHash = searchHash;
+    globalThis.searchFormatLabel = searchFormatLabel;
+    globalThis.parseBrowseHash = parseBrowseHash;
+    globalThis.componentSearchParams = componentSearchParams;
+  `, context);
+  return context;
+}
+
+test("builds a custom search target and restores its keyword", () => {
+  assert.equal(
+    globalSearch.target("  grpcur  "),
+    "/browse/#browse/search/custom?q=grpcur",
+  );
+  assert.equal(
+    globalSearch.keywordFromHash("#browse/search/custom?q=grpcurl+linux"),
+    "grpcurl linux",
+  );
+  assert.equal(globalSearch.target("   "), null);
+});
+
+test("binds the topbar form, focuses empty input, and navigates on submit", () => {
+  let submit;
+  let assigned = null;
+  let focused = false;
+  const input = {
+    value: "",
+    focus() { focused = true; },
+  };
+  const form = {
+    querySelector() { return input; },
+    addEventListener(type, listener) {
+      if (type === "submit") submit = listener;
+    },
+  };
+  const documentRef = {
+    querySelector(selector) {
+      return selector === "[data-global-component-search]" ? form : input;
+    },
+  };
+  const locationRef = {
+    hash: "#browse/search/custom?q=existing",
+    assign(value) { assigned = value; },
+  };
+
+  globalSearch.bind(documentRef, locationRef);
+  assert.equal(input.value, "existing");
+
+  input.value = " ";
+  submit({ preventDefault() {} });
+  assert.equal(focused, true);
+  assert.equal(assigned, null);
+
+  input.value = " grpcurl ";
+  submit({ preventDefault() {} });
+  assert.equal(assigned, "/browse/#browse/search/custom?q=grpcurl");
+});
+
+test("custom route omits format while format-specific search keeps it", () => {
+  const helpers = loadBrowseSearchHelpers();
+
+  assert.equal(
+    helpers.searchHash("custom", " grpcur "),
+    "#browse/search/custom?q=grpcur",
+  );
+  assert.equal(
+    helpers.componentSearchParams("custom", "grpcur").toString(),
+    "q=grpcur&limit=20",
+  );
+  assert.equal(
+    helpers.componentSearchParams("maven2", "junit").toString(),
+    "q=junit&format=maven2&limit=20",
+  );
+
+  helpers.window.location.hash = "#browse/search/custom?q=grpcurl+linux";
+  const route = helpers.parseBrowseHash();
+  assert.equal(route.view, "search");
+  assert.equal(route.searchFormat, "custom");
+  assert.equal(route.keyword, "grpcurl linux");
+});
+
+test("uses the selected repository format in the search page title", () => {
+  const helpers = loadBrowseSearchHelpers();
+
+  assert.equal(helpers.searchFormatLabel("custom"), "All formats");
+  assert.equal(helpers.searchFormatLabel("maven2"), "Maven");
+  assert.equal(helpers.searchFormatLabel("ansiblegalaxy"), "Ansible Galaxy");
+  assert.equal(helpers.searchFormatLabel("alpine"), "Alpine / APK");
+});

--- a/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/api/ComponentDao.java
+++ b/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/api/ComponentDao.java
@@ -66,6 +66,25 @@ public interface ComponentDao {
       String keyword,
       int limit);
 
+  /**
+   * Returns a stable search page scoped to repositories the caller has already authorized.
+   *
+   * <p>The cursor follows {@code last_updated_at DESC, id DESC}. The default keeps lightweight
+   * adapters source-compatible for the first page; production implementations must override this
+   * method when callers need to continue after a cursor.
+   */
+  default List<ComponentSearchRow> searchPageByRepositoryIds(
+      List<Long> repositoryIds,
+      RepositoryFormat format,
+      String keyword,
+      ComponentSearchCursor after,
+      int limit) {
+    if (after != null) {
+      throw new UnsupportedOperationException("component search cursor is not supported");
+    }
+    return searchByRepositoryIds(repositoryIds, format, keyword, limit);
+  }
+
   List<ComponentRecord> searchComponentsByRepositoryIds(
       List<Long> repositoryIds,
       RepositoryFormat format,
@@ -93,6 +112,12 @@ public interface ComponentDao {
       String kind,
       java.time.Instant lastUpdatedAt,
       String storagePath) {
+  }
+
+  record ComponentSearchCursor(java.time.Instant lastUpdatedAt, long id) {
+    public static ComponentSearchCursor after(ComponentSearchRow row) {
+      return new ComponentSearchCursor(row.lastUpdatedAt(), row.id());
+    }
   }
 
   record CleanupFamilyCursor(String namespace, String name, String kind) {

--- a/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/JdbcComponentDao.java
+++ b/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/JdbcComponentDao.java
@@ -4,6 +4,7 @@ import static com.github.klboke.kkrepo.persistence.jdbc.internal.support.JdbcRow
 import static com.github.klboke.kkrepo.persistence.jdbc.internal.support.JdbcRows.nullableTimestamp;
 
 import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.persistence.jdbc.api.ComponentDao.ComponentSearchCursor;
 import com.github.klboke.kkrepo.persistence.jdbc.api.ComponentDao.ComponentSearchRow;
 import com.github.klboke.kkrepo.persistence.jdbc.api.ComponentDao.CleanupFamilyCursor;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.ComponentRecord;
@@ -20,6 +21,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -31,6 +33,10 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public class JdbcComponentDao implements com.github.klboke.kkrepo.persistence.jdbc.api.ComponentDao {
+  private static final int FULLTEXT_PLAN_PROBE_THRESHOLD = 5_000;
+  private static final int FULLTEXT_PLAN_PROBE_LIMIT = FULLTEXT_PLAN_PROBE_THRESHOLD + 1;
+  private static final int SEARCH_PLAN_CACHE_MAX_ENTRIES = 256;
+  private static final long SEARCH_PLAN_CACHE_TTL_NANOS = 30_000_000_000L;
   private static final String INSERT_SQL = """
       INSERT INTO component
         (repository_id, format, namespace, name, version, kind, coordinate_hash,
@@ -56,6 +62,10 @@ public class JdbcComponentDao implements com.github.klboke.kkrepo.persistence.jd
   private final String searchSelect;
   private final List<String> cleanupFamilyOrder;
   private final RowMapper<ComponentRecord> rowMapper;
+  // Advisory node-local cache only: both plans enforce identical repository predicates and
+  // ordering. Cache loss, expiry, or disagreement across replicas can only change query cost.
+  private final LinkedHashMap<ComponentSearchPlanKey, ComponentSearchPlanEntry> searchPlanCache =
+      new LinkedHashMap<>(16, 0.75f, true);
 
   @Autowired
   public JdbcComponentDao(
@@ -284,36 +294,153 @@ public class JdbcComponentDao implements com.github.klboke.kkrepo.persistence.jd
       RepositoryFormat format,
       String keyword,
       int limit) {
+    return searchPageByRepositoryIds(repositoryIds, format, keyword, null, limit);
+  }
+
+  @Override
+  public List<ComponentSearchRow> searchPageByRepositoryIds(
+      List<Long> repositoryIds,
+      RepositoryFormat format,
+      String keyword,
+      ComponentSearchCursor after,
+      int limit) {
     if (repositoryIds == null || repositoryIds.isEmpty()) {
       return List.of();
     }
     String normalized = keyword == null ? "" : keyword.trim();
     int safeLimit = Math.max(1, Math.min(limit, 300));
     String placeholders = String.join(",", Collections.nCopies(repositoryIds.size(), "?"));
+    String booleanQuery = normalized.isEmpty()
+        ? ""
+        : searchDialect.prepareComponentQuery(normalized);
+    if (!normalized.isEmpty() && booleanQuery.isBlank()) {
+      return List.of();
+    }
+    boolean fullText = !booleanQuery.isBlank();
+    boolean denseFullText = fullText
+        && searchDialect.supportsAdaptiveComponentSearch()
+        && denseFullTextSearch(repositoryIds, format, booleanQuery, placeholders);
+    boolean orderedPlan = !fullText || denseFullText;
+    String hint = orderedPlan
+        ? searchDialect.orderedComponentSearchHint(
+            format != null, repositoryIds.size() == 1, fullText)
+        : "";
     List<Object> args = new ArrayList<>(repositoryIds);
-    args.add(EnumColumns.write(format));
-    StringBuilder sql = new StringBuilder(searchProjection).append("""
-        FROM component c
-        JOIN repository r ON r.id = c.repository_id
-        WHERE c.repository_id IN (
-        """);
-    sql.append(placeholders).append(") AND c.format = ?\n");
-    if (!normalized.isEmpty()) {
-      String booleanQuery = searchDialect.prepareComponentQuery(normalized);
-      if (booleanQuery.isBlank()) return List.of();
-      int fromIndex = sql.indexOf("FROM component c");
-      sql.replace(fromIndex, fromIndex + "FROM component c".length(), """
+    StringBuilder sql = new StringBuilder(hintedSearchProjection(hint));
+    if (!orderedPlan) {
+      sql.append("""
           FROM component_search cs
-          JOIN component c ON c.id = cs.component_id""");
+          JOIN component c ON c.id = cs.component_id
+          """);
+    } else {
+      sql.append("""
+          FROM component search_order
+          """);
+      if (fullText) {
+        sql.append("JOIN component_search cs ON cs.component_id = search_order.id\n");
+      }
+      // Keep the ordered scan index-only until the permission/full-text predicates have selected
+      // a result. This avoids fetching every skipped component row for sparse repository scopes.
+      sql.append("JOIN component c ON c.id = search_order.id\n");
+    }
+    sql.append("JOIN repository r ON r.id = c.repository_id\nWHERE ")
+        .append(orderedPlan ? "search_order" : "c")
+        .append(".repository_id IN (\n");
+    sql.append(placeholders).append(")\n");
+    if (format != null) {
+      sql.append("  AND ")
+          .append(orderedPlan ? "search_order" : "c")
+          .append(".format = ?\n");
+      args.add(EnumColumns.write(format));
+    }
+    if (fullText) {
+      // component_search is the cheapest place to discard unauthorized full-text hits. Keep the
+      // component predicate above as the authoritative defense if a denormalized row ever drifts.
+      sql.append("  AND cs.repository_id IN (").append(placeholders).append(")\n");
+      args.addAll(repositoryIds);
       sql.append("  AND ").append(searchDialect.componentSearchPredicate("cs")).append('\n');
       args.add(booleanQuery);
     }
-    sql.append("""
-        ORDER BY c.last_updated_at DESC, r.name, c.namespace, c.name, c.version
-        LIMIT ?
-        """);
+    sql.append("  AND ").append(SEARCH_VISIBLE_PREDICATE).append('\n');
+    String orderAlias = orderedPlan ? "search_order" : "c";
+    if (after != null && after.lastUpdatedAt() != null) {
+      sql.append("  AND (").append(orderAlias).append(".last_updated_at < ?\n")
+          .append("       OR (").append(orderAlias).append(".last_updated_at = ? AND ")
+          .append(orderAlias).append(".id < ?)\n")
+          .append("       OR ").append(orderAlias).append(".last_updated_at IS NULL)\n");
+      args.add(nullableTimestamp(after.lastUpdatedAt()));
+      args.add(nullableTimestamp(after.lastUpdatedAt()));
+      args.add(after.id());
+    } else if (after != null) {
+      sql.append("  AND ").append(orderAlias).append(".last_updated_at IS NULL AND ")
+          .append(orderAlias).append(".id < ?\n");
+      args.add(after.id());
+    }
+    sql.append("ORDER BY ")
+        .append(searchDialect.componentSearchOrderBy(orderAlias))
+        .append("\nLIMIT ?\n");
     args.add(safeLimit);
     return jdbcTemplate.query(sql.toString(), searchRowMapper, args.toArray());
+  }
+
+  private boolean denseFullTextSearch(
+      List<Long> repositoryIds,
+      RepositoryFormat format,
+      String booleanQuery,
+      String placeholders) {
+    ComponentSearchPlanKey key = new ComponentSearchPlanKey(
+        repositoryIds.stream().distinct().sorted().toList(), format, booleanQuery);
+    long now = System.nanoTime();
+    synchronized (searchPlanCache) {
+      ComponentSearchPlanEntry cached = searchPlanCache.get(key);
+      if (cached != null && cached.expiresAtNanos() > now) {
+        return cached.dense();
+      }
+      if (cached != null) {
+        searchPlanCache.remove(key);
+      }
+    }
+
+    List<Object> args = new ArrayList<>(repositoryIds);
+    StringBuilder sql = new StringBuilder("""
+        SELECT cs.component_id
+        FROM component_search cs
+        WHERE cs.repository_id IN (
+        """).append(placeholders).append(")\n");
+    if (format != null) {
+      sql.append("  AND cs.format = ?\n");
+      args.add(EnumColumns.write(format));
+    }
+    sql.append("  AND ").append(searchDialect.componentSearchPredicate("cs")).append('\n');
+    args.add(booleanQuery);
+    sql.append("LIMIT ?\n");
+    args.add(FULLTEXT_PLAN_PROBE_LIMIT);
+    boolean dense = jdbcTemplate.queryForList(
+        sql.toString(), Long.class, args.toArray()).size() > FULLTEXT_PLAN_PROBE_THRESHOLD;
+
+    synchronized (searchPlanCache) {
+      if (!searchPlanCache.containsKey(key)
+          && searchPlanCache.size() >= SEARCH_PLAN_CACHE_MAX_ENTRIES) {
+        var oldest = searchPlanCache.keySet().iterator();
+        if (oldest.hasNext()) {
+          oldest.next();
+          oldest.remove();
+        }
+      }
+      searchPlanCache.put(
+          key, new ComponentSearchPlanEntry(dense, now + SEARCH_PLAN_CACHE_TTL_NANOS));
+    }
+    return dense;
+  }
+
+  private String hintedSearchProjection(String hint) {
+    if (hint == null || hint.isBlank()) {
+      return searchProjection;
+    }
+    if (!searchProjection.startsWith("SELECT ")) {
+      throw new IllegalStateException("component search projection must start with SELECT");
+    }
+    return "SELECT " + hint + " " + searchProjection.substring("SELECT ".length());
   }
 
   public List<ComponentRecord> searchComponentsByRepositoryIds(
@@ -465,5 +592,15 @@ public class JdbcComponentDao implements com.github.klboke.kkrepo.persistence.jd
       rs.getString("kind"),
       nullableInstant(rs, "last_updated_at"),
       rs.getString("storage_path"));
+
+  private record ComponentSearchPlanKey(
+      List<Long> repositoryIds, RepositoryFormat format, String booleanQuery) {
+    private ComponentSearchPlanKey {
+      repositoryIds = List.copyOf(repositoryIds);
+    }
+  }
+
+  private record ComponentSearchPlanEntry(boolean dense, long expiresAtNanos) {
+  }
 
 }

--- a/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/spi/SearchPersistenceDialect.java
+++ b/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/spi/SearchPersistenceDialect.java
@@ -5,4 +5,28 @@ public interface SearchPersistenceDialect {
   String componentSearchPredicate(String searchAlias);
 
   String prepareComponentQuery(String keyword);
+
+  /** Stable newest-first order with null timestamps placed last. */
+  String componentSearchOrderBy(String componentAlias);
+
+  /**
+   * Whether broad full-text searches should probe cardinality before choosing the access path.
+   *
+   * <p>This is an execution-plan choice only. Both paths must enforce the same repository scope
+   * and return the same ordered rows.
+   */
+  default boolean supportsAdaptiveComponentSearch() {
+    return false;
+  }
+
+  /**
+   * Optional optimizer hint for a time-ordered component search.
+   *
+   * <p>The hint is inserted immediately after {@code SELECT}. Backends that cost full-text and
+   * B-tree plans reliably can return an empty string.
+   */
+  default String orderedComponentSearchHint(
+      boolean formatScoped, boolean singleRepository, boolean fullText) {
+    return "";
+  }
 }

--- a/persistence-jdbc/src/test/java/com/github/klboke/kkrepo/persistence/jdbc/api/PersistenceApiContractsTest.java
+++ b/persistence-jdbc/src/test/java/com/github/klboke/kkrepo/persistence/jdbc/api/PersistenceApiContractsTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.klboke.kkrepo.core.RepositoryFormat;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 import java.time.Instant;
@@ -129,6 +131,51 @@ class PersistenceApiContractsTest {
         Map.of(1L, 11L, 2L, 22L),
         conan.currentRepositoryRevisions(List.of(1L, 2L, 1L)));
     assertEquals(List.of(1L, 2L), lookups);
+  }
+
+  @Test
+  void componentSearchDefaultDelegatesTheFirstPageAndRejectsACursor() {
+    ComponentDao.ComponentSearchRow row = new ComponentDao.ComponentSearchRow(
+        7L,
+        11L,
+        "releases",
+        RepositoryFormat.MAVEN2,
+        "com.acme",
+        "library",
+        "1.0.0",
+        "component",
+        Instant.EPOCH,
+        null);
+    ComponentDao components = (ComponentDao) Proxy.newProxyInstance(
+        ComponentDao.class.getClassLoader(),
+        new Class<?>[] {ComponentDao.class},
+        (proxy, method, arguments) -> {
+          if (method.isDefault()) {
+            return InvocationHandler.invokeDefault(proxy, method, arguments);
+          }
+          if (method.getName().equals("searchByRepositoryIds")
+              && method.getParameterCount() == 4) {
+            assertEquals(List.of(11L), arguments[0]);
+            assertEquals(RepositoryFormat.MAVEN2, arguments[1]);
+            assertEquals("library", arguments[2]);
+            assertEquals(25, arguments[3]);
+            return List.of(row);
+          }
+          throw new UnsupportedOperationException(method.getName());
+        });
+
+    assertEquals(
+        List.of(row),
+        components.searchPageByRepositoryIds(
+            List.of(11L), RepositoryFormat.MAVEN2, "library", null, 25));
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> components.searchPageByRepositoryIds(
+            List.of(11L),
+            RepositoryFormat.MAVEN2,
+            "library",
+            ComponentDao.ComponentSearchCursor.after(row),
+            25));
   }
 
   private static BrowseNodeDao.BrowseChild browseChild(Long assetId, boolean hasChildren) {

--- a/persistence-jdbc/src/test/java/com/github/klboke/kkrepo/persistence/jdbc/contract/PersistenceApiContract.java
+++ b/persistence-jdbc/src/test/java/com/github/klboke/kkrepo/persistence/jdbc/contract/PersistenceApiContract.java
@@ -15,6 +15,7 @@ import com.github.klboke.kkrepo.core.RepositoryType;
 import com.github.klboke.kkrepo.persistence.jdbc.api.AnsibleGalaxyRegistryDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.ArtifactChangeDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.CleanupPolicyDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.ComponentDao.ComponentSearchCursor;
 import com.github.klboke.kkrepo.persistence.jdbc.api.DockerAuthTokenDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.DockerAuthTokenDao.ScannerResourceKind;
 import com.github.klboke.kkrepo.persistence.jdbc.api.DockerAuthTokenDao.ScannerTokenResource;
@@ -4360,6 +4361,9 @@ public abstract class PersistenceApiContract {
         otherMavenRepository, RepositoryFormat.MAVEN2, "org.example", "observability-library",
         "3.0.0", Map.of("keywords", "telemetry tracing"), Instant.parse("2026-07-13T08:00:00Z")));
     stores().components().upsertReturningId(component(
+        otherMavenRepository, RepositoryFormat.MAVEN2, "org.example", "unknown-update",
+        "0.0.0", Map.of("keywords", "unknown timestamp"), null));
+    stores().components().upsertReturningId(component(
         npmRepository, RepositoryFormat.NPM, "@acme", "observability-library",
         "4.0.0", Map.of("keywords", "telemetry tracing"), Instant.parse("2026-07-13T11:00:00Z")));
     stores().components().upsertReturningId(component(
@@ -4378,6 +4382,45 @@ public abstract class PersistenceApiContract {
         .stream().map(row -> row.version()).toList());
     assertEquals(List.of("2.0.0", "3.0.0"),
         stores().components().search("telemetry tracing", RepositoryFormat.MAVEN2, 20)
+            .stream().map(row -> row.version()).toList());
+    var firstScopedPage = stores().components().searchPageByRepositoryIds(
+        List.of(mavenRepository, otherMavenRepository),
+        RepositoryFormat.MAVEN2,
+        "telemetry tracing",
+        null,
+        1);
+    var secondScopedPage = stores().components().searchPageByRepositoryIds(
+        List.of(mavenRepository, otherMavenRepository),
+        RepositoryFormat.MAVEN2,
+        "telemetry tracing",
+        ComponentSearchCursor.after(firstScopedPage.getFirst()),
+        1);
+    assertEquals(List.of("2.0.0"),
+        firstScopedPage.stream().map(row -> row.version()).toList());
+    assertEquals(List.of("3.0.0"),
+        secondScopedPage.stream().map(row -> row.version()).toList());
+    var newestMavenRows = stores().components().searchPageByRepositoryIds(
+        List.of(mavenRepository, otherMavenRepository), RepositoryFormat.MAVEN2, null, null, 3);
+    assertEquals(List.of("2.0.0", "1.0.0", "3.0.0"),
+        newestMavenRows.stream().map(row -> row.version()).toList());
+    var nullTimestampPage = stores().components().searchPageByRepositoryIds(
+        List.of(mavenRepository, otherMavenRepository),
+        RepositoryFormat.MAVEN2,
+        null,
+        ComponentSearchCursor.after(newestMavenRows.getLast()),
+        3);
+    assertEquals(List.of("0.0.0"),
+        nullTimestampPage.stream().map(row -> row.version()).toList());
+    assertNull(nullTimestampPage.getFirst().lastUpdatedAt());
+    assertTrue(stores().components().searchPageByRepositoryIds(
+        List.of(mavenRepository, otherMavenRepository),
+        RepositoryFormat.MAVEN2,
+        null,
+        ComponentSearchCursor.after(nullTimestampPage.getFirst()),
+        3).isEmpty());
+    assertEquals(List.of("4.0.0", "2.0.0"),
+        stores().components().searchPageByRepositoryIds(
+                List.of(mavenRepository, npmRepository), null, "telemetry tracing", null, 2)
             .stream().map(row -> row.version()).toList());
     assertFalse(stores().components().search("telemetry", RepositoryFormat.NPM, 20).isEmpty());
     assertEquals(migratedAlpinePackage,

--- a/persistence-mysql/src/main/java/com/github/klboke/kkrepo/persistence/mysql/MySqlDatabaseDialect.java
+++ b/persistence-mysql/src/main/java/com/github/klboke/kkrepo/persistence/mysql/MySqlDatabaseDialect.java
@@ -454,6 +454,40 @@ public final class MySqlDatabaseDialect implements DatabaseDialect {
       return String.join(" ", terms);
     }
 
+    @Override
+    public String componentSearchOrderBy(String componentAlias) {
+      requireAlias(componentAlias);
+      // MySQL sorts NULL below non-NULL values, so a descending scan naturally places NULL last.
+      return componentAlias + ".last_updated_at DESC, " + componentAlias + ".id DESC";
+    }
+
+    @Override
+    public boolean supportsAdaptiveComponentSearch() {
+      return true;
+    }
+
+    @Override
+    public String orderedComponentSearchHint(
+        boolean formatScoped, boolean singleRepository, boolean fullText) {
+      String index = singleRepository
+          ? formatScoped
+              ? "idx_component_repo_format_updated"
+              : "idx_component_repo_last_updated"
+          : formatScoped
+              ? "idx_component_format_last_updated"
+              : "idx_component_last_updated";
+      String joinOrder = fullText
+          ? "JOIN_ORDER(search_order, cs, c, r)"
+          : "JOIN_ORDER(search_order, c, r)";
+      return "/*+ " + joinOrder + " INDEX(search_order " + index + ") */";
+    }
+
+    private static void requireAlias(String alias) {
+      if (alias == null || !ALIAS.matcher(alias).matches()) {
+        throw new IllegalArgumentException("Unsafe component search alias: " + alias);
+      }
+    }
+
     private static void addTerm(List<String> terms, StringBuilder token) {
       if (!token.isEmpty()) {
         terms.add("+" + token + "*");

--- a/persistence-mysql/src/main/resources/db/migration/mysql/V47__component_search_ordering_indexes.sql
+++ b/persistence-mysql/src/main/resources/db/migration/mysql/V47__component_search_ordering_indexes.sql
@@ -1,0 +1,16 @@
+-- Keep repository authorization and newest-first pagination indexable at large component counts.
+-- Replacing the three prefix-equivalent indexes avoids permanent duplicate write amplification.
+ALTER TABLE component
+  DROP INDEX idx_component_last_updated,
+  DROP INDEX idx_component_format_last_updated,
+  DROP INDEX idx_component_repo_format_updated,
+  ADD INDEX idx_component_last_updated
+    (last_updated_at, id, repository_id, format),
+  ADD INDEX idx_component_format_last_updated
+    (format, last_updated_at, id, repository_id),
+  ADD INDEX idx_component_repo_format_updated
+    (repository_id, format, last_updated_at, id),
+  ADD INDEX idx_component_repo_last_updated
+    (repository_id, last_updated_at, id),
+  ALGORITHM=INPLACE,
+  LOCK=NONE;

--- a/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/MySqlDatabaseDialectTest.java
+++ b/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/MySqlDatabaseDialectTest.java
@@ -49,10 +49,24 @@ class MySqlDatabaseDialectTest {
         "+kkrepo* +alpine* +migration* +app* +datastore_h2_31894582966_1*",
         dialect.search().prepareComponentQuery(
             "kkrepo-alpine-migration-app-datastore_h2_31894582966_1"));
+    assertEquals(
+        "c.last_updated_at DESC, c.id DESC",
+        dialect.search().componentSearchOrderBy("c"));
+    assertTrue(dialect.search().supportsAdaptiveComponentSearch());
+    assertEquals(
+        "/*+ JOIN_ORDER(search_order, cs, c, r) "
+            + "INDEX(search_order idx_component_format_last_updated) */",
+        dialect.search().orderedComponentSearchHint(true, false, true));
+    assertEquals(
+        "/*+ JOIN_ORDER(search_order, c, r) "
+            + "INDEX(search_order idx_component_repo_last_updated) */",
+        dialect.search().orderedComponentSearchHint(false, true, false));
     assertThrows(IllegalArgumentException.class,
         () -> dialect.json().extractText("attributes_json; DROP TABLE asset", "key"));
     assertThrows(IllegalArgumentException.class,
         () -> dialect.search().componentSearchPredicate("s JOIN component"));
+    assertThrows(IllegalArgumentException.class,
+        () -> dialect.search().componentSearchOrderBy("c; DROP TABLE component"));
   }
 
   @Test

--- a/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/MySqlDatabaseDialectTest.java
+++ b/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/MySqlDatabaseDialectTest.java
@@ -58,6 +58,10 @@ class MySqlDatabaseDialectTest {
             + "INDEX(search_order idx_component_format_last_updated) */",
         dialect.search().orderedComponentSearchHint(true, false, true));
     assertEquals(
+        "/*+ JOIN_ORDER(search_order, cs, c, r) "
+            + "INDEX(search_order idx_component_repo_format_updated) */",
+        dialect.search().orderedComponentSearchHint(true, true, true));
+    assertEquals(
         "/*+ JOIN_ORDER(search_order, c, r) "
             + "INDEX(search_order idx_component_repo_last_updated) */",
         dialect.search().orderedComponentSearchHint(false, true, false));

--- a/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/MySqlV29MigrationCompatibilityTest.java
+++ b/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/MySqlV29MigrationCompatibilityTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 /** Guards the frozen V1-V29 chain and validates repeat startup after newer migrations. */
 class MySqlV29MigrationCompatibilityTest extends MySqlIntegrationTestSupport {
-  private static final int LATEST_MIGRATION = 46;
+  private static final int LATEST_MIGRATION = 47;
   private static final Map<String, String> V29_SHA256 = checksums();
 
   @Test

--- a/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/ComponentDaoTest.java
+++ b/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/ComponentDaoTest.java
@@ -13,6 +13,7 @@ import java.lang.reflect.Proxy;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -153,6 +154,52 @@ class ComponentDaoTest {
     assertTrue(jdbcTemplate.sql.contains("END AS storage_path"));
     assertTrue(jdbcTemplate.sql.contains("c.format = ?"));
     assertTrue(jdbcTemplate.sql.contains("MATCH(cs.namespace, cs.name, cs.version, cs.keywords)"));
+    assertTrue(jdbcTemplate.probeSql.contains("WHERE cs.repository_id IN"));
+  }
+
+  @Test
+  void newestRepositoryScopedSearchUsesTheOrderedAuthorizationIndex() {
+    RecordingJdbcTemplate jdbcTemplate = new RecordingJdbcTemplate();
+    ComponentDao dao = new JdbcComponentDao(
+        jdbcTemplate,
+        new JsonColumns(new ObjectMapper(), DIALECT),
+        DIALECT);
+
+    dao.searchPageByRepositoryIds(
+        List.of(1L, 2L), RepositoryFormat.NPM, null, null, 20);
+
+    assertTrue(jdbcTemplate.sql.contains(
+        "/*+ JOIN_ORDER(search_order, c, r) "
+            + "INDEX(search_order idx_component_format_last_updated) */"));
+    assertTrue(jdbcTemplate.sql.contains(
+        "ORDER BY search_order.last_updated_at DESC, search_order.id DESC"));
+    assertTrue(jdbcTemplate.sql.contains(
+        "JOIN component c ON c.id = search_order.id"));
+    Assertions.assertFalse(jdbcTemplate.sql.contains("CASE WHEN c.last_updated_at IS NULL"));
+  }
+
+  @Test
+  void broadFulltextSearchSwitchesToTheTimeOrderedPlan() {
+    RecordingJdbcTemplate jdbcTemplate = new RecordingJdbcTemplate(5_001);
+    ComponentDao dao = new JdbcComponentDao(
+        jdbcTemplate,
+        new JsonColumns(new ObjectMapper(), DIALECT),
+        DIALECT);
+
+    dao.searchPageByRepositoryIds(
+        List.of(1L, 2L), RepositoryFormat.NPM, "common", null, 20);
+    dao.searchPageByRepositoryIds(
+        List.of(1L, 2L), RepositoryFormat.NPM, "common", null, 20);
+
+    assertTrue(jdbcTemplate.probeSql.contains("FROM component_search cs"));
+    assertTrue(jdbcTemplate.probeSql.contains("LIMIT ?"));
+    Assertions.assertEquals(1, jdbcTemplate.probeCalls);
+    assertTrue(jdbcTemplate.sql.contains(
+        "/*+ JOIN_ORDER(search_order, cs, c, r) "
+            + "INDEX(search_order idx_component_format_last_updated) */"));
+    assertTrue(jdbcTemplate.sql.indexOf("FROM component search_order")
+        < jdbcTemplate.sql.indexOf("JOIN component_search cs"));
+    assertTrue(jdbcTemplate.sql.contains("AND cs.repository_id IN"));
   }
 
   @Test
@@ -206,12 +253,34 @@ class ComponentDaoTest {
   }
 
   private static final class RecordingJdbcTemplate extends JdbcTemplate {
+    private final int probeRows;
     private String sql;
+    private String probeSql;
+    private int probeCalls;
+
+    private RecordingJdbcTemplate() {
+      this(0);
+    }
+
+    private RecordingJdbcTemplate(int probeRows) {
+      this.probeRows = probeRows;
+    }
 
     @Override
     public <T> List<T> query(String sql, RowMapper<T> rowMapper, Object... args) {
       this.sql = sql;
       return List.of();
+    }
+
+    @Override
+    public <T> List<T> queryForList(String sql, Class<T> elementType, Object... args) {
+      this.probeSql = sql;
+      this.probeCalls++;
+      List<T> rows = new ArrayList<>(probeRows);
+      for (int index = 0; index < probeRows; index++) {
+        rows.add(elementType.cast(1L));
+      }
+      return rows;
     }
   }
 

--- a/persistence-postgresql/src/main/java/com/github/klboke/kkrepo/persistence/postgresql/PostgreSqlDatabaseDialect.java
+++ b/persistence-postgresql/src/main/java/com/github/klboke/kkrepo/persistence/postgresql/PostgreSqlDatabaseDialect.java
@@ -389,6 +389,15 @@ public final class PostgreSqlDatabaseDialect implements DatabaseDialect {
       return String.join(" & ", terms);
     }
 
+    @Override
+    public String componentSearchOrderBy(String componentAlias) {
+      if (componentAlias == null || !ALIAS.matcher(componentAlias).matches()) {
+        throw new IllegalArgumentException("Unsafe component search alias: " + componentAlias);
+      }
+      return componentAlias + ".last_updated_at DESC NULLS LAST, "
+          + componentAlias + ".id DESC";
+    }
+
     private static void addTerm(List<String> terms, StringBuilder token) {
       if (!token.isEmpty()) {
         terms.add(token + ":*");

--- a/persistence-postgresql/src/main/resources/db/migration/postgresql/V47__component_search_ordering_indexes.sql
+++ b/persistence-postgresql/src/main/resources/db/migration/postgresql/V47__component_search_ordering_indexes.sql
@@ -1,0 +1,26 @@
+-- Build replacements before swapping names so component writes remain available throughout the
+-- potentially long index scans. The _v2 names also make a repaired Flyway run deterministic.
+DROP INDEX CONCURRENTLY IF EXISTS idx_component_last_updated_v2;
+CREATE INDEX CONCURRENTLY idx_component_last_updated_v2
+  ON component (last_updated_at DESC NULLS LAST, id DESC, repository_id, format);
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_component_format_last_updated_v2;
+CREATE INDEX CONCURRENTLY idx_component_format_last_updated_v2
+  ON component (format, last_updated_at DESC NULLS LAST, id DESC, repository_id);
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_component_repo_format_updated_v2;
+CREATE INDEX CONCURRENTLY idx_component_repo_format_updated_v2
+  ON component (repository_id, format, last_updated_at DESC NULLS LAST, id DESC);
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_component_repo_last_updated;
+CREATE INDEX CONCURRENTLY idx_component_repo_last_updated
+  ON component (repository_id, last_updated_at DESC NULLS LAST, id DESC);
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_component_last_updated;
+ALTER INDEX idx_component_last_updated_v2 RENAME TO idx_component_last_updated;
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_component_format_last_updated;
+ALTER INDEX idx_component_format_last_updated_v2 RENAME TO idx_component_format_last_updated;
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_component_repo_format_updated;
+ALTER INDEX idx_component_repo_format_updated_v2 RENAME TO idx_component_repo_format_updated;

--- a/persistence-postgresql/src/main/resources/db/migration/postgresql/V47__component_search_ordering_indexes.sql.conf
+++ b/persistence-postgresql/src/main/resources/db/migration/postgresql/V47__component_search_ordering_indexes.sql.conf
@@ -1,0 +1,1 @@
+executeInTransaction=false

--- a/persistence-postgresql/src/test/java/com/github/klboke/kkrepo/persistence/postgresql/PostgreSqlDatabaseDialectTest.java
+++ b/persistence-postgresql/src/test/java/com/github/klboke/kkrepo/persistence/postgresql/PostgreSqlDatabaseDialectTest.java
@@ -1,6 +1,7 @@
 package com.github.klboke.kkrepo.persistence.postgresql;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -50,6 +51,11 @@ class PostgreSqlDatabaseDialectTest {
         dialect.search().prepareComponentQuery("Com.Example artifact-1.0"));
     assertEquals("", dialect.search().prepareComponentQuery("  --  "));
     assertEquals(
+        "c.last_updated_at DESC NULLS LAST, c.id DESC",
+        dialect.search().componentSearchOrderBy("c"));
+    assertFalse(dialect.search().supportsAdaptiveComponentSearch());
+    assertEquals("", dialect.search().orderedComponentSearchHint(true, false, true));
+    assertEquals(
         "COALESCE(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - MIN(enqueued_at))), 0)",
         dialect.coordination().oldestBacklogAgeSecondsExpression("enqueued_at"));
 
@@ -61,6 +67,8 @@ class PostgreSqlDatabaseDialectTest {
         () -> dialect.json().extractText("attributes_json"));
     assertThrows(IllegalArgumentException.class,
         () -> dialect.search().componentSearchPredicate("s JOIN component"));
+    assertThrows(IllegalArgumentException.class,
+        () -> dialect.search().componentSearchOrderBy("c; DROP TABLE component"));
     assertThrows(IllegalArgumentException.class,
         () -> dialect.coordination().oldestBacklogAgeSecondsExpression("created_at) FROM asset"));
   }

--- a/persistence-postgresql/src/test/java/com/github/klboke/kkrepo/persistence/postgresql/PostgreSqlMigrationCompatibilityTest.java
+++ b/persistence-postgresql/src/test/java/com/github/klboke/kkrepo/persistence/postgresql/PostgreSqlMigrationCompatibilityTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 
 /** Proves the PostgreSQL baseline validates and remains idempotent on repeated startup. */
 class PostgreSqlMigrationCompatibilityTest extends PostgreSqlIntegrationTestSupport {
-  private static final int LATEST_MIGRATION = 46;
+  private static final int LATEST_MIGRATION = 47;
 
   @Test
   void baselineValidatesAndSecondMigrateHasNoPendingWork() {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/browse/ComponentSearchController.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/browse/ComponentSearchController.java
@@ -4,26 +4,37 @@ import com.github.klboke.kkrepo.auth.AccessDecision;
 import com.github.klboke.kkrepo.auth.PermissionAction;
 import com.github.klboke.kkrepo.auth.RepositoryPermission;
 import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.jdbc.api.AssetDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.ComponentDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.ComponentDao.ComponentSearchCursor;
 import com.github.klboke.kkrepo.persistence.jdbc.api.ComponentDao.ComponentSearchRow;
 import com.github.klboke.kkrepo.persistence.jdbc.api.AnsibleGalaxyRegistryDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.AptRegistryDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.AlpineRegistryDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.CondaRegistryDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.SwiftRegistryDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.model.AssetRecord;
+import com.github.klboke.kkrepo.persistence.jdbc.api.model.RepositoryRecord;
 import com.github.klboke.kkrepo.protocol.conda.CondaPath;
 import com.github.klboke.kkrepo.server.conda.CondaBrowsePaths;
+import com.github.klboke.kkrepo.server.repositories.RepositoryCatalogCache;
 import com.github.klboke.kkrepo.server.security.AuthenticatedSubject;
 import com.github.klboke.kkrepo.server.security.SecurityAuthenticationService;
 import com.github.klboke.kkrepo.server.security.SecurityManagementService;
+import com.github.klboke.kkrepo.server.security.SecurityManagementService.RepositoryAccessMode;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.Instant;
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.LinkedHashMap;
+import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -36,11 +47,15 @@ import org.springframework.web.server.ResponseStatusException;
 @RequestMapping("/internal/search/components")
 public class ComponentSearchController {
   private static final int DEFAULT_LIMIT = 300;
+  private static final int SELECTOR_PAGE_SIZE = 200;
+  private static final int MAX_SELECTOR_CANDIDATES = 1_000;
 
   private final ComponentDao componentDao;
+  private final AssetDao assetDao;
   private final SecurityAuthenticationService authenticationService;
   private final SecurityManagementService securityService;
   private final SwiftRegistryDao swiftRegistry;
+  private final RepositoryCatalogCache repositoryCatalogCache;
   private AnsibleGalaxyRegistryDao ansibleRegistry;
   private AptRegistryDao aptRegistry;
   private AlpineRegistryDao alpineRegistry;
@@ -49,13 +64,17 @@ public class ComponentSearchController {
   @Autowired
   public ComponentSearchController(
       ComponentDao componentDao,
+      AssetDao assetDao,
       SecurityAuthenticationService authenticationService,
       SecurityManagementService securityService,
-      SwiftRegistryDao swiftRegistry) {
+      SwiftRegistryDao swiftRegistry,
+      RepositoryCatalogCache repositoryCatalogCache) {
     this.componentDao = componentDao;
+    this.assetDao = assetDao;
     this.authenticationService = authenticationService;
     this.securityService = securityService;
     this.swiftRegistry = swiftRegistry;
+    this.repositoryCatalogCache = repositoryCatalogCache;
   }
 
   @Autowired(required = false)
@@ -76,13 +95,6 @@ public class ComponentSearchController {
   @Autowired(required = false)
   void setCondaRegistry(CondaRegistryDao condaRegistry) {
     this.condaRegistry = condaRegistry;
-  }
-
-  public ComponentSearchController(
-      ComponentDao componentDao,
-      SecurityAuthenticationService authenticationService,
-      SecurityManagementService securityService) {
-    this(componentDao, authenticationService, securityService, null);
   }
 
   @GetMapping
@@ -130,17 +142,257 @@ public class ComponentSearchController {
       throw new ResponseStatusException(
           HttpStatus.BAD_REQUEST, "APT coordinate filters require format=apt");
     }
-    Map<RepositoryBrowseKey, Boolean> browseDecisions = new HashMap<>();
-    int queryLimit = normalizedFilters.present() ? DEFAULT_LIMIT : effectiveLimit;
-    List<ComponentSearchItem> items = componentDao.search(keyword, repositoryFormat, queryLimit).stream()
-        .filter(row -> !BrowseAssetVisibility.hidden(row.format(), row.name())
-            && !BrowseAssetVisibility.hidden(row.format(), row.storagePath()))
-        .filter(row -> repositoryBrowseAllowed(subject, row, browseDecisions))
+    return searchAuthorized(
+        subject, keyword, repositoryFormat, effectiveLimit, normalizedFilters);
+  }
+
+  private ComponentSearchResponse searchAuthorized(
+      AuthenticatedSubject subject,
+      String keyword,
+      RepositoryFormat repositoryFormat,
+      int effectiveLimit,
+      AptSearchFilters filters) {
+    RepositoryCatalogCache.RepositoryCatalog catalog = repositoryCatalogCache.snapshot();
+    List<RepositoryRecord> searchableRepositories = catalog.records().stream()
+        .filter(record -> record.id() != null && record.name() != null && record.format() != null)
+        .filter(record -> repositoryFormat == null || record.format() == repositoryFormat)
+        .toList();
+    List<RepositoryPermission> requestedScopes = searchableRepositories.stream()
+        .map(record -> new RepositoryPermission(
+            record.name(), record.format(), "", PermissionAction.BROWSE))
+        .distinct()
+        .toList();
+    Map<RepositoryPermission, RepositoryAccessMode> accessModes =
+        securityService.repositoryAccessModes(subject.permissionSubject(), requestedScopes);
+    SearchAccessScope scope = buildSearchAccessScope(
+        searchableRepositories, catalog, accessModes);
+    if (scope.empty()) {
+      return new ComponentSearchResponse(effectiveLimit, 0, List.of());
+    }
+
+    int candidateLimit = filters.present() ? DEFAULT_LIMIT : effectiveLimit;
+    List<ComponentSearchRow> visible = new ArrayList<>();
+    boolean truncated = false;
+    if (!scope.fullRepositoryIds().isEmpty()) {
+      componentDao.searchPageByRepositoryIds(
+              scope.fullRepositoryIds(), repositoryFormat, keyword, null, candidateLimit).stream()
+          .filter(ComponentSearchController::searchVisible)
+          .map(row -> withBrowseContext(
+              row, scope.fullContext(row.repositoryId()), row.storagePath()))
+          .filter(java.util.Objects::nonNull)
+          .forEach(visible::add);
+    }
+    if (!scope.selectorRepositoryIds().isEmpty()) {
+      SelectorSearchResult selectorResult = searchSelectorRows(
+          subject, scope, keyword, repositoryFormat, candidateLimit, filters.present());
+      visible.addAll(selectorResult.rows());
+      truncated = selectorResult.truncated();
+    }
+
+    Comparator<ComponentSearchRow> newestFirst = Comparator
+        .comparing(
+            ComponentSearchRow::lastUpdatedAt,
+            Comparator.nullsLast(Comparator.reverseOrder()))
+        .thenComparing(ComponentSearchRow::id, Comparator.reverseOrder());
+    List<ComponentSearchItem> items = visible.stream()
+        .sorted(newestFirst)
         .map(this::toItem)
-        .filter(normalizedFilters::matches)
+        .filter(filters::matches)
         .limit(effectiveLimit)
         .toList();
-    return new ComponentSearchResponse(effectiveLimit, items.size(), items);
+    return new ComponentSearchResponse(effectiveLimit, items.size(), items, truncated);
+  }
+
+  private SelectorSearchResult searchSelectorRows(
+      AuthenticatedSubject subject,
+      SearchAccessScope scope,
+      String keyword,
+      RepositoryFormat repositoryFormat,
+      int candidateLimit,
+      boolean scanForCoordinateFilters) {
+    List<ComponentSearchRow> visible = new ArrayList<>();
+    ComponentSearchCursor cursor = null;
+    int scanned = 0;
+    boolean reachedEnd = false;
+    while (scanned < MAX_SELECTOR_CANDIDATES
+        && (scanForCoordinateFilters || visible.size() < candidateLimit)) {
+      int pageLimit = Math.min(SELECTOR_PAGE_SIZE, MAX_SELECTOR_CANDIDATES - scanned);
+      List<ComponentSearchRow> page = componentDao.searchPageByRepositoryIds(
+          scope.selectorRepositoryIds(), repositoryFormat, keyword, cursor, pageLimit);
+      if (page.isEmpty()) {
+        reachedEnd = true;
+        break;
+      }
+      scanned += page.size();
+      List<ComponentSearchRow> searchablePage = page.stream()
+          .filter(ComponentSearchController::searchVisible)
+          .toList();
+      visible.addAll(authorizeSelectorPage(subject, scope, searchablePage));
+      cursor = ComponentSearchCursor.after(page.getLast());
+      if (page.size() < pageLimit) {
+        reachedEnd = true;
+        break;
+      }
+    }
+    boolean truncated = !reachedEnd
+        && scanned >= MAX_SELECTOR_CANDIDATES
+        && (scanForCoordinateFilters || visible.size() < candidateLimit);
+    return new SelectorSearchResult(List.copyOf(visible), truncated);
+  }
+
+  private List<ComponentSearchRow> authorizeSelectorPage(
+      AuthenticatedSubject subject,
+      SearchAccessScope scope,
+      List<ComponentSearchRow> rows) {
+    if (rows.isEmpty()) {
+      return List.of();
+    }
+    Map<Long, List<AssetRecord>> assetsByComponent = new LinkedHashMap<>();
+    assetDao.listAssetsByComponents(rows.stream().map(ComponentSearchRow::id).toList())
+        .forEach(asset -> {
+          if (asset.componentId() != null && asset.path() != null
+              && !BrowseAssetVisibility.hidden(asset.format(), asset.path())) {
+            assetsByComponent.computeIfAbsent(asset.componentId(), ignored -> new ArrayList<>())
+                .add(asset);
+          }
+        });
+
+    List<RepositoryPermission> pathPermissions = new ArrayList<>();
+    for (ComponentSearchRow row : rows) {
+      for (BrowseContext context : scope.selectorContexts(row.repositoryId())) {
+        for (AssetRecord asset : assetsByComponent.getOrDefault(row.id(), List.of())) {
+          if (asset.repositoryId() == row.repositoryId()) {
+            pathPermissions.add(pathPermission(context, row.format(), asset.path()));
+          }
+        }
+      }
+    }
+    Map<RepositoryPermission, AccessDecision> decisions = securityService.decideAll(
+        subject.permissionSubject(), pathPermissions);
+
+    List<ComponentSearchRow> allowed = new ArrayList<>();
+    for (ComponentSearchRow row : rows) {
+      ComponentSearchRow authorized = null;
+      for (BrowseContext context : scope.selectorContexts(row.repositoryId())) {
+        for (AssetRecord asset : assetsByComponent.getOrDefault(row.id(), List.of())) {
+          if (asset.repositoryId() != row.repositoryId()) {
+            continue;
+          }
+          AccessDecision decision = decisions.get(
+              pathPermission(context, row.format(), asset.path()));
+          if (decision != null && decision.allowed()) {
+            authorized = withBrowseContext(row, context, asset.path());
+            break;
+          }
+        }
+        if (authorized != null) {
+          break;
+        }
+      }
+      if (authorized != null) {
+        allowed.add(authorized);
+      }
+    }
+    return allowed;
+  }
+
+  private SearchAccessScope buildSearchAccessScope(
+      List<RepositoryRecord> records,
+      RepositoryCatalogCache.RepositoryCatalog catalog,
+      Map<RepositoryPermission, RepositoryAccessMode> accessModes) {
+    SearchAccessScope scope = new SearchAccessScope();
+    Map<String, RepositoryRecord> recordsByName = new LinkedHashMap<>();
+    records.forEach(record -> recordsByName.put(record.name(), record));
+
+    for (RepositoryRecord record : records) {
+      RepositoryAccessMode mode = accessModes.getOrDefault(
+          repositoryPermission(record), RepositoryAccessMode.DENIED);
+      scope.add(record.id(), new BrowseContext(record.name()), mode);
+    }
+    for (RepositoryRecord group : records) {
+      if (group.type() != RepositoryType.GROUP) {
+        continue;
+      }
+      RepositoryAccessMode mode = accessModes.getOrDefault(
+          repositoryPermission(group), RepositoryAccessMode.DENIED);
+      if (mode == RepositoryAccessMode.DENIED) {
+        continue;
+      }
+      for (Long memberId : groupMemberRepositoryIds(group, catalog, recordsByName)) {
+        scope.add(memberId, new BrowseContext(group.name()), mode);
+      }
+    }
+    return scope;
+  }
+
+  private static Set<Long> groupMemberRepositoryIds(
+      RepositoryRecord group,
+      RepositoryCatalogCache.RepositoryCatalog catalog,
+      Map<String, RepositoryRecord> recordsByName) {
+    Set<Long> members = new LinkedHashSet<>();
+    collectGroupMembers(group, group.format(), catalog, recordsByName, new HashSet<>(), members);
+    return members;
+  }
+
+  private static void collectGroupMembers(
+      RepositoryRecord group,
+      RepositoryFormat groupFormat,
+      RepositoryCatalogCache.RepositoryCatalog catalog,
+      Map<String, RepositoryRecord> recordsByName,
+      Set<Long> visitedGroups,
+      Set<Long> members) {
+    if (group.id() == null || !visitedGroups.add(group.id())) {
+      return;
+    }
+    for (String memberName : catalog.membersOf(group.id())) {
+      RepositoryRecord member = recordsByName.get(memberName);
+      if (member == null || member.id() == null || member.format() != groupFormat) {
+        continue;
+      }
+      members.add(member.id());
+      if (member.type() == RepositoryType.GROUP) {
+        collectGroupMembers(
+            member, groupFormat, catalog, recordsByName, visitedGroups, members);
+      }
+    }
+  }
+
+  private static RepositoryPermission repositoryPermission(RepositoryRecord record) {
+    return new RepositoryPermission(
+        record.name(), record.format(), "", PermissionAction.BROWSE);
+  }
+
+  private static RepositoryPermission pathPermission(
+      BrowseContext context,
+      RepositoryFormat format,
+      String path) {
+    return new RepositoryPermission(
+        context.repositoryName(), format, path, PermissionAction.BROWSE);
+  }
+
+  private static boolean searchVisible(ComponentSearchRow row) {
+    return !BrowseAssetVisibility.hidden(row.format(), row.name())
+        && !BrowseAssetVisibility.hidden(row.format(), row.storagePath());
+  }
+
+  private static ComponentSearchRow withBrowseContext(
+      ComponentSearchRow row,
+      BrowseContext context,
+      String browsePath) {
+    if (context == null) {
+      return null;
+    }
+    return new ComponentSearchRow(
+        row.id(),
+        row.repositoryId(),
+        context.repositoryName(),
+        row.format(),
+        row.namespace(),
+        row.name(),
+        row.version(),
+        row.kind(),
+        row.lastUpdatedAt(),
+        browsePath);
   }
 
   private ComponentSearchItem toItem(ComponentSearchRow row) {
@@ -373,17 +625,46 @@ public class ComponentSearchController {
     }
   }
 
-  private boolean repositoryBrowseAllowed(
-      AuthenticatedSubject subject,
-      ComponentSearchRow row,
-      Map<RepositoryBrowseKey, Boolean> browseDecisions) {
-    RepositoryBrowseKey key = new RepositoryBrowseKey(row.repositoryName(), row.format());
-    return browseDecisions.computeIfAbsent(key, ignored -> securityService.decide(
-        subject.permissionSubject(),
-        new RepositoryPermission(row.repositoryName(), row.format(), "", PermissionAction.BROWSE)).allowed());
+  private static final class SearchAccessScope {
+    private final Map<Long, List<BrowseContext>> full = new LinkedHashMap<>();
+    private final Map<Long, List<BrowseContext>> selectors = new LinkedHashMap<>();
+
+    void add(long repositoryId, BrowseContext context, RepositoryAccessMode mode) {
+      if (mode == RepositoryAccessMode.FULL) {
+        full.computeIfAbsent(repositoryId, ignored -> new ArrayList<>()).add(context);
+        selectors.remove(repositoryId);
+      } else if (mode == RepositoryAccessMode.CONTENT_SELECTOR
+          && !full.containsKey(repositoryId)) {
+        selectors.computeIfAbsent(repositoryId, ignored -> new ArrayList<>()).add(context);
+      }
+    }
+
+    boolean empty() {
+      return full.isEmpty() && selectors.isEmpty();
+    }
+
+    List<Long> fullRepositoryIds() {
+      return List.copyOf(full.keySet());
+    }
+
+    List<Long> selectorRepositoryIds() {
+      return List.copyOf(selectors.keySet());
+    }
+
+    BrowseContext fullContext(long repositoryId) {
+      List<BrowseContext> contexts = full.get(repositoryId);
+      return contexts == null || contexts.isEmpty() ? null : contexts.getFirst();
+    }
+
+    List<BrowseContext> selectorContexts(long repositoryId) {
+      return selectors.getOrDefault(repositoryId, List.of());
+    }
   }
 
-  private record RepositoryBrowseKey(String repositoryName, RepositoryFormat format) {
+  private record BrowseContext(String repositoryName) {
+  }
+
+  private record SelectorSearchResult(List<ComponentSearchRow> rows, boolean truncated) {
   }
 
   private record AptSearchFilters(
@@ -443,7 +724,14 @@ public class ComponentSearchController {
     }
   }
 
-  public record ComponentSearchResponse(int limit, int count, List<ComponentSearchItem> items) {
+  public record ComponentSearchResponse(
+      int limit,
+      int count,
+      List<ComponentSearchItem> items,
+      boolean truncated) {
+    public ComponentSearchResponse(int limit, int count, List<ComponentSearchItem> items) {
+      this(limit, count, items, false);
+    }
   }
 
   public record ComponentSearchItem(

--- a/server/src/main/java/com/github/klboke/kkrepo/server/repositories/RepositoryCatalogCache.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/repositories/RepositoryCatalogCache.java
@@ -88,6 +88,15 @@ public class RepositoryCatalogCache {
     return Optional.ofNullable(refreshBlocking());
   }
 
+  /**
+   * Returns a complete repository snapshot even when the node-local catalog cache is disabled.
+   * The fallback remains a bounded set of database queries and is used by authorization-sensitive
+   * request paths that must never fall back to an unscoped query.
+   */
+  public RepositoryCatalog snapshot() {
+    return current().orElseGet(this::loadCatalog);
+  }
+
   @EventListener(ApplicationReadyEvent.class)
   public void warmUp() {
     if (!enabled) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/security/SecurityManagementService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/security/SecurityManagementService.java
@@ -920,6 +920,50 @@ public class SecurityManagementService implements AccessDecisionService {
     return decide(subject, repositoryPermissionString(permission), permission);
   }
 
+  /**
+   * Classifies repository browse grants without evaluating a content selector against a fake or
+   * empty path. Callers use this to push full-repository grants into SQL while reserving
+   * selector-only repositories for path-aware authorization.
+   */
+  public Map<RepositoryPermission, RepositoryAccessMode> repositoryAccessModes(
+      PermissionSubject subject,
+      Collection<RepositoryPermission> permissions) {
+    if (subject == null || permissions == null || permissions.isEmpty()) {
+      return Map.of();
+    }
+    AuthorizationSnapshot snapshot = authorizationSnapshot(subject);
+    Map<RepositoryPermission, RepositoryAccessMode> result = new LinkedHashMap<>();
+    permissions.stream()
+        .filter(java.util.Objects::nonNull)
+        .distinct()
+        .forEach(permission -> result.put(permission, repositoryAccessMode(snapshot, permission)));
+    return Map.copyOf(result);
+  }
+
+  /** Evaluates a bounded batch of real repository paths against one authorization snapshot. */
+  public Map<RepositoryPermission, AccessDecision> decideAll(
+      PermissionSubject subject,
+      Collection<RepositoryPermission> permissions) {
+    if (subject == null || permissions == null || permissions.isEmpty()) {
+      return Map.of();
+    }
+    AuthorizationSnapshot snapshot = authorizationSnapshot(subject);
+    Map<RepositoryPermission, AccessDecision> result = new LinkedHashMap<>();
+    permissions.stream()
+        .filter(java.util.Objects::nonNull)
+        .distinct()
+        .forEach(permission -> {
+          String requested = repositoryPermissionString(permission);
+          boolean allowed = !snapshot.roleIds().isEmpty()
+              && permissionAllowed(
+                  snapshot.privileges(), requested, permission, snapshot.repositoryTargets());
+          result.put(permission, allowed
+              ? AccessDecision.allow()
+              : AccessDecision.deny("missing permission " + requested));
+        });
+    return Map.copyOf(result);
+  }
+
   public AccessDecision decide(PermissionSubject subject, String requestedPermission) {
     if (subject == null || requestedPermission == null || requestedPermission.isBlank()) {
       return AccessDecision.deny("missing subject or permission");
@@ -995,6 +1039,24 @@ public class SecurityManagementService implements AccessDecisionService {
       }
     }
     return false;
+  }
+
+  private RepositoryAccessMode repositoryAccessMode(
+      AuthorizationSnapshot snapshot,
+      RepositoryPermission permission) {
+    if (snapshot.roleIds().isEmpty()) {
+      return RepositoryAccessMode.DENIED;
+    }
+    String requestedPermission = repositoryPermissionString(permission);
+    boolean selectorApplies = false;
+    for (SecurityPrivilegeRecord privilege : snapshot.privileges()) {
+      if (wildcardMatches(toPermission(privilege), requestedPermission)) {
+        return RepositoryAccessMode.FULL;
+      }
+      selectorApplies |= repositoryContentSelectorApplies(
+          privilege, permission, snapshot.repositoryTargets());
+    }
+    return selectorApplies ? RepositoryAccessMode.CONTENT_SELECTOR : RepositoryAccessMode.DENIED;
   }
 
   private AuthorizationSnapshot authorizationSnapshot(PermissionSubject subject) {
@@ -1372,6 +1434,26 @@ public class SecurityManagementService implements AccessDecisionService {
       SecurityPrivilegeRecord privilege,
       RepositoryPermission requested,
       Map<String, SecurityRepositoryTargetRecord> repositoryTargets) {
+    if (!repositoryContentSelectorApplies(privilege, requested, repositoryTargets)) {
+      return false;
+    }
+    Map<String, Object> properties = privilege.properties();
+    SecurityRepositoryTargetRecord contentSelector = repositoryTargets.get(
+        contentSelectorName(properties));
+    String requestedFormat = requested.format() == null
+        ? "*"
+        : ContentSelectorExpressionEvaluator.nexusFormat(requested.format().name());
+    return ContentSelectorExpressionEvaluator.matches(
+        contentSelector.contentExpression(),
+        requested.repository(),
+        requestedFormat,
+        defaultString(requested.pathPattern(), ""));
+  }
+
+  private boolean repositoryContentSelectorApplies(
+      SecurityPrivilegeRecord privilege,
+      RepositoryPermission requested,
+      Map<String, SecurityRepositoryTargetRecord> repositoryTargets) {
     if (!"repository-content-selector".equals(privilege.type())) {
       return false;
     }
@@ -1401,11 +1483,13 @@ public class SecurityManagementService implements AccessDecisionService {
     if (!partMatches(actions(properties), action.nexusAction())) {
       return false;
     }
-    return ContentSelectorExpressionEvaluator.matches(
-        contentSelector.contentExpression(),
-        requested.repository(),
-        requestedFormat,
-        defaultString(requested.pathPattern(), ""));
+    return true;
+  }
+
+  public enum RepositoryAccessMode {
+    DENIED,
+    CONTENT_SELECTOR,
+    FULL
   }
 
   private void invalidateAuthorizationCacheAfterCommit() {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/browse/ComponentSearchControllerAuthorizedSearchTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/browse/ComponentSearchControllerAuthorizedSearchTest.java
@@ -1,0 +1,420 @@
+package com.github.klboke.kkrepo.server.browse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.klboke.kkrepo.auth.AccessDecision;
+import com.github.klboke.kkrepo.auth.PermissionSubject;
+import com.github.klboke.kkrepo.auth.RepositoryPermission;
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.jdbc.api.ComponentDao.ComponentSearchCursor;
+import com.github.klboke.kkrepo.persistence.jdbc.api.ComponentDao.ComponentSearchRow;
+import com.github.klboke.kkrepo.persistence.jdbc.api.model.AssetRecord;
+import com.github.klboke.kkrepo.persistence.jdbc.api.model.RepositoryRecord;
+import com.github.klboke.kkrepo.server.repositories.RepositoryCatalogCache;
+import com.github.klboke.kkrepo.server.security.AuthenticatedSubject;
+import com.github.klboke.kkrepo.server.security.SecurityAuthenticationService;
+import com.github.klboke.kkrepo.server.security.SecurityManagementService;
+import com.github.klboke.kkrepo.server.security.SecurityManagementService.RepositoryAccessMode;
+import com.github.klboke.kkrepo.server.support.dao.AssetDaoAdapter;
+import com.github.klboke.kkrepo.server.support.dao.ComponentDaoAdapter;
+import com.github.klboke.kkrepo.server.support.dao.SecurityDaoAdapter;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.http.HttpServletRequest;
+import java.lang.reflect.Proxy;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.Test;
+
+class ComponentSearchControllerAuthorizedSearchTest {
+
+  @Test
+  void selectorOnlySearchAuthorizesRealAssetPathsWithoutLeakingSiblingComponents() {
+    StubComponentDao components = new StubComponentDao(List.of(
+        row(2L, 10L, "releases", "secret", 2),
+        row(1L, 10L, "releases", "public", 1)));
+    StubAssetDao assets = new StubAssetDao(Map.of(
+        2L, List.of(asset(2L, 10L, "com/acme/private/secret.jar")),
+        1L, List.of(asset(1L, 10L, "com/acme/public/app.jar"))));
+    RecordingSecurityService security = new RecordingSecurityService(
+        Map.of("releases", RepositoryAccessMode.CONTENT_SELECTOR),
+        permission -> !permission.pathPattern().contains("/private/"));
+    ComponentSearchController controller = controller(
+        components, assets, security, catalog(List.of(hosted(10L, "releases")), Map.of()));
+
+    ComponentSearchController.ComponentSearchResponse response = controller.search(
+        null, "maven2", 10, request());
+
+    assertEquals(1, response.count());
+    assertEquals("public", response.items().getFirst().name());
+    assertEquals("com/acme/public/app.jar", response.items().getFirst().browsePath());
+    assertEquals(List.of(10L), components.calls.getFirst().repositoryIds());
+    assertEquals(1, assets.calls.size());
+    assertTrue(security.pathPermissions.stream()
+        .anyMatch(permission -> permission.pathPattern().contains("/private/")));
+    assertTrue(security.pathPermissions.stream()
+        .allMatch(permission -> permission.pathPattern() != null
+            && !permission.pathPattern().isBlank()));
+  }
+
+  @Test
+  void selectorSearchContinuesAfterUnauthorizedFirstPage() {
+    List<ComponentSearchRow> rows = new ArrayList<>();
+    Map<Long, List<AssetRecord>> assetRows = new LinkedHashMap<>();
+    for (long id = 202; id >= 3; id--) {
+      rows.add(row(id, 10L, "releases", "private-" + id, id));
+      assetRows.put(id, List.of(asset(id, 10L, "private/" + id + ".jar")));
+    }
+    rows.add(row(2L, 10L, "releases", "public-two", 2));
+    rows.add(row(1L, 10L, "releases", "public-one", 1));
+    assetRows.put(2L, List.of(asset(2L, 10L, "public/two.jar")));
+    assetRows.put(1L, List.of(asset(1L, 10L, "public/one.jar")));
+    StubComponentDao components = new StubComponentDao(rows);
+    StubAssetDao assets = new StubAssetDao(assetRows);
+    RecordingSecurityService security = new RecordingSecurityService(
+        Map.of("releases", RepositoryAccessMode.CONTENT_SELECTOR),
+        permission -> permission.pathPattern().startsWith("public/"));
+    ComponentSearchController controller = controller(
+        components, assets, security, catalog(List.of(hosted(10L, "releases")), Map.of()));
+
+    ComponentSearchController.ComponentSearchResponse response = controller.search(
+        null, "maven2", 2, request());
+
+    assertEquals(List.of("public-two", "public-one"), response.items().stream()
+        .map(ComponentSearchController.ComponentSearchItem::name)
+        .toList());
+    assertEquals(2, components.calls.size());
+    assertEquals(200, components.calls.getFirst().limit());
+    assertEquals(3L, components.calls.getFirst().lastReturnedId());
+    assertEquals(3L, components.calls.get(1).after().id());
+    assertEquals(2, assets.calls.size());
+  }
+
+  @Test
+  void fullRepositoryAccessIsPushedIntoSqlAndSkipsAssetAuthorization() {
+    StubComponentDao components = new StubComponentDao(List.of(
+        row(2L, 20L, "denied", "secret", 2),
+        row(1L, 10L, "public", "visible", 1)));
+    StubAssetDao assets = new StubAssetDao(Map.of());
+    RecordingSecurityService security = new RecordingSecurityService(
+        Map.of(
+            "public", RepositoryAccessMode.FULL,
+            "denied", RepositoryAccessMode.DENIED),
+        permission -> false);
+    ComponentSearchController controller = controller(
+        components,
+        assets,
+        security,
+        catalog(List.of(hosted(10L, "public"), hosted(20L, "denied")), Map.of()));
+
+    ComponentSearchController.ComponentSearchResponse response = controller.search(
+        null, "maven2", 10, request());
+
+    assertEquals(List.of("visible"), response.items().stream()
+        .map(ComponentSearchController.ComponentSearchItem::name)
+        .toList());
+    assertEquals(List.of(10L), components.calls.getFirst().repositoryIds());
+    assertEquals(List.of(), assets.calls);
+    assertEquals(List.of(), security.pathPermissions);
+  }
+
+  @Test
+  void selectorSearchReportsWhenItsBoundedCandidateScanIsTruncated() {
+    List<ComponentSearchRow> rows = new ArrayList<>();
+    Map<Long, List<AssetRecord>> assetRows = new LinkedHashMap<>();
+    for (long id = 1_001; id >= 1; id--) {
+      rows.add(row(id, 10L, "releases", "private-" + id, id));
+      assetRows.put(id, List.of(asset(id, 10L, "private/" + id + ".jar")));
+    }
+    StubComponentDao components = new StubComponentDao(rows);
+    StubAssetDao assets = new StubAssetDao(assetRows);
+    RecordingSecurityService security = new RecordingSecurityService(
+        Map.of("releases", RepositoryAccessMode.CONTENT_SELECTOR),
+        permission -> false);
+    ComponentSearchController controller = controller(
+        components, assets, security, catalog(List.of(hosted(10L, "releases")), Map.of()));
+
+    ComponentSearchController.ComponentSearchResponse response = controller.search(
+        null, "maven2", 10, request());
+
+    assertEquals(0, response.count());
+    assertTrue(response.truncated());
+    assertEquals(5, components.calls.size());
+    assertEquals(5, assets.calls.size());
+  }
+
+  @Test
+  void groupOnlyBrowsePermissionReturnsMemberComponentsThroughGroupName() {
+    StubComponentDao components = new StubComponentDao(List.of(
+        row(1L, 10L, "member", "visible", 1)));
+    StubAssetDao assets = new StubAssetDao(Map.of());
+    RecordingSecurityService security = new RecordingSecurityService(
+        Map.of(
+            "member", RepositoryAccessMode.DENIED,
+            "public-group", RepositoryAccessMode.FULL),
+        permission -> false);
+    ComponentSearchController controller = controller(
+        components,
+        assets,
+        security,
+        catalog(
+            List.of(hosted(10L, "member"), group(20L, "public-group")),
+            Map.of(20L, List.of("member"))));
+
+    ComponentSearchController.ComponentSearchItem item = controller.search(
+        null, "maven2", 10, request()).items().getFirst();
+
+    assertEquals("public-group", item.repository());
+    assertEquals(List.of(20L, 10L), components.calls.getFirst().repositoryIds());
+  }
+
+  private static ComponentSearchController controller(
+      StubComponentDao components,
+      StubAssetDao assets,
+      RecordingSecurityService security,
+      RepositoryCatalogCache.RepositoryCatalog repositoryCatalog) {
+    RepositoryCatalogCache catalogCache = mock(RepositoryCatalogCache.class);
+    when(catalogCache.snapshot()).thenReturn(repositoryCatalog);
+    return new ComponentSearchController(
+        components,
+        assets,
+        new StubAuthenticationService(subject()),
+        security,
+        null,
+        catalogCache);
+  }
+
+  private static RepositoryCatalogCache.RepositoryCatalog catalog(
+      List<RepositoryRecord> repositories,
+      Map<Long, List<String>> members) {
+    return new RepositoryCatalogCache.RepositoryCatalog(
+        Instant.EPOCH, repositories, Map.of(), members);
+  }
+
+  private static RepositoryRecord hosted(long id, String name) {
+    return repository(id, name, RepositoryType.HOSTED);
+  }
+
+  private static RepositoryRecord group(long id, String name) {
+    return repository(id, name, RepositoryType.GROUP);
+  }
+
+  private static RepositoryRecord repository(long id, String name, RepositoryType type) {
+    return new RepositoryRecord(
+        id,
+        name,
+        RepositoryFormat.MAVEN2,
+        type,
+        "maven2-" + type.name().toLowerCase(java.util.Locale.ROOT),
+        true,
+        1L,
+        null,
+        null,
+        null,
+        null,
+        null,
+        true,
+        Map.of());
+  }
+
+  private static ComponentSearchRow row(
+      long id,
+      long repositoryId,
+      String repositoryName,
+      String name,
+      long timestampSeconds) {
+    return new ComponentSearchRow(
+        id,
+        repositoryId,
+        repositoryName,
+        RepositoryFormat.MAVEN2,
+        "com.acme",
+        name,
+        "1.0.0",
+        "component",
+        Instant.ofEpochSecond(timestampSeconds),
+        null);
+  }
+
+  private static AssetRecord asset(long componentId, long repositoryId, String path) {
+    return new AssetRecord(
+        componentId,
+        repositoryId,
+        componentId,
+        componentId,
+        RepositoryFormat.MAVEN2,
+        path,
+        new byte[] {(byte) componentId},
+        path.substring(path.lastIndexOf('/') + 1),
+        "asset",
+        "application/octet-stream",
+        1L,
+        null,
+        Instant.EPOCH,
+        Map.of());
+  }
+
+  private static AuthenticatedSubject subject() {
+    return new AuthenticatedSubject(
+        "Local",
+        "alice",
+        "local",
+        null,
+        new PermissionSubject("Local", "alice", Set.of(), null));
+  }
+
+  private static HttpServletRequest request() {
+    Map<String, Object> attributes = new LinkedHashMap<>();
+    return (HttpServletRequest) Proxy.newProxyInstance(
+        ComponentSearchControllerAuthorizedSearchTest.class.getClassLoader(),
+        new Class<?>[] {HttpServletRequest.class},
+        (proxy, invoked, args) -> switch (invoked.getName()) {
+          case "getMethod" -> "GET";
+          case "getRequestURI" -> "/internal/search/components";
+          case "getContextPath" -> "";
+          case "getDispatcherType" -> DispatcherType.REQUEST;
+          case "getAttribute" -> attributes.get(String.valueOf(args[0]));
+          case "setAttribute" -> {
+            attributes.put(String.valueOf(args[0]), args[1]);
+            yield null;
+          }
+          case "toString" -> "GET /internal/search/components";
+          default -> primitiveDefault(invoked.getReturnType());
+        });
+  }
+
+  private static Object primitiveDefault(Class<?> type) {
+    if (boolean.class.equals(type)) return false;
+    if (int.class.equals(type) || long.class.equals(type)
+        || short.class.equals(type) || byte.class.equals(type)) return 0;
+    if (char.class.equals(type)) return '\0';
+    return null;
+  }
+
+  private static final class StubComponentDao extends ComponentDaoAdapter {
+    private final List<ComponentSearchRow> rows;
+    private final List<SearchCall> calls = new ArrayList<>();
+
+    private StubComponentDao(List<ComponentSearchRow> rows) {
+      this.rows = rows.stream()
+          .sorted(Comparator
+              .comparing(ComponentSearchRow::lastUpdatedAt).reversed()
+              .thenComparing(ComponentSearchRow::id, Comparator.reverseOrder()))
+          .toList();
+    }
+
+    @Override
+    public List<ComponentSearchRow> searchPageByRepositoryIds(
+        List<Long> repositoryIds,
+        RepositoryFormat format,
+        String keyword,
+        ComponentSearchCursor after,
+        int limit) {
+      List<ComponentSearchRow> page = rows.stream()
+          .filter(row -> repositoryIds.contains(row.repositoryId()))
+          .filter(row -> format == null || row.format() == format)
+          .filter(row -> after == null
+              || row.lastUpdatedAt().isBefore(after.lastUpdatedAt())
+              || (row.lastUpdatedAt().equals(after.lastUpdatedAt()) && row.id() < after.id()))
+          .limit(limit)
+          .toList();
+      calls.add(new SearchCall(
+          List.copyOf(repositoryIds), after, limit,
+          page.isEmpty() ? null : page.getLast().id()));
+      return page;
+    }
+  }
+
+  private static final class StubAssetDao extends AssetDaoAdapter {
+    private final Map<Long, List<AssetRecord>> assets;
+    private final List<List<Long>> calls = new ArrayList<>();
+
+    private StubAssetDao(Map<Long, List<AssetRecord>> assets) {
+      this.assets = assets;
+    }
+
+    @Override
+    public List<AssetRecord> listAssetsByComponents(Collection<Long> componentIds) {
+      List<Long> ids = List.copyOf(componentIds);
+      calls.add(ids);
+      return ids.stream().flatMap(id -> assets.getOrDefault(id, List.of()).stream()).toList();
+    }
+  }
+
+  private static final class RecordingSecurityService extends SecurityManagementService {
+    private final Map<String, RepositoryAccessMode> modes;
+    private final Predicate<RepositoryPermission> pathDecision;
+    private final List<RepositoryPermission> pathPermissions = new ArrayList<>();
+
+    private RecordingSecurityService(
+        Map<String, RepositoryAccessMode> modes,
+        Predicate<RepositoryPermission> pathDecision) {
+      super(new SecurityDaoAdapter(null, null));
+      this.modes = modes;
+      this.pathDecision = pathDecision;
+    }
+
+    @Override
+    public AccessDecision decide(PermissionSubject subject, String permission) {
+      return AccessDecision.allow();
+    }
+
+    @Override
+    public Map<RepositoryPermission, RepositoryAccessMode> repositoryAccessModes(
+        PermissionSubject subject,
+        Collection<RepositoryPermission> permissions) {
+      Map<RepositoryPermission, RepositoryAccessMode> result = new LinkedHashMap<>();
+      permissions.forEach(permission -> result.put(
+          permission,
+          modes.getOrDefault(permission.repository(), RepositoryAccessMode.DENIED)));
+      return result;
+    }
+
+    @Override
+    public Map<RepositoryPermission, AccessDecision> decideAll(
+        PermissionSubject subject,
+        Collection<RepositoryPermission> permissions) {
+      Map<RepositoryPermission, AccessDecision> result = new LinkedHashMap<>();
+      permissions.forEach(permission -> {
+        pathPermissions.add(permission);
+        result.put(permission, pathDecision.test(permission)
+            ? AccessDecision.allow()
+            : AccessDecision.deny("denied"));
+      });
+      return result;
+    }
+  }
+
+  private static final class StubAuthenticationService extends SecurityAuthenticationService {
+    private final AuthenticatedSubject subject;
+
+    private StubAuthenticationService(AuthenticatedSubject subject) {
+      super(new SecurityDaoAdapter(null, null), new ObjectMapper(), "X-Nexus-Plus-Token");
+      this.subject = subject;
+    }
+
+    @Override
+    public Optional<AuthenticatedSubject> authenticate(HttpServletRequest request) {
+      return Optional.of(subject);
+    }
+  }
+
+  private record SearchCall(
+      List<Long> repositoryIds,
+      ComponentSearchCursor after,
+      int limit,
+      Long lastReturnedId) {
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/browse/ComponentSearchControllerAuthorizedSearchTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/browse/ComponentSearchControllerAuthorizedSearchTest.java
@@ -1,6 +1,7 @@
 package com.github.klboke.kkrepo.server.browse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -178,6 +179,80 @@ class ComponentSearchControllerAuthorizedSearchTest {
 
     assertEquals("public-group", item.repository());
     assertEquals(List.of(20L, 10L), components.calls.getFirst().repositoryIds());
+  }
+
+  @Test
+  void searchReturnsEmptyWithoutQueryingWhenNoRepositoryIsAuthorized() {
+    StubComponentDao components = new StubComponentDao(List.of(
+        row(1L, 10L, "private", "hidden", 1)));
+    StubAssetDao assets = new StubAssetDao(Map.of());
+    RecordingSecurityService security = new RecordingSecurityService(Map.of(), permission -> false);
+    ComponentSearchController controller = controller(
+        components, assets, security, catalog(List.of(hosted(10L, "private")), Map.of()));
+
+    ComponentSearchController.ComponentSearchResponse response = controller.search(
+        null, "maven2", 10, request());
+
+    assertEquals(0, response.count());
+    assertEquals(List.of(), components.calls);
+    assertEquals(List.of(), assets.calls);
+  }
+
+  @Test
+  void selectorSearchStopsCleanlyWhenTheFirstPageIsEmpty() {
+    StubComponentDao components = new StubComponentDao(List.of());
+    StubAssetDao assets = new StubAssetDao(Map.of());
+    RecordingSecurityService security = new RecordingSecurityService(
+        Map.of("releases", RepositoryAccessMode.CONTENT_SELECTOR), permission -> false);
+    ComponentSearchController controller = controller(
+        components, assets, security, catalog(List.of(hosted(10L, "releases")), Map.of()));
+
+    ComponentSearchController.ComponentSearchResponse response = controller.search(
+        null, "maven2", 10, request());
+
+    assertEquals(0, response.count());
+    assertFalse(response.truncated());
+    assertEquals(1, components.calls.size());
+    assertEquals(List.of(), assets.calls);
+  }
+
+  @Test
+  void nestedGroupsIgnoreMissingMembersAndCycles() {
+    StubComponentDao components = new StubComponentDao(List.of(
+        row(1L, 10L, "member", "visible", 1)));
+    StubAssetDao assets = new StubAssetDao(Map.of());
+    RecordingSecurityService security = new RecordingSecurityService(
+        Map.of(
+            "member", RepositoryAccessMode.DENIED,
+            "outer", RepositoryAccessMode.FULL,
+            "nested", RepositoryAccessMode.DENIED),
+        permission -> false);
+    ComponentSearchController controller = controller(
+        components,
+        assets,
+        security,
+        catalog(
+            List.of(
+                hosted(10L, "member"),
+                group(20L, "outer"),
+                group(30L, "nested")),
+            Map.of(
+                20L, List.of("missing", "nested"),
+                30L, List.of("outer", "member"))));
+
+    ComponentSearchController.ComponentSearchItem item = controller.search(
+        null, "maven2", 10, request()).items().getFirst();
+
+    assertEquals("outer", item.repository());
+    assertEquals(Set.of(10L, 20L, 30L), Set.copyOf(components.calls.getFirst().repositoryIds()));
+  }
+
+  @Test
+  void legacyResponseConstructorDefaultsTruncationToFalse() {
+    ComponentSearchController.ComponentSearchResponse response =
+        new ComponentSearchController.ComponentSearchResponse(10, 0, List.of());
+
+    assertFalse(response.truncated());
   }
 
   private static ComponentSearchController controller(

--- a/server/src/test/java/com/github/klboke/kkrepo/server/browse/ComponentSearchControllerSecurityTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/browse/ComponentSearchControllerSecurityTest.java
@@ -11,16 +11,21 @@ import com.github.klboke.kkrepo.auth.AccessDecision;
 import com.github.klboke.kkrepo.auth.PermissionSubject;
 import com.github.klboke.kkrepo.auth.RepositoryPermission;
 import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.jdbc.api.AssetDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.ComponentDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.ComponentDao.ComponentSearchCursor;
 import com.github.klboke.kkrepo.persistence.jdbc.api.AnsibleGalaxyRegistryDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.AptRegistryDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.AlpineRegistryDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.CondaRegistryDao;
-import com.github.klboke.kkrepo.persistence.jdbc.api.SecurityDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.SwiftRegistryDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.model.RepositoryRecord;
+import com.github.klboke.kkrepo.server.repositories.RepositoryCatalogCache;
 import com.github.klboke.kkrepo.server.security.AuthenticatedSubject;
 import com.github.klboke.kkrepo.server.security.SecurityAuthenticationService;
 import com.github.klboke.kkrepo.server.security.SecurityManagementService;
+import com.github.klboke.kkrepo.server.security.SecurityManagementService.RepositoryAccessMode;
 import com.github.klboke.kkrepo.server.support.dao.ComponentDaoAdapter;
 import com.github.klboke.kkrepo.server.support.dao.SecurityDaoAdapter;
 import jakarta.servlet.DispatcherType;
@@ -28,6 +33,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.lang.reflect.Proxy;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -107,10 +113,10 @@ class ComponentSearchControllerSecurityTest {
         request("GET", "/internal/search/components"));
 
     assertEquals(2, response.count());
-    assertEquals(List.of("p2/psr/log.json", "psr/log"), response.items().stream()
+    assertEquals(List.of("psr/log", "p2/psr/log.json"), response.items().stream()
         .map(ComponentSearchController.ComponentSearchItem::name)
         .toList());
-    assertEquals(List.of("p2/psr/log.json", "psr/log/3.0.2/psr-log-3.0.2.zip"), response.items().stream()
+    assertEquals(List.of("psr/log/3.0.2/psr-log-3.0.2.zip", "p2/psr/log.json"), response.items().stream()
         .map(ComponentSearchController.ComponentSearchItem::browsePath)
         .toList());
   }
@@ -239,14 +245,18 @@ class ComponentSearchControllerSecurityTest {
             1L, version.id(), null, "b".repeat(64), null, "HOSTED", now)));
     RecordingSecurityService security =
         new RecordingSecurityService(permission -> AccessDecision.allow());
-    ComponentSearchController controller = new ComponentSearchController(
-        components, new StubAuthenticationService(subject("alice"), null), security);
+    ComponentSearchController controller = controller(
+        components, subject("alice"), null, security);
     controller.setAnsibleGalaxyRegistry(ansible);
 
     ComponentSearchController.ComponentSearchResponse response = controller.search(
         "tools", "ansiblegalaxy", 10, request("GET", "/internal/search/components"));
 
-    Map<String, Object> details = response.items().getFirst().details();
+    Map<String, ComponentSearchController.ComponentSearchItem> byName = response.items().stream()
+        .collect(java.util.stream.Collectors.toMap(
+            ComponentSearchController.ComponentSearchItem::name,
+            item -> item));
+    Map<String, Object> details = byName.get("tools").details();
     assertEquals("a".repeat(64), details.get("artifactSha256"));
     assertEquals(1024L, details.get("artifactSize"));
     assertEquals(Map.of("acme.base", ">=1.0.0"), details.get("dependencies"));
@@ -254,8 +264,8 @@ class ComponentSearchControllerSecurityTest {
     assertEquals(1, details.get("signatureCount"));
     assertEquals("HOSTED", details.get("sourceKind"));
     assertEquals("ansible-hosted", details.get("sourceRepository"));
-    assertFalse(response.items().get(1).details().containsKey("requiresAnsible"));
-    assertEquals(Map.of(), response.items().get(2).details());
+    assertFalse(byName.get("minimal").details().containsKey("requiresAnsible"));
+    assertEquals(Map.of(), byName.get("missing").details());
   }
 
   @Test
@@ -284,11 +294,8 @@ class ComponentSearchControllerSecurityTest {
             2L, "Package@swift-5.9.swift", "5.9", 103L, "c".repeat(64))));
     RecordingSecurityService security =
         new RecordingSecurityService(permission -> AccessDecision.allow());
-    ComponentSearchController controller = new ComponentSearchController(
-        components,
-        new StubAuthenticationService(subject("alice"), null),
-        security,
-        swift);
+    ComponentSearchController controller = controller(
+        components, subject("alice"), null, security, swift);
 
     ComponentSearchController.ComponentSearchItem item = controller.search(
         "demo", "swift", 10, request("GET", "/internal/search/components"))
@@ -329,7 +336,11 @@ class ComponentSearchControllerSecurityTest {
         "demo", "conda", 10, request("GET", "/internal/search/components"));
 
     assertEquals("demo|conda|10", components.calls.getFirst());
-    Map<String, Object> details = response.items().getFirst().details();
+    Map<String, Object> details = response.items().stream()
+        .filter(item -> "demo".equals(item.name()))
+        .findFirst()
+        .orElseThrow()
+        .details();
     assertEquals("main", details.get("channel"));
     assertEquals("noarch", details.get("subdir"));
     assertEquals("0", details.get("build"));
@@ -341,8 +352,10 @@ class ComponentSearchControllerSecurityTest {
     assertEquals(CondaRegistryDao.SOURCE_HOSTED, details.get("sourceKind"));
     assertEquals("conda-hosted", details.get("sourceRepository"));
     assertEquals(List.of("python >=3.12"), details.get("depends"));
-    assertEquals(Map.of(), response.items().get(1).details());
-    assertEquals(Map.of(), response.items().get(2).details());
+    assertEquals(List.of(Map.of(), Map.of()), response.items().stream()
+        .filter(item -> !"demo".equals(item.name()))
+        .map(ComponentSearchController.ComponentSearchItem::details)
+        .toList());
 
     ComponentSearchController withoutRegistry = controller(
         components, subject("alice"), null, security);
@@ -462,10 +475,60 @@ class ComponentSearchControllerSecurityTest {
       AuthenticatedSubject authenticated,
       AuthenticatedSubject anonymous,
       RecordingSecurityService security) {
+    return controller(components, authenticated, anonymous, security, null);
+  }
+
+  private static ComponentSearchController controller(
+      StubComponentDao components,
+      AuthenticatedSubject authenticated,
+      AuthenticatedSubject anonymous,
+      RecordingSecurityService security,
+      SwiftRegistryDao swiftRegistry) {
+    RepositoryCatalogCache catalogCache = mock(RepositoryCatalogCache.class);
+    when(catalogCache.snapshot()).thenAnswer(ignored -> catalog(components.rows));
     return new ComponentSearchController(
         components,
+        mock(AssetDao.class),
         new StubAuthenticationService(authenticated, anonymous),
-        security);
+        security,
+        swiftRegistry,
+        catalogCache);
+  }
+
+  private static RepositoryCatalogCache.RepositoryCatalog catalog(
+      List<ComponentDao.ComponentSearchRow> rows) {
+    List<RepositoryRecord> repositories = new ArrayList<>();
+    if (rows.isEmpty()) {
+      for (RepositoryFormat format : RepositoryFormat.values()) {
+        repositories.add(repository(-(format.ordinal() + 1L), format.id() + "-hosted", format));
+      }
+    } else {
+      rows.forEach(row -> repositories.add(
+          repository(row.repositoryId(), row.repositoryName(), row.format())));
+    }
+    return new RepositoryCatalogCache.RepositoryCatalog(
+        Instant.EPOCH, List.copyOf(repositories), Map.of(), Map.of());
+  }
+
+  private static RepositoryRecord repository(
+      long id,
+      String name,
+      RepositoryFormat format) {
+    return new RepositoryRecord(
+        id,
+        name,
+        format,
+        RepositoryType.HOSTED,
+        format.id() + "-hosted",
+        true,
+        1L,
+        null,
+        null,
+        null,
+        null,
+        null,
+        true,
+        Map.of());
   }
 
   private static ComponentDao.ComponentSearchRow row(
@@ -567,9 +630,18 @@ class ComponentSearchControllerSecurityTest {
     }
 
     @Override
-    public List<ComponentSearchRow> search(String keyword, RepositoryFormat format, int limit) {
+    public List<ComponentSearchRow> searchPageByRepositoryIds(
+        List<Long> repositoryIds,
+        RepositoryFormat format,
+        String keyword,
+        ComponentSearchCursor after,
+        int limit) {
       calls.add((keyword == null ? "" : keyword) + "|" + format + "|" + limit);
-      return rows;
+      return rows.stream()
+          .filter(row -> repositoryIds.contains(row.repositoryId()))
+          .filter(row -> format == null || row.format() == format)
+          .limit(limit)
+          .toList();
     }
   }
 
@@ -614,6 +686,23 @@ class ComponentSearchControllerSecurityTest {
       String requestedPermission = repositoryPermissionString(permission);
       permissions.add(requestedPermission);
       return decisions.apply(requestedPermission);
+    }
+
+    @Override
+    public Map<RepositoryPermission, RepositoryAccessMode> repositoryAccessModes(
+        PermissionSubject subject,
+        Collection<RepositoryPermission> requestedPermissions) {
+      Map<RepositoryPermission, RepositoryAccessMode> modes = new LinkedHashMap<>();
+      requestedPermissions.forEach(permission -> {
+        String requestedPermission = repositoryPermissionString(permission);
+        permissions.add(requestedPermission);
+        modes.put(
+            permission,
+            decisions.apply(requestedPermission).allowed()
+                ? RepositoryAccessMode.FULL
+                : RepositoryAccessMode.DENIED);
+      });
+      return modes;
     }
 
     private static String repositoryPermissionString(RepositoryPermission permission) {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/repositories/RepositoryCatalogCacheTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/repositories/RepositoryCatalogCacheTest.java
@@ -41,6 +41,21 @@ class RepositoryCatalogCacheTest {
   }
 
   @Test
+  void snapshotLoadsTheCatalogWhenTheNodeLocalCacheIsDisabled() {
+    StubRepositoryDao repositories = new StubRepositoryDao();
+    repositories.add(hosted(1L, "npm-hosted"));
+    RepositoryCatalogCache cache =
+        new RepositoryCatalogCache(repositories, new StubBlobStoreDao(), false);
+
+    RepositoryCatalogCache.RepositoryCatalog catalog = cache.snapshot();
+
+    assertEquals(List.of("npm-hosted"), catalog.records().stream()
+        .map(RepositoryRecord::name)
+        .toList());
+    assertEquals(1, repositories.listAllCalls);
+  }
+
+  @Test
   void mutationBroadcastRefreshesSiblingCatalogImmediately() {
     StubRepositoryDao repositories = new StubRepositoryDao();
     repositories.add(group(2L, "npm-group"));

--- a/server/src/test/java/com/github/klboke/kkrepo/server/security/SecurityManagementServicePermissionTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/security/SecurityManagementServicePermissionTest.java
@@ -1,5 +1,6 @@
 package com.github.klboke.kkrepo.server.security;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -209,6 +210,65 @@ class SecurityManagementServicePermissionTest {
         .allowed());
     assertFalse(service.decide(subject("alice"), repositoryPermission("releases", "com/acme/app/1.0/app-1.0.jar", PermissionAction.READ))
         .allowed());
+  }
+
+  @Test
+  void repositoryAccessModesKeepContentSelectorsPathAware() {
+    FakeSecurityDao dao = new FakeSecurityDao();
+    dao.assign("Local", "alice", "nx-search-reader");
+    dao.target(new SecurityRepositoryTargetRecord(
+        1L,
+        "non-private",
+        "Non-private paths",
+        "maven2",
+        "path =~ \"(?!.*private.*).*\"",
+        Map.of(),
+        Map.of("source", "nexus-content-selector")));
+    dao.grant("nx-search-reader", privilege(
+        "nx-repository-content-selector-public-browse",
+        "repository-content-selector",
+        Map.of(
+            "contentSelector", "non-private",
+            "format", "maven2",
+            "repository", "releases",
+            "actions", "browse")));
+    dao.grant("nx-search-reader", privilege(
+        "nx-repository-view-maven2-public-browse",
+        "repository-view",
+        Map.of(
+            "format", "maven2",
+            "repository", "public",
+            "actions", "browse")));
+    SecurityManagementService service = new SecurityManagementService(dao);
+    RepositoryPermission releases = repositoryPermission(
+        "releases", "", PermissionAction.BROWSE);
+    RepositoryPermission publicRepository = repositoryPermission(
+        "public", "", PermissionAction.BROWSE);
+    RepositoryPermission denied = repositoryPermission(
+        "internal", "", PermissionAction.BROWSE);
+
+    Map<RepositoryPermission, SecurityManagementService.RepositoryAccessMode> modes =
+        service.repositoryAccessModes(
+            subject("alice"), List.of(releases, publicRepository, denied));
+
+    assertEquals(
+        SecurityManagementService.RepositoryAccessMode.CONTENT_SELECTOR,
+        modes.get(releases));
+    assertEquals(
+        SecurityManagementService.RepositoryAccessMode.FULL,
+        modes.get(publicRepository));
+    assertEquals(
+        SecurityManagementService.RepositoryAccessMode.DENIED,
+        modes.get(denied));
+
+    RepositoryPermission allowedPath = repositoryPermission(
+        "releases", "com/acme/public/app.jar", PermissionAction.BROWSE);
+    RepositoryPermission privatePath = repositoryPermission(
+        "releases", "com/acme/private/app.jar", PermissionAction.BROWSE);
+    Map<RepositoryPermission, com.github.klboke.kkrepo.auth.AccessDecision> decisions =
+        service.decideAll(subject("alice"), List.of(allowedPath, privatePath));
+    assertTrue(decisions.get(allowedPath).allowed());
+    assertFalse(decisions.get(privatePath).allowed());
   }
 
   @Test


### PR DESCRIPTION
## Summary

- add a persistent global component search field to the Browse and Admin headers; Enter submits the search without a separate button or a preselected repository format
- route global searches to the existing Browse result experience, preserve the keyword, and show the selected repository format in format-specific result titles
- keep prefix matching implicit so users do not need to append Nexus-style `*`
- enforce `nexus:search:read`, batch-resolve repository Browse access, push whole-repository authorization into SQL, and retain exact selector checks for content-selector scopes
- add stable keyset pagination, late materialization, adaptive MySQL full-text planning, and MySQL/PostgreSQL V47 ordering indexes for large component tables

Closes #219

## Security and multi-replica behavior

- searches without `nexus:search:read` are rejected before component lookup
- repositories with whole-repository Browse access are passed into both the authoritative component predicate and the denormalized full-text predicate
- selector-only repositories are read in bounded keyset pages and each candidate is checked against the selector before it can be returned
- repository and plan caches are node-local and recoverable; the 30-second search-plan cache only selects between equivalent SQL access paths and never caches authorization decisions or results
- cache loss, expiry, or disagreement between replicas can change query cost but cannot broaden visibility

## Million-row MySQL benchmark

### Dataset and method

- MySQL `8.0.46` in the local development container
- InnoDB buffer pool: `128 MiB`
- isolated schema with `100` npm repositories
- `1,000,000` component rows (`10,000` per repository)
- `1,000,000` matching `component_search` FULLTEXT rows
- keyword distributions included a broad term with about `360,000` matches, a very broad term with about `959,900` matches, and a rare term with `200` matches
- all before/after values below are representative elapsed observations on the same instance and dataset; the authorization scope and result limit were held constant for each comparison

### Latest-component search with repository authorization

The original `IN (...) + ORDER BY` shape scanned and sorted the full authorized population. The replacement drives a covering newest-first index and stops as soon as the requested page is complete.

| Authorized repositories | Rows in scope | Before | After |
| ---: | ---: | ---: | ---: |
| 1 | 10,000 | 31 ms | 8.4 ms |
| 5 | 50,000 | 318 ms | 5.54 ms |
| 50 | 500,000 | 3,696 ms | 3.13 ms |
| 100 | 1,000,000 | 6,805 ms | 1.97 ms |

The broad-scope cases become cheaper because the ordered index finds enough authorized Top-N rows earlier; repository count alone is therefore not the dominant cost after the change.

### Full-text search

A single static access path is pathological at one end of the selectivity range: FULLTEXT-first is best for rare terms, while newest-index-first is substantially faster for broad terms. MySQL now probes at most `5,001` matching IDs, selects the access path, and caches that plan choice for 30 seconds (maximum 256 entries).

| Search shape | Matches / limit | Before | After plan selection |
| --- | ---: | ---: | ---: |
| broad term, 1 authorized repository | about 360k globally / 300 | about 6.7 s | 35.8 ms |
| broad term, all 100 repositories | about 360k / 300 | about 10.3 s | 80.9 ms |
| broad term, all repositories, UI page | about 360k / 20 | not separately recorded | 20.4 ms |
| rare term, all repositories | 200 / 300 | about 4.4 ms | about 4.4 ms |

The first unseen broad query also pays the bounded selectivity probe. Observed probe cost was about `191 ms` for the all-repository broad query and up to about `915 ms` for a narrow single-repository scope; subsequent identical searches during the cache window use the selected 20-81 ms query path. A very broad approximately 959.9k-match probe was about `700 ms`. This is still materially below the previous multi-second sort, while rare searches retain the fast FULLTEXT path.

The benchmark schema was removed after measurement; the existing DEV schema and artifacts were not replaced.

## Index and migration design

- replace the three prefix-equivalent component ordering indexes with covering variants instead of retaining duplicate indexes
- add one repository-only newest-first index for searches without a format filter
- use MySQL `ALGORITHM=INPLACE, LOCK=NONE`
- use restart-safe PostgreSQL `CREATE/DROP INDEX CONCURRENTLY` with Flyway transaction handling disabled for V47
- use `(last_updated_at, id)` keyset pagination with database-specific NULL ordering

## Validation

- [x] 22 DAO and MySQL/PostgreSQL dialect unit tests
- [x] MySQL and PostgreSQL persistence contract tests against real database containers, including V47 migration and NULL-timestamp pagination
- [x] 31 search permission, authorization-scope, selector, and controller tests
- [x] 4 Node global-search interaction tests
- [x] Admin/Browse global-search and Terraform UI resource contract tests
- [x] `git diff --check`
- [x] DEV Flyway V47 startup and authenticated search smoke test; local request returned HTTP 200 in about 29 ms and the LAN request in about 35 ms

## Compatibility and design checklist

- [x] The UI behavior was scoped from the Nexus 3.27 global component search flow reported in #219; no package protocol behavior changes.
- [x] UI-to-backend route and parameter mapping have regression coverage.
- [x] Permission and node-local cache behavior document multi-replica correctness.
- [x] MySQL and PostgreSQL migration paths were exercised against fresh real database containers.

## Notes for reviewers

- Full-repository permissions are SQL-pushed because they map exactly to repository IDs.
- Content selectors remain an explicit bounded post-filter because translating arbitrary selectors into SQL would risk semantic drift or authorization leaks.
- V47 rebuilds component ordering indexes, so large production databases should apply it during a lower-I/O window even though the migration uses online/concurrent index operations.
