### PR TITLE
修复 MySQL 搜索无法匹配短坐标词

### DIFF
--- a/persistence-mysql/src/main/java/com/github/klboke/kkrepo/persistence/mysql/MySqlDatabaseDialect.java
+++ b/persistence-mysql/src/main/java/com/github/klboke/kkrepo/persistence/mysql/MySqlDatabaseDialect.java
@@ -420,6 +420,7 @@ public final class MySqlDatabaseDialect implements DatabaseDialect {
   }
 
   private static final class MySqlSearchPersistenceDialect implements SearchPersistenceDialect {
+    private static final int DEFAULT_INNODB_FT_MIN_TOKEN_SIZE = 3;
     private static final Pattern ALIAS = Pattern.compile("[A-Za-z0-9_]+");
 
     @Override
@@ -456,7 +457,11 @@ public final class MySqlDatabaseDialect implements DatabaseDialect {
 
     private static void addTerm(List<String> terms, StringBuilder token) {
       if (!token.isEmpty()) {
-        terms.add("+" + token + "*");
+        // Requiring a term omitted by InnoDB's default FULLTEXT parser makes the whole boolean
+        // query unmatchable. Keep short terms optional while retaining AND semantics for indexed
+        // terms.
+        boolean indexedByDefault = token.length() >= DEFAULT_INNODB_FT_MIN_TOKEN_SIZE;
+        terms.add((indexedByDefault ? "+" : "") + token + "*");
         token.setLength(0);
       }
     }

--- a/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/MySqlDatabaseDialectTest.java
+++ b/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/MySqlDatabaseDialectTest.java
@@ -43,7 +43,7 @@ class MySqlDatabaseDialectTest {
         "MATCH(s.namespace, s.name, s.version, s.keywords) AGAINST (? IN BOOLEAN MODE)",
         dialect.search().componentSearchPredicate("s"));
     assertEquals(
-        "+com* +example* +artifact* +1* +0*",
+        "+com* +example* +artifact* 1* 0*",
         dialect.search().prepareComponentQuery("\"".repeat(4096) + "Com.Example artifact-1.0"));
     assertEquals(
         "+kkrepo* +alpine* +migration* +app* +datastore_h2_31894582966_1*",
@@ -53,6 +53,13 @@ class MySqlDatabaseDialectTest {
         () -> dialect.json().extractText("attributes_json; DROP TABLE asset", "key"));
     assertThrows(IllegalArgumentException.class,
         () -> dialect.search().componentSearchPredicate("s JOIN component"));
+  }
+
+  @Test
+  void keepsTermsBelowTheDefaultInnoDbFullTextMinimumOptional() {
+    assertEquals(
+        "qh* +agent* +spec* +agentscope*",
+        dialect.search().prepareComponentQuery("qh-agent-spec-agentscope"));
   }
 
   @Test

--- a/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/ComponentDaoTest.java
+++ b/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/ComponentDaoTest.java
@@ -176,7 +176,7 @@ class ComponentDaoTest {
     String keyword = "\"".repeat(4096) + "Com.Example artifact-1.0";
 
     Assertions.assertEquals(
-        "+com* +example* +artifact* +1* +0*",
+        "+com* +example* +artifact* 1* 0*",
         DIALECT.search().prepareComponentQuery(keyword));
   }
 

--- a/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/ComponentSearchMySqlIntegrationTest.java
+++ b/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/ComponentSearchMySqlIntegrationTest.java
@@ -1,0 +1,43 @@
+package com.github.klboke.kkrepo.persistence.jdbc.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.persistence.jdbc.api.ComponentDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.ComponentDao.ComponentSearchRow;
+import com.github.klboke.kkrepo.persistence.jdbc.api.model.ComponentRecord;
+import com.github.klboke.kkrepo.persistence.jdbc.internal.support.HashColumns;
+import com.github.klboke.kkrepo.persistence.mysql.support.MySqlIntegrationTestSupport;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ComponentSearchMySqlIntegrationTest extends MySqlIntegrationTestSupport {
+
+  @Test
+  void searchFindsHyphenatedMavenNameWithShortPrefix() {
+    long repositoryId = insertRepository("maven-releases", "maven2");
+    ComponentDao components = new JdbcComponentDao(jdbc(), jsonColumns(), dialect());
+    String namespace = "com.qunhe.mdw";
+    String name = "qh-agent-spec-agentscope";
+    String version = "0.0.1";
+    components.insert(new ComponentRecord(
+        null,
+        repositoryId,
+        RepositoryFormat.MAVEN2,
+        namespace,
+        name,
+        version,
+        "release",
+        HashColumns.componentCoordinateHash(namespace, name, version),
+        Map.of(),
+        Instant.parse("2026-08-17T00:00:00Z")));
+
+    assertEquals(
+        List.of(name),
+        components.search(name, RepositoryFormat.MAVEN2, 20).stream()
+            .map(ComponentSearchRow::name)
+            .toList());
+  }
+}


### PR DESCRIPTION
## 修改说明

- 对短于 InnoDB 默认 FULLTEXT 最小词长的搜索词取消强制匹配
- 对能够被默认 FULLTEXT 索引的词继续保持 AND 语义
- 增加 qh-agent-spec-agentscope 这类 Maven 坐标的回归测试
- 增加覆盖完整组件搜索流程的真实 MySQL 集成测试

## 问题原因

组件名 qh-agent-spec-agentscope 原来会转换为：

    +qh* +agent* +spec* +agentscope*

InnoDB 默认 innodb_ft_min_token_size 为 3，因此两个字符的 qh 不会进入 FULLTEXT 索引。但查询又要求必须匹配 qh，导致整个布尔查询无法命中。

修改后短词保持可选，其他已索引词仍然必须匹配：

    qh* +agent* +spec* +agentscope*

场景如图：
<img width="1344" height="493" alt="PixPin_2026-08-17_19-42-24" src="https://github.com/user-attachments/assets/e6663af7-cdf6-4015-b30a-58f49cb1dc9a" />

<img width="1918" height="944" alt="PixPin_2026-08-17_18-18-42" src="https://github.com/user-attachments/assets/e972f442-0605-4fae-b5f7-db672110016c" />

## 验证

- [x] 使用 JDK 25 运行 16 个相关单元测试，全部通过
- [x] mvn -pl persistence-mysql -am -DskipTests test-compile
- [x] 部署到 SIT 环境后验证通过
- [ ] 本地 Docker 服务不可用，因此未执行 ComponentSearchMySqlIntegrationTest；该测试已编译通过并提交给 CI 执行

## 兼容性与设计检查

- [x] 不改变仓库协议行为
- [x] 不涉及分布式状态、缓存、锁、会话、后台任务、上传、删除、元数据或权限
- [x] 不涉及数据库迁移