### PR TITLE
refactor: unify local cache creation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@
 
 任何功能在设计和实现时都必须考虑分布式多副本部署。涉及状态、缓存、锁、后台任务、session、上传/删除、索引重建、metadata、negative cache 或权限判定的逻辑，默认不能依赖单个 JVM 进程内状态作为唯一真相；应使用 MySQL、OSS/S3、共享 TTL cache、分布式锁、marker 队列或其它可协调机制。允许使用进程内缓存作为节点本地热缓存，但必须满足：丢失后可自动恢复、不影响正确性、有明确 TTL 或失效条件，并在代码或文档中说明多副本语义。
 
-所有业务模块的进程内缓存必须通过 `cache` 模块提供的统一抽象创建：强类型、可重建的节点本地热缓存使用 `LocalCacheFactory`，跨业务复用的字符串/JSON TTL、negative cache 和 per-pod 计数使用 `SharedCache`。业务模块禁止直接依赖或配置 Caffeine 等具体缓存库，也禁止用裸 `Map` 自行实现长期缓存。新增缓存策略时必须在 `cache` 模块实现，并同步补充 Native runtime hints 与对应测试；已有直接 Caffeine 使用仅允许保留在 `CacheAbstractionBoundaryTest` 的迁移清单中，后续迁移时必须删除对应例外，禁止新增例外。
+所有业务模块的进程内缓存必须通过 `cache` 模块提供的统一抽象创建：强类型、可重建的节点本地热缓存使用 `LocalCacheFactory`，跨业务复用的字符串/JSON TTL、negative cache 和 per-pod 计数使用 `SharedCache`。业务模块禁止直接依赖或配置 Caffeine 等具体缓存库，也禁止用裸 `Map` 自行实现长期缓存。新增缓存策略时必须在 `cache` 模块实现，并同步补充 Native runtime hints 与对应测试；`CacheAbstractionBoundaryTest` 必须保持无业务模块例外。
 
 实现任何类型仓库功能前，必须先检查该仓库的官方协议，保持和官方仓库协议对齐 ，不要自行发明协议行为。
 

--- a/cache/src/main/java/com/github/klboke/kkrepo/cache/CaffeineRuntimeHints.java
+++ b/cache/src/main/java/com/github/klboke/kkrepo/cache/CaffeineRuntimeHints.java
@@ -1,11 +1,11 @@
-package com.github.klboke.kkrepo.server.nativeimage;
+package com.github.klboke.kkrepo.cache;
 
 import java.util.List;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
 
-/** Reflection metadata for Caffeine's configuration-specific cache implementations. */
+/** Reflection metadata for the cache module's configuration-specific Caffeine implementations. */
 public final class CaffeineRuntimeHints implements RuntimeHintsRegistrar {
   static final String CACHE_PACKAGE = "com.github.benmanes.caffeine.cache.";
 
@@ -27,8 +27,7 @@ public final class CaffeineRuntimeHints implements RuntimeHintsRegistrar {
 
   @Override
   public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
-    BOUNDED_CACHE_TYPES.forEach(
-        type -> registerDynamicType(hints, classLoader, type));
+    BOUNDED_CACHE_TYPES.forEach(type -> registerDynamicType(hints, classLoader, type));
     NODE_TYPES.forEach(type -> registerDynamicType(hints, classLoader, type));
   }
 

--- a/cache/src/test/java/com/github/klboke/kkrepo/cache/CaffeineRuntimeHintsTest.java
+++ b/cache/src/test/java/com/github/klboke/kkrepo/cache/CaffeineRuntimeHintsTest.java
@@ -1,4 +1,4 @@
-package com.github.klboke.kkrepo.server.nativeimage;
+package com.github.klboke.kkrepo.cache;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Expiry;
 import com.github.benmanes.caffeine.cache.RemovalCause;
-import com.github.klboke.kkrepo.cache.LocalCacheFactory;
 import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.HashSet;

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -37,10 +37,6 @@
       <artifactId>re2j</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.github.ben-manes.caffeine</groupId>
-      <artifactId>caffeine</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>
       <artifactId>httpclient5</artifactId>
     </dependency>

--- a/server/src/main/java/com/github/klboke/kkrepo/server/KkRepoApplication.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/KkRepoApplication.java
@@ -1,7 +1,7 @@
 package com.github.klboke.kkrepo.server;
 
+import com.github.klboke.kkrepo.cache.CaffeineRuntimeHints;
 import com.github.klboke.kkrepo.server.nativeimage.ApolloRuntimeHints;
-import com.github.klboke.kkrepo.server.nativeimage.CaffeineRuntimeHints;
 import com.github.klboke.kkrepo.server.nativeimage.JacksonRuntimeHints;
 import com.github.klboke.kkrepo.server.nativeimage.QuartzRuntimeHints;
 import com.github.klboke.kkrepo.server.nativeimage.SecuritySessionRuntimeHints;

--- a/server/src/main/java/com/github/klboke/kkrepo/server/alpine/AlpinePublishedSnapshotCache.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/alpine/AlpinePublishedSnapshotCache.java
@@ -1,7 +1,7 @@
 package com.github.klboke.kkrepo.server.alpine;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.klboke.kkrepo.cache.LocalCache;
+import com.github.klboke.kkrepo.cache.LocalCacheFactory;
 import com.github.klboke.kkrepo.persistence.jdbc.api.AlpineRegistryDao;
 import com.github.klboke.kkrepo.server.cache.VersionWatermark;
 import java.time.Duration;
@@ -28,8 +28,8 @@ final class AlpinePublishedSnapshotCache {
 
   private final AlpineRegistryDao registry;
   private final VersionWatermark watermark;
-  private final Cache<SuiteKey, AlpineRegistryDao.Snapshot> snapshots;
-  private final Cache<SuiteKey, Long> observedVersions;
+  private final LocalCache<SuiteKey, AlpineRegistryDao.Snapshot> snapshots;
+  private final LocalCache<SuiteKey, Long> observedVersions;
   private final boolean enabled;
 
   @Autowired
@@ -42,11 +42,13 @@ final class AlpinePublishedSnapshotCache {
     this.watermark = watermark;
     this.enabled = enabled && ttlSeconds > 0;
     Duration ttl = Duration.ofSeconds(Math.max(1, ttlSeconds));
-    this.snapshots = Caffeine.newBuilder()
+    this.snapshots = LocalCacheFactory.standard()
+        .<SuiteKey, AlpineRegistryDao.Snapshot>builder("alpine-published-snapshots")
         .expireAfterWrite(ttl)
         .maximumSize(100_000)
         .build();
-    this.observedVersions = Caffeine.newBuilder()
+    this.observedVersions = LocalCacheFactory.standard()
+        .<SuiteKey, Long>builder("alpine-published-snapshot-versions")
         .maximumSize(100_000)
         .build();
   }

--- a/server/src/main/java/com/github/klboke/kkrepo/server/alpine/AlpineRepositorySettings.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/alpine/AlpineRepositorySettings.java
@@ -1,7 +1,7 @@
 package com.github.klboke.kkrepo.server.alpine;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.klboke.kkrepo.cache.LocalCache;
+import com.github.klboke.kkrepo.cache.LocalCacheFactory;
 import com.github.klboke.kkrepo.core.RepositoryFormat;
 import com.github.klboke.kkrepo.core.RepositoryType;
 import com.github.klboke.kkrepo.persistence.jdbc.api.RepositoryDao;
@@ -32,7 +32,7 @@ import org.springframework.stereotype.Component;
 @Component
 final class AlpineRepositorySettings {
   private final RepositoryRuntimeRegistry repositories;
-  private final Cache<RepositoryKey, CachedSettings> cache;
+  private final LocalCache<RepositoryKey, CachedSettings> cache;
   private final boolean cacheEnabled;
 
   @Autowired
@@ -41,7 +41,8 @@ final class AlpineRepositorySettings {
       @Value("${kkrepo.alpine.settings-cache-ttl-seconds:30}") long ttlSeconds) {
     this.repositories = repositories;
     this.cacheEnabled = ttlSeconds > 0;
-    this.cache = Caffeine.newBuilder()
+    this.cache = LocalCacheFactory.standard()
+        .<RepositoryKey, CachedSettings>builder("alpine-repository-settings")
         .expireAfterWrite(Duration.ofSeconds(Math.max(1, ttlSeconds)))
         .maximumSize(100_000)
         .build();

--- a/server/src/main/java/com/github/klboke/kkrepo/server/apt/AptPublishedSnapshotCache.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/apt/AptPublishedSnapshotCache.java
@@ -1,7 +1,7 @@
 package com.github.klboke.kkrepo.server.apt;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.klboke.kkrepo.cache.LocalCache;
+import com.github.klboke.kkrepo.cache.LocalCacheFactory;
 import com.github.klboke.kkrepo.persistence.jdbc.api.AptRegistryDao;
 import com.github.klboke.kkrepo.server.cache.VersionWatermark;
 import java.time.Duration;
@@ -28,8 +28,8 @@ final class AptPublishedSnapshotCache {
 
   private final AptRegistryDao registry;
   private final VersionWatermark watermark;
-  private final Cache<SuiteKey, AptRegistryDao.Snapshot> snapshots;
-  private final Cache<SuiteKey, Long> observedVersions;
+  private final LocalCache<SuiteKey, AptRegistryDao.Snapshot> snapshots;
+  private final LocalCache<SuiteKey, Long> observedVersions;
   private final boolean enabled;
 
   @Autowired
@@ -42,11 +42,13 @@ final class AptPublishedSnapshotCache {
     this.watermark = watermark;
     this.enabled = enabled && ttlSeconds > 0;
     Duration ttl = Duration.ofSeconds(Math.max(1, ttlSeconds));
-    this.snapshots = Caffeine.newBuilder()
+    this.snapshots = LocalCacheFactory.standard()
+        .<SuiteKey, AptRegistryDao.Snapshot>builder("apt-published-snapshots")
         .expireAfterWrite(ttl)
         .maximumSize(100_000)
         .build();
-    this.observedVersions = Caffeine.newBuilder()
+    this.observedVersions = LocalCacheFactory.standard()
+        .<SuiteKey, Long>builder("apt-published-snapshot-versions")
         .maximumSize(100_000)
         .build();
   }

--- a/server/src/main/java/com/github/klboke/kkrepo/server/apt/AptRepositorySettings.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/apt/AptRepositorySettings.java
@@ -1,7 +1,7 @@
 package com.github.klboke.kkrepo.server.apt;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.klboke.kkrepo.cache.LocalCache;
+import com.github.klboke.kkrepo.cache.LocalCacheFactory;
 import com.github.klboke.kkrepo.core.RepositoryFormat;
 import com.github.klboke.kkrepo.core.RepositoryType;
 import com.github.klboke.kkrepo.persistence.jdbc.api.RepositoryDao;
@@ -29,7 +29,7 @@ import org.springframework.stereotype.Component;
 @Component
 final class AptRepositorySettings {
   private final RepositoryRuntimeRegistry repositories;
-  private final Cache<RepositoryKey, CachedSettings> cache;
+  private final LocalCache<RepositoryKey, CachedSettings> cache;
   private final boolean cacheEnabled;
 
   @Autowired
@@ -38,7 +38,8 @@ final class AptRepositorySettings {
       @Value("${kkrepo.apt.settings-cache-ttl-seconds:30}") long ttlSeconds) {
     this.repositories = repositories;
     this.cacheEnabled = ttlSeconds > 0;
-    this.cache = Caffeine.newBuilder()
+    this.cache = LocalCacheFactory.standard()
+        .<RepositoryKey, CachedSettings>builder("apt-repository-settings")
         .expireAfterWrite(Duration.ofSeconds(Math.max(1, ttlSeconds)))
         .maximumSize(100_000)
         .build();

--- a/server/src/main/java/com/github/klboke/kkrepo/server/cache/AssetMetadataCache.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/cache/AssetMetadataCache.java
@@ -3,8 +3,8 @@ package com.github.klboke.kkrepo.server.cache;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.klboke.kkrepo.cache.LocalCache;
+import com.github.klboke.kkrepo.cache.LocalCacheFactory;
 import com.github.klboke.kkrepo.cache.SharedCache;
 import com.github.klboke.kkrepo.persistence.jdbc.api.AssetDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.AssetBlobRecord;
@@ -49,9 +49,9 @@ public class AssetMetadataCache {
   private final SharedCache sharedCache;
   private final ObjectMapper objectMapper;
   private final VersionWatermark watermark;
-  private final Cache<Long, Long> observedVersions;
-  private final Cache<String, CachedAssetMetadata> localSnapshots;
-  private final Cache<String, Boolean> localMissing;
+  private final LocalCache<Long, Long> observedVersions;
+  private final LocalCache<String, CachedAssetMetadata> localSnapshots;
+  private final LocalCache<String, Boolean> localMissing;
   private final boolean enabled;
   private final Duration positiveTtl;
   private final Duration missingTtl;
@@ -67,15 +67,20 @@ public class AssetMetadataCache {
     this.sharedCache = sharedCache;
     this.objectMapper = objectMapper;
     this.watermark = watermark;
-    this.observedVersions = Caffeine.newBuilder().maximumSize(100_000).build();
+    this.observedVersions = LocalCacheFactory.standard()
+        .<Long, Long>builder("asset-metadata-versions")
+        .maximumSize(100_000)
+        .build();
     this.enabled = enabled;
     this.positiveTtl = ttlSeconds <= 0 ? Duration.ZERO : Duration.ofSeconds(ttlSeconds);
     this.missingTtl = missingTtlSeconds <= 0 ? Duration.ZERO : Duration.ofSeconds(missingTtlSeconds);
-    this.localSnapshots = Caffeine.newBuilder()
+    this.localSnapshots = LocalCacheFactory.standard()
+        .<String, CachedAssetMetadata>builder("asset-metadata-snapshots")
         .expireAfterWrite(Duration.ofSeconds(Math.max(1, ttlSeconds)))
         .maximumSize(100_000)
         .build();
-    this.localMissing = Caffeine.newBuilder()
+    this.localMissing = LocalCacheFactory.standard()
+        .<String, Boolean>builder("asset-metadata-missing")
         .expireAfterWrite(Duration.ofSeconds(Math.max(1, missingTtlSeconds)))
         .maximumSize(100_000)
         .build();

--- a/server/src/main/java/com/github/klboke/kkrepo/server/cache/JdbcVersionWatermark.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/cache/JdbcVersionWatermark.java
@@ -1,24 +1,25 @@
 package com.github.klboke.kkrepo.server.cache;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.klboke.kkrepo.cache.LocalCache;
+import com.github.klboke.kkrepo.cache.LocalCacheFactory;
 import com.github.klboke.kkrepo.persistence.jdbc.api.CacheVersionDao;
+import java.time.Duration;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
 public class JdbcVersionWatermark implements VersionWatermark {
   private final CacheVersionDao dao;
-  private final Cache<String, Long> localVersions;
+  private final LocalCache<String, Long> localVersions;
 
   public JdbcVersionWatermark(
       CacheVersionDao dao,
       @Value("${kkrepo.cache.version.local-ttl-seconds:2}") long localTtlSeconds) {
     this.dao = dao;
-    this.localVersions = Caffeine.newBuilder()
-        .expireAfterWrite(Math.max(1, localTtlSeconds), TimeUnit.SECONDS)
+    this.localVersions = LocalCacheFactory.standard()
+        .<String, Long>builder("jdbc-version-watermarks")
+        .expireAfterWrite(Duration.ofSeconds(Math.max(1, localTtlSeconds)))
         .maximumSize(100_000)
         .build();
   }

--- a/server/src/main/java/com/github/klboke/kkrepo/server/cache/NexusLikeCacheController.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/cache/NexusLikeCacheController.java
@@ -1,11 +1,11 @@
 package com.github.klboke.kkrepo.server.cache;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.klboke.kkrepo.cache.LocalCache;
+import com.github.klboke.kkrepo.cache.LocalCacheFactory;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.LinkedHashSet;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,14 +22,15 @@ public class NexusLikeCacheController {
       NexusLikeCacheController.class.getName() + ".PENDING_INVALIDATIONS";
 
   private final VersionWatermark watermark;
-  private final Cache<String, String> localTokens;
+  private final LocalCache<String, String> localTokens;
 
   public NexusLikeCacheController(
       VersionWatermark watermark,
       @Value("${kkrepo.cache.repository-token.local-ttl-seconds:2}") long localTokenTtlSeconds) {
     this.watermark = watermark;
-    this.localTokens = Caffeine.newBuilder()
-        .expireAfterWrite(Math.max(1, localTokenTtlSeconds), TimeUnit.SECONDS)
+    this.localTokens = LocalCacheFactory.standard()
+        .<String, String>builder("nexus-like-repository-tokens")
+        .expireAfterWrite(Duration.ofSeconds(Math.max(1, localTokenTtlSeconds)))
         .maximumSize(100_000)
         .build();
   }

--- a/server/src/main/java/com/github/klboke/kkrepo/server/conan/ConanRemoteClient.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/conan/ConanRemoteClient.java
@@ -1,7 +1,7 @@
 package com.github.klboke.kkrepo.server.conan;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.klboke.kkrepo.cache.LocalCache;
+import com.github.klboke.kkrepo.cache.LocalCacheFactory;
 import com.github.klboke.kkrepo.persistence.jdbc.api.PersistenceHashes;
 import com.github.klboke.kkrepo.server.maven.HttpRemoteFetcher;
 import com.github.klboke.kkrepo.server.maven.MavenResponse;
@@ -22,7 +22,8 @@ final class ConanRemoteClient {
   private static final int MAX_TOKEN_BYTES = 4096;
   private final RawProxyService proxy;
   private final HttpRemoteFetcher fetcher;
-  private final Cache<String, String> exchangedTokens = Caffeine.newBuilder()
+  private final LocalCache<String, String> exchangedTokens = LocalCacheFactory.standard()
+      .<String, String>builder("conan-exchanged-tokens")
       .expireAfterWrite(Duration.ofMinutes(50))
       .maximumSize(10_000)
       .build();

--- a/server/src/main/java/com/github/klboke/kkrepo/server/maven/BlobStorageRegistry.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/maven/BlobStorageRegistry.java
@@ -1,8 +1,7 @@
 package com.github.klboke.kkrepo.server.maven;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.klboke.kkrepo.cache.LocalCache;
+import com.github.klboke.kkrepo.cache.LocalCacheFactory;
 import com.github.klboke.kkrepo.core.BlobStorage;
 import com.github.klboke.kkrepo.persistence.jdbc.api.BlobStoreDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.BlobStoreRecord;
@@ -49,8 +48,9 @@ public class BlobStorageRegistry {
   private final FileBlobStorageFactory fileFactory;
   private final S3StorageProperties fallback;
   private final KkRepoMetrics metrics;
-  private final Cache<String, BlobStorage> cache = Caffeine.newBuilder()
-      .removalListener((String key, BlobStorage storage, RemovalCause cause) -> closeQuietly(storage))
+  private final LocalCache<String, BlobStorage> cache = LocalCacheFactory.standard()
+      .<String, BlobStorage>builder("blob-storages")
+      .removalListener((key, storage, cause) -> closeQuietly(storage))
       .build();
   private final boolean catalogCacheEnabled;
   private final CatalogCacheBroadcaster broadcaster;

--- a/server/src/main/java/com/github/klboke/kkrepo/server/maven/RepositoryRuntimeRegistry.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/maven/RepositoryRuntimeRegistry.java
@@ -2,8 +2,8 @@ package com.github.klboke.kkrepo.server.maven;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.klboke.kkrepo.cache.LocalCache;
+import com.github.klboke.kkrepo.cache.LocalCacheFactory;
 import com.github.klboke.kkrepo.cache.SharedCache;
 import com.github.klboke.kkrepo.core.RepositoryFormat;
 import com.github.klboke.kkrepo.core.RepositoryType;
@@ -56,9 +56,9 @@ public class RepositoryRuntimeRegistry {
   private final SharedCache cache;
   private final ObjectMapper objectMapper;
   private final CatalogCacheBroadcaster broadcaster;
-  private final Cache<String, Optional<RepositoryRuntime>> localRuntimes;
-  private final Cache<String, Optional<RepositoryRecord>> localRecordsByName;
-  private final Cache<Long, RepositoryRecord> localRecordsById;
+  private final LocalCache<String, Optional<RepositoryRuntime>> localRuntimes;
+  private final LocalCache<String, Optional<RepositoryRecord>> localRecordsByName;
+  private final LocalCache<Long, RepositoryRecord> localRecordsById;
   private final AtomicBoolean subscribed = new AtomicBoolean();
   private final AtomicLong configurationVersion = new AtomicLong();
 
@@ -85,15 +85,18 @@ public class RepositoryRuntimeRegistry {
     this.broadcaster = broadcaster;
     this.ttl = Duration.ofSeconds(Math.max(0, ttlSeconds));
     Duration localTtl = this.ttl.isZero() ? Duration.ofSeconds(1) : this.ttl;
-    this.localRuntimes = Caffeine.newBuilder()
+    this.localRuntimes = LocalCacheFactory.standard()
+        .<String, Optional<RepositoryRuntime>>builder("repository-runtimes")
         .expireAfterWrite(localTtl)
         .maximumSize(100_000)
         .build();
-    this.localRecordsByName = Caffeine.newBuilder()
+    this.localRecordsByName = LocalCacheFactory.standard()
+        .<String, Optional<RepositoryRecord>>builder("repository-records-by-name")
         .expireAfterWrite(localTtl)
         .maximumSize(100_000)
         .build();
-    this.localRecordsById = Caffeine.newBuilder()
+    this.localRecordsById = LocalCacheFactory.standard()
+        .<Long, RepositoryRecord>builder("repository-records-by-id")
         .expireAfterWrite(localTtl)
         .maximumSize(100_000)
         .build();
@@ -106,15 +109,18 @@ public class RepositoryRuntimeRegistry {
     this.broadcaster = null;
     this.ttl = Duration.ofSeconds(Math.max(0, ttlSeconds));
     Duration localTtl = this.ttl.isZero() ? Duration.ofSeconds(1) : this.ttl;
-    this.localRuntimes = Caffeine.newBuilder()
+    this.localRuntimes = LocalCacheFactory.standard()
+        .<String, Optional<RepositoryRuntime>>builder("repository-runtimes")
         .expireAfterWrite(localTtl)
         .maximumSize(100_000)
         .build();
-    this.localRecordsByName = Caffeine.newBuilder()
+    this.localRecordsByName = LocalCacheFactory.standard()
+        .<String, Optional<RepositoryRecord>>builder("repository-records-by-name")
         .expireAfterWrite(localTtl)
         .maximumSize(100_000)
         .build();
-    this.localRecordsById = Caffeine.newBuilder()
+    this.localRecordsById = LocalCacheFactory.standard()
+        .<Long, RepositoryRecord>builder("repository-records-by-id")
         .expireAfterWrite(localTtl)
         .maximumSize(100_000)
         .build();

--- a/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmReleaseAgeCache.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmReleaseAgeCache.java
@@ -1,7 +1,7 @@
 package com.github.klboke.kkrepo.server.npm;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.klboke.kkrepo.cache.LocalCache;
+import com.github.klboke.kkrepo.cache.LocalCacheFactory;
 import com.github.klboke.kkrepo.protocol.npm.NpmMinimumReleaseAge;
 import com.github.klboke.kkrepo.server.cache.CachedAssetMetadata;
 import java.time.Duration;
@@ -16,13 +16,14 @@ import org.springframework.stereotype.Service;
  *
  * <p>The raw packument in shared blob storage remains the source of truth. Keys include the durable
  * blob identity and the configured policy, so losing this cache only costs a rebuild and stale
- * entries cannot be selected after another replica stores a new packument revision. Caffeine's
- * atomic {@code get(key, mappingFunction)} also gives each replica per-key single-flight loading.
+ * entries cannot be selected after another replica stores a new packument revision. The local
+ * cache's atomic {@code get(key, mappingFunction)} also gives each replica per-key single-flight
+ * loading.
  */
 @Service
 public class NpmReleaseAgeCache {
-  private final Cache<AnalysisKey, NpmMinimumReleaseAge.Analysis> analyses;
-  private final Cache<ResponseKey, byte[]> responses;
+  private final LocalCache<AnalysisKey, NpmMinimumReleaseAge.Analysis> analyses;
+  private final LocalCache<ResponseKey, byte[]> responses;
 
   public NpmReleaseAgeCache(
       @Value("${kkrepo.cache.npm-release-age.maximum-version-entries:100000}")
@@ -32,15 +33,18 @@ public class NpmReleaseAgeCache {
       @Value("${kkrepo.cache.npm-release-age.expire-after-access-minutes:30}")
       long expireAfterAccessMinutes) {
     Duration expiry = Duration.ofMinutes(Math.max(1, expireAfterAccessMinutes));
-    this.analyses = Caffeine.newBuilder()
-        .maximumWeight(Math.max(1, maximumVersionEntries))
-        .weigher((AnalysisKey ignored, NpmMinimumReleaseAge.Analysis analysis) ->
-            analysis.cacheWeight())
+    this.analyses = LocalCacheFactory.standard()
+        .<AnalysisKey, NpmMinimumReleaseAge.Analysis>builder("npm-release-age-analyses")
+        .maximumWeight(
+            Math.max(1, maximumVersionEntries),
+            (ignored, analysis) -> analysis.cacheWeight())
         .expireAfterAccess(expiry)
         .build();
-    this.responses = Caffeine.newBuilder()
-        .maximumWeight(Math.max(1, responseMaximumBytes))
-        .weigher((ResponseKey ignored, byte[] bytes) -> Math.max(1, bytes.length))
+    this.responses = LocalCacheFactory.standard()
+        .<ResponseKey, byte[]>builder("npm-release-age-responses")
+        .maximumWeight(
+            Math.max(1, responseMaximumBytes),
+            (ignored, bytes) -> Math.max(1, bytes.length))
         .expireAfterAccess(expiry)
         .build();
   }

--- a/server/src/main/java/com/github/klboke/kkrepo/server/proxy/ProxiedHttpClientFactory.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/proxy/ProxiedHttpClientFactory.java
@@ -1,8 +1,7 @@
 package com.github.klboke.kkrepo.server.proxy;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.klboke.kkrepo.cache.LocalCache;
+import com.github.klboke.kkrepo.cache.LocalCacheFactory;
 import com.github.klboke.kkrepo.server.security.OutboundRequestPolicy.ResolvedHttpTarget;
 import jakarta.annotation.PreDestroy;
 import java.io.IOException;
@@ -62,7 +61,7 @@ import org.springframework.stereotype.Component;
  * cached client drops its credentials with it.
  *
  * <p>Each distinct (owning repository, {@link OutboundProxyConfig#cacheKey()}) pair gets its own
- * pooled {@link CloseableHttpClient} in a Caffeine cache. Keying by owner means two repositories
+ * pooled {@link CloseableHttpClient} in a node-local cache. Keying by owner means two repositories
  * that happen to share identical proxy settings never share one client, so an update or delete of
  * one repository can never close a pool the other repository is still streaming from. Entries
  * expire after a period without use
@@ -93,7 +92,7 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
     }
   };
 
-  private final Cache<String, CloseableHttpClient> cache;
+  private final LocalCache<String, CloseableHttpClient> cache;
   private final CloseableHttpClient directClient;
   private final Duration idleTtl;
   private final Duration connectTimeout;
@@ -103,10 +102,10 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
       @Value("${kkrepo.outbound-proxy.connect-timeout-ms:10000}") long connectTimeoutMillis) {
     this.idleTtl = Duration.ofMillis(Math.max(1L, idleTtlMillis));
     this.connectTimeout = Duration.ofMillis(Math.max(1L, connectTimeoutMillis));
-    this.cache = Caffeine.newBuilder()
+    this.cache = LocalCacheFactory.standard()
+        .<String, CloseableHttpClient>builder("outbound-proxy-clients")
         .expireAfterAccess(this.idleTtl)
-        .removalListener((String key, CloseableHttpClient client, RemovalCause cause) ->
-            closeQuietly(client))
+        .removalListener((key, client, cause) -> closeQuietly(client))
         .build();
     this.directClient = buildDirect();
   }
@@ -144,7 +143,7 @@ public class ProxiedHttpClientFactory implements AutoCloseable {
 
   /**
    * Closes every cached client and its connection pool. Invoked on application shutdown so pooled
-   * connections do not outlive the process; the Caffeine removal listener also closes any client
+   * connections do not outlive the process; the cache removal listener also closes any client
    * evicted by the idle TTL.
    */
   @PreDestroy

--- a/server/src/main/java/com/github/klboke/kkrepo/server/security/BasicAuthCache.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/security/BasicAuthCache.java
@@ -2,8 +2,8 @@ package com.github.klboke.kkrepo.server.security;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.klboke.kkrepo.cache.LocalCache;
+import com.github.klboke.kkrepo.cache.LocalCacheFactory;
 import com.github.klboke.kkrepo.cache.SharedCache;
 import com.github.klboke.kkrepo.core.security.EncryptionSecrets;
 import java.nio.charset.StandardCharsets;
@@ -52,8 +52,8 @@ public class BasicAuthCache {
 
   private final SharedCache sharedCache;
   private final ObjectMapper objectMapper;
-  private final Cache<String, AuthenticatedSubject> localSubjects;
-  private final Cache<String, Boolean> localMissing;
+  private final LocalCache<String, AuthenticatedSubject> localSubjects;
+  private final LocalCache<String, Boolean> localMissing;
   private final boolean enabled;
   private final Duration positiveTtl;
   private final Duration negativeTtl;
@@ -70,11 +70,13 @@ public class BasicAuthCache {
     this.enabled = enabled;
     this.positiveTtl = ttlSeconds <= 0 ? Duration.ZERO : Duration.ofSeconds(ttlSeconds);
     this.negativeTtl = missingTtlSeconds <= 0 ? Duration.ZERO : Duration.ofSeconds(missingTtlSeconds);
-    this.localSubjects = Caffeine.newBuilder()
+    this.localSubjects = LocalCacheFactory.standard()
+        .<String, AuthenticatedSubject>builder("basic-auth-subjects")
         .expireAfterWrite(Duration.ofSeconds(Math.max(1, ttlSeconds)))
         .maximumSize(100_000)
         .build();
-    this.localMissing = Caffeine.newBuilder()
+    this.localMissing = LocalCacheFactory.standard()
+        .<String, Boolean>builder("basic-auth-missing")
         .expireAfterWrite(Duration.ofSeconds(Math.max(1, missingTtlSeconds)))
         .maximumSize(100_000)
         .build();

--- a/server/src/main/java/com/github/klboke/kkrepo/server/security/SecurityAuthorizationCache.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/security/SecurityAuthorizationCache.java
@@ -1,9 +1,9 @@
 package com.github.klboke.kkrepo.server.security;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.klboke.kkrepo.auth.PermissionSubject;
+import com.github.klboke.kkrepo.cache.LocalCache;
+import com.github.klboke.kkrepo.cache.LocalCacheFactory;
 import com.github.klboke.kkrepo.cache.SharedCache;
 import com.github.klboke.kkrepo.server.cache.VersionWatermark;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.SecurityPrivilegeRecord;
@@ -16,7 +16,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.slf4j.Logger;
@@ -40,7 +39,7 @@ public class SecurityAuthorizationCache {
   private final VersionWatermark watermark;
   private final boolean enabled;
   private final Duration snapshotTtl;
-  private final Cache<String, String> versionCache;
+  private final LocalCache<String, String> versionCache;
 
   @Autowired
   public SecurityAuthorizationCache(
@@ -53,8 +52,9 @@ public class SecurityAuthorizationCache {
     this.watermark = watermark;
     this.enabled = enabled;
     this.snapshotTtl = ttlMinutes <= 0 ? Duration.ZERO : Duration.ofMinutes(ttlMinutes);
-    this.versionCache = Caffeine.newBuilder()
-        .expireAfterWrite(Math.max(1, versionLocalTtlSeconds), TimeUnit.SECONDS)
+    this.versionCache = LocalCacheFactory.standard()
+        .<String, String>builder("security-authorization-version")
+        .expireAfterWrite(Duration.ofSeconds(Math.max(1, versionLocalTtlSeconds)))
         .maximumSize(1)
         .build();
   }

--- a/server/src/test/java/com/github/klboke/kkrepo/server/architecture/CacheAbstractionBoundaryTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/architecture/CacheAbstractionBoundaryTest.java
@@ -12,29 +12,8 @@ import org.junit.jupiter.api.Test;
 
 class CacheAbstractionBoundaryTest {
   private static final String CAFFEINE_PACKAGE = "com.github.benmanes.caffeine";
-
-  /**
-   * Audited migration debt. New entries are forbidden; follow-up cache migration work must remove
-   * entries as each class moves to LocalCacheFactory.
-   */
-  private static final Set<String> LEGACY_DIRECT_CAFFEINE_FILES = Set.of(
-      "server/src/main/java/com/github/klboke/kkrepo/server/alpine/AlpinePublishedSnapshotCache.java",
-      "server/src/main/java/com/github/klboke/kkrepo/server/alpine/AlpineRepositorySettings.java",
-      "server/src/main/java/com/github/klboke/kkrepo/server/apt/AptPublishedSnapshotCache.java",
-      "server/src/main/java/com/github/klboke/kkrepo/server/apt/AptRepositorySettings.java",
-      "server/src/main/java/com/github/klboke/kkrepo/server/cache/AssetMetadataCache.java",
-      "server/src/main/java/com/github/klboke/kkrepo/server/cache/JdbcVersionWatermark.java",
-      "server/src/main/java/com/github/klboke/kkrepo/server/cache/NexusLikeCacheController.java",
-      "server/src/main/java/com/github/klboke/kkrepo/server/conan/ConanRemoteClient.java",
-      "server/src/main/java/com/github/klboke/kkrepo/server/maven/BlobStorageRegistry.java",
-      "server/src/main/java/com/github/klboke/kkrepo/server/maven/RepositoryRuntimeRegistry.java",
-      "server/src/main/java/com/github/klboke/kkrepo/server/nativeimage/CaffeineRuntimeHints.java",
-      "server/src/main/java/com/github/klboke/kkrepo/server/npm/NpmReleaseAgeCache.java",
-      "server/src/main/java/com/github/klboke/kkrepo/server/proxy/ProxiedHttpClientFactory.java",
-      "server/src/main/java/com/github/klboke/kkrepo/server/security/BasicAuthCache.java",
-      "server/src/main/java/com/github/klboke/kkrepo/server/security/SecurityAuthorizationCache.java",
-      "storage-s3/src/main/java/com/github/klboke/kkrepo/storage/s3/OssClientFactory.java",
-      "storage-s3/src/main/java/com/github/klboke/kkrepo/storage/s3/S3ClientFactory.java");
+  private static final String CAFFEINE_GROUP_ID =
+      "<groupId>com.github.ben-manes.caffeine</groupId>";
 
   @Test
   void productionCodeDoesNotAddDirectCacheBackendDependencies() throws IOException {
@@ -59,9 +38,29 @@ class CacheAbstractionBoundaryTest {
       }
     }
 
-    assertEquals(LEGACY_DIRECT_CAFFEINE_FILES, directBackendUsers,
-        "Business caches must use cache-module abstractions. Remove migrated legacy entries; "
-            + "do not add new direct Caffeine users.");
+    assertEquals(Set.of(), directBackendUsers,
+        "Production caches outside the cache module must use cache-module abstractions; "
+            + "direct Caffeine dependencies are forbidden.");
+  }
+
+  @Test
+  void businessModulesDoNotDeclareDirectCacheBackendDependencies() throws IOException {
+    Path root = repositoryRoot();
+    Set<String> directBackendDependencies = new LinkedHashSet<>();
+    try (Stream<Path> modules = Files.list(root)) {
+      for (Path module : modules.filter(Files::isDirectory).toList()) {
+        if (module.getFileName().toString().equals("cache")) {
+          continue;
+        }
+        Path pom = module.resolve("pom.xml");
+        if (Files.isRegularFile(pom) && Files.readString(pom).contains(CAFFEINE_GROUP_ID)) {
+          directBackendDependencies.add(root.relativize(pom).toString());
+        }
+      }
+    }
+
+    assertEquals(Set.of(), directBackendDependencies,
+        "Business modules must depend on the cache module rather than a cache backend directly.");
   }
 
   private static Path repositoryRoot() {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/support/InMemorySharedCache.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/support/InMemorySharedCache.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.klboke.kkrepo.cache.LocalCache;
+import com.github.klboke.kkrepo.cache.LocalCacheFactory;
 import com.github.klboke.kkrepo.cache.SharedCache;
 import java.time.Duration;
 import java.time.Instant;
@@ -14,8 +14,12 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class InMemorySharedCache implements SharedCache {
   private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
-  private final Cache<String, Entry> values = Caffeine.newBuilder().build();
-  private final Cache<String, AtomicLong> counters = Caffeine.newBuilder().build();
+  private final LocalCache<String, Entry> values = LocalCacheFactory.standard()
+      .<String, Entry>builder("test-shared-cache-values")
+      .build();
+  private final LocalCache<String, AtomicLong> counters = LocalCacheFactory.standard()
+      .<String, AtomicLong>builder("test-shared-cache-counters")
+      .build();
 
   @Override
   public Optional<String> getString(String namespace, String key) {

--- a/storage-s3/pom.xml
+++ b/storage-s3/pom.xml
@@ -17,16 +17,16 @@
       <artifactId>kkrepo-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.github.klboke</groupId>
+      <artifactId>kkrepo-cache</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.github.ben-manes.caffeine</groupId>
-      <artifactId>caffeine</artifactId>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>

--- a/storage-s3/src/main/java/com/github/klboke/kkrepo/storage/s3/OssClientFactory.java
+++ b/storage-s3/src/main/java/com/github/klboke/kkrepo/storage/s3/OssClientFactory.java
@@ -5,8 +5,8 @@ import com.aliyun.sdk.service.oss2.credentials.StaticCredentialsProvider;
 import com.aliyun.sdk.service.oss2.transport.HttpClientOptions;
 import com.aliyun.sdk.service.oss2.transport.apache5client.Apache5HttpClient;
 import com.aliyun.sdk.service.oss2.transport.apache5client.Apache5HttpClientBuilder;
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.klboke.kkrepo.cache.LocalCache;
+import com.github.klboke.kkrepo.cache.LocalCacheFactory;
 import jakarta.annotation.PreDestroy;
 import java.time.Duration;
 import org.springframework.stereotype.Component;
@@ -21,7 +21,9 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class OssClientFactory {
-  private final Cache<Long, CachedClient> cache = Caffeine.newBuilder().build();
+  private final LocalCache<Long, CachedClient> cache = LocalCacheFactory.standard()
+      .<Long, CachedClient>builder("oss-clients")
+      .build();
 
   public OSSClient client(S3BlobStoreConfig config) {
     String signature = config.signature();

--- a/storage-s3/src/main/java/com/github/klboke/kkrepo/storage/s3/S3ClientFactory.java
+++ b/storage-s3/src/main/java/com/github/klboke/kkrepo/storage/s3/S3ClientFactory.java
@@ -1,7 +1,7 @@
 package com.github.klboke.kkrepo.storage.s3;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.klboke.kkrepo.cache.LocalCache;
+import com.github.klboke.kkrepo.cache.LocalCacheFactory;
 import jakarta.annotation.PreDestroy;
 import java.net.URI;
 import java.time.Duration;
@@ -15,7 +15,9 @@ import software.amazon.awssdk.services.s3.S3Configuration;
 
 @Component
 public class S3ClientFactory {
-  private final Cache<Long, CachedClient> cache = Caffeine.newBuilder().build();
+  private final LocalCache<Long, CachedClient> cache = LocalCacheFactory.standard()
+      .<Long, CachedClient>builder("s3-clients")
+      .build();
 
   public S3Client client(S3BlobStoreConfig config) {
     String signature = config.signature();


### PR DESCRIPTION
## Summary

- Migrate all 16 remaining direct Caffeine users in `server` and `storage-s3` to the typed `LocalCacheFactory` abstraction while preserving their existing TTL, size/weight, single-flight, concurrent-map, and removal-listener behavior.
- Move Caffeine native runtime hints and their tests into the `cache` module, remove direct Caffeine dependencies from business modules, and make `storage-s3` depend on `kkrepo-cache` instead.
- Tighten `CacheAbstractionBoundaryTest` so both production source imports and Maven dependencies must keep the cache backend isolated inside the `cache` module, and update `AGENTS.md` to require zero business-module exceptions.

## Why

PR #224 introduced the typed local-cache abstraction for Hugging Face and intentionally left the existing direct Caffeine users on an audited migration list. Keeping backend configuration in business modules makes cache implementations harder to replace or manage consistently. This follow-up removes that migration debt and makes the module boundary enforceable.

## Validation

- [x] `mvn -pl cache,storage-s3,server -am -DskipTests compile`
- [x] Targeted cache regression suite: 103 tests passed.
- [x] `mvn -pl cache,storage-s3,server -am test` — all 33 reactor modules passed; server ran 2,567 tests with zero failures (9m16s total).
- [x] `mvn -pl server -am -Dtest=CacheAbstractionBoundaryTest -Dsurefire.failIfNoSpecifiedTests=false test` — 2 tests passed.
- [x] Full E2E [run 32107989779](https://github.com/klboke/kkRepo/actions/runs/32107989779) passed, including OCI conformance, Nexus compatibility, Swift Windows/macOS/dual-replica coverage, and the full Nexus migration matrix.
- [x] JVM real-client E2E passed on MySQL (24m09s) and PostgreSQL (21m00s).
- [x] Native real-client E2E passed on MySQL (16m40s) and PostgreSQL (19m45s).
- [x] Live compatibility coverage passed inside the unified Full E2E workflow.

## Compatibility and design checklist

- [x] No protocol behavior changes; existing cache policies and observable behavior are preserved.
- [x] Compatibility-test changes are not required because no repository protocol behavior changes.
- [x] Migrated caches remain disposable node-local hot caches. MySQL/blob state and existing shared version watermarks remain authoritative, so cache loss or replica-local eviction does not affect correctness.
- [x] No persistence migration changes.

## Notes for reviewers

- The Caffeine backend and its configuration-specific native hints now live only in `kkrepo-cache`.
- The architecture guard has no legacy allowlist and rejects future direct backend imports or Maven dependencies from business modules.
