### PR TITLE
Improve account and sign-in UI

### DIFF
--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js
@@ -766,12 +766,23 @@ function updateSessionControls(session) {
   currentSession = session || null;
   const signedIn = Boolean(currentSession?.userId);
   const userMenu = document.getElementById("user-menu");
-  const currentUserPill = document.getElementById("current-user-pill");
+  const userMenuTrigger = document.getElementById("user-menu-trigger");
+  const currentUser = document.getElementById("current-user");
+  const userMenuName = document.getElementById("user-menu-name");
+  const userMenuSource = document.getElementById("user-menu-source");
   userMenu.hidden = !signedIn;
   if (!signedIn) closeUserMenu();
   if (signedIn) {
-    const source = currentSession.source ? `${displaySource(currentSession.source)}/` : "";
-    currentUserPill.textContent = `${source}${currentSession.userId}`;
+    const userId = String(currentSession.userId);
+    const source = displaySource(currentSession.source).trim();
+    const sourceLabel = accountSourceLabel(source);
+    const qualifiedUser = source ? `${source}/${userId}` : userId;
+
+    currentUser.textContent = userId;
+    userMenuName.textContent = userId;
+    userMenuSource.textContent = sourceLabel;
+    userMenuTrigger.title = `Account menu for ${qualifiedUser}`;
+    userMenuTrigger.setAttribute("aria-label", `Account menu for ${qualifiedUser}`);
     sessionStorage.setItem(AUTH_SNAPSHOT_KEY, JSON.stringify({
       session: currentSession,
       permissions: ["nexus:*"],
@@ -882,6 +893,12 @@ function isLocalSource(source) {
 
 function displaySource(source) {
   return source == null ? "" : String(source);
+}
+
+function accountSourceLabel(source) {
+  const value = displaySource(source).trim();
+  if (!value) return "Authenticated account";
+  return `${value.charAt(0).toUpperCase()}${value.slice(1)} account`;
 }
 
 function commaList(value) {
@@ -7389,6 +7406,10 @@ document.getElementById("user-menu").addEventListener("mouseleave", scheduleClos
 document.getElementById("user-menu-trigger").addEventListener("click", (event) => {
   event.stopPropagation();
   toggleUserMenu();
+});
+document.getElementById("my-token-menu-item").addEventListener("click", () => {
+  closeUserMenu();
+  window.location.href = "/browse/#browse/my-token";
 });
 document.getElementById("signout-button").addEventListener("click", () => {
   closeUserMenu();

--- a/admin-ui/src/main/resources/META-INF/resources/admin/index.html
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/index.html
@@ -7,8 +7,9 @@
     <link rel="icon" type="image/svg+xml" href="/admin/assets/favicon.svg?v=20260609-kl-logo-1">
     <link rel="stylesheet" href="/browse/assets/tokens.css?v=20260724-visual-upgrade-1">
     <link rel="stylesheet" href="/browse/assets/format-icons.css?v=20260811-conan-1">
-    <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260728-security-advisory-link-1">
+    <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260818-user-round-1">
     <link rel="stylesheet" href="./assets/admin.css?v=20260818-security-provider-layout-8">
+    <link rel="stylesheet" href="/browse/assets/account-menu.css?v=20260818-shared-account-menu-2">
     <link rel="stylesheet" href="/browse/assets/global-component-search.css?v=20260817-global-search-3">
   </head>
   <body>
@@ -32,11 +33,39 @@
         </form>
         <div class="user-menu" id="user-menu" hidden>
           <button class="user-menu-trigger" id="user-menu-trigger" type="button" aria-haspopup="menu" aria-expanded="false">
-            <span class="user-pill" id="current-user-pill" title="Current user"></span>
+            <span class="user-avatar" aria-hidden="true">
+              <span class="user-avatar-icon lucide-icon icon-user-round"></span>
+            </span>
+            <span class="user-identity">
+              <span class="user-name" id="current-user"></span>
+            </span>
             <span class="user-menu-caret lucide-icon icon-chevron-down" aria-hidden="true"></span>
           </button>
           <div class="user-menu-popover" id="user-menu-popover" role="menu" aria-hidden="true">
-            <button class="user-menu-item" id="signout-button" type="button" role="menuitem">Sign out</button>
+            <div class="user-menu-summary" role="presentation">
+              <span class="user-avatar user-menu-avatar" aria-hidden="true">
+                <span class="user-avatar-icon lucide-icon icon-user-round"></span>
+              </span>
+              <span class="user-menu-summary-copy">
+                <strong id="user-menu-name"></strong>
+                <span id="user-menu-source"></span>
+              </span>
+            </div>
+            <div class="user-menu-divider" role="separator"></div>
+            <button class="user-menu-item" id="my-token-menu-item" type="button" role="menuitem">
+              <span class="user-menu-item-icon lucide-icon icon-key-round" aria-hidden="true"></span>
+              <span class="user-menu-item-copy">
+                <strong>My Token</strong>
+                <span>Manage access keys</span>
+              </span>
+            </button>
+            <button class="user-menu-item user-menu-item-danger" id="signout-button" type="button" role="menuitem">
+              <span class="user-menu-item-icon user-menu-signout-icon lucide-icon icon-log-in" aria-hidden="true"></span>
+              <span class="user-menu-item-copy">
+                <strong>Sign out</strong>
+                <span>End current session</span>
+              </span>
+            </button>
           </div>
         </div>
       </header>
@@ -1777,6 +1806,6 @@
     <script src="/login/assets/ui-i18n.js?v=20260818-security-provider-layout-4"></script>
     <script src="./assets/admin-filter.js?v=20260706-wildcard-filter-1"></script>
     <script src="/browse/assets/global-component-search.js?v=20260817-global-search-2"></script>
-    <script src="./assets/admin.js?v=20260818-security-provider-layout-5"></script>
+    <script src="./assets/admin.js?v=20260818-shared-account-menu-1"></script>
   </body>
 </html>

--- a/admin-ui/src/main/resources/META-INF/resources/login/assets/login-modal.css
+++ b/admin-ui/src/main/resources/META-INF/resources/login/assets/login-modal.css
@@ -119,6 +119,28 @@
   font-weight: 700;
 }
 
+.login-dialog-input-wrap {
+  position: relative;
+  display: block;
+}
+
+.login-dialog-field-icon {
+  position: absolute;
+  top: 50%;
+  left: 12px;
+  z-index: 1;
+  width: 18px;
+  height: 18px;
+  color: var(--ink-3);
+  pointer-events: none;
+  transform: translateY(-50%);
+  transition: color 0.14s ease;
+}
+
+.login-dialog-input-wrap:focus-within .login-dialog-field-icon {
+  color: var(--brand);
+}
+
 .login-dialog-form input {
   width: 100%;
   height: 38px;
@@ -126,7 +148,7 @@
   border-radius: var(--r-sm);
   outline: 0;
   color: var(--ink-1);
-  padding: 0 10px;
+  padding: 0 42px 0 40px;
 }
 
 .login-dialog-form input:focus {
@@ -150,11 +172,20 @@
 
 .login-dialog-primary,
 .login-dialog-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   height: 40px;
+  gap: 8px;
   border-radius: var(--r-sm);
   cursor: pointer;
   font-weight: 700;
   transition: background-color 0.14s ease, border-color 0.14s ease, color 0.14s ease, box-shadow 0.14s ease, transform 0.1s ease;
+}
+
+.login-dialog-button-icon {
+  width: 18px;
+  height: 18px;
 }
 
 .login-dialog-primary {

--- a/admin-ui/src/main/resources/META-INF/resources/login/assets/login-modal.js
+++ b/admin-ui/src/main/resources/META-INF/resources/login/assets/login-modal.js
@@ -59,20 +59,26 @@
           <button class="login-dialog-tab" id="login-tab-password" type="button" role="tab" aria-controls="login-panel-password" aria-selected="false">Local / LDAP</button>
         </div>
         <div class="login-dialog-oidc-panel" id="login-panel-oidc" role="tabpanel" aria-labelledby="login-tab-oidc" hidden>
-          <button class="login-dialog-primary login-dialog-oidc-button" type="button">Sign in with SSO</button>
+          <button class="login-dialog-primary login-dialog-oidc-button" type="button"><span class="login-dialog-button-icon lucide-icon icon-shield-check" aria-hidden="true"></span><span>Sign in with SSO</span></button>
         </div>
         <form class="login-dialog-form" id="login-panel-password" role="tabpanel" aria-labelledby="login-tab-password" novalidate>
           <label>
             <span>Username</span>
-            <input class="login-dialog-username" name="username" type="text" autocomplete="username" required>
+            <span class="login-dialog-input-wrap">
+              <span class="login-dialog-field-icon lucide-icon icon-user-round" aria-hidden="true"></span>
+              <input class="login-dialog-username" name="username" type="text" autocomplete="username" required>
+            </span>
           </label>
           <label>
             <span>Password</span>
-            <input class="login-dialog-password" name="password" type="password" autocomplete="current-password" required>
+            <span class="login-dialog-input-wrap">
+              <span class="login-dialog-field-icon lucide-icon icon-lock" aria-hidden="true"></span>
+              <input class="login-dialog-password" name="password" type="password" autocomplete="current-password" required>
+            </span>
           </label>
           <div class="login-dialog-error" role="alert" hidden></div>
           <div class="login-dialog-actions">
-            <button class="login-dialog-primary login-dialog-submit" type="submit">Sign in</button>
+            <button class="login-dialog-primary login-dialog-submit" type="submit"><span class="login-dialog-button-icon lucide-icon icon-log-in" aria-hidden="true"></span><span>Sign in</span></button>
           </div>
         </form>
       </section>

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminAccountMenuContractTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminAccountMenuContractTest.java
@@ -1,0 +1,44 @@
+package com.github.klboke.kkrepo.admin.ui;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import org.junit.jupiter.api.Test;
+
+class AdminAccountMenuContractTest {
+
+  @Test
+  void administrationUsesTheSharedBrowseAccountMenu() throws IOException {
+    String index = resource("/META-INF/resources/admin/index.html");
+
+    assertTrue(index.contains("/browse/assets/account-menu.css"));
+    assertTrue(index.contains("user-avatar-icon lucide-icon icon-user-round"));
+    assertTrue(index.contains("class=\"user-name\" id=\"current-user\""));
+    assertFalse(index.contains("current-user-source"));
+    assertTrue(index.contains("id=\"user-menu-source\""));
+    assertTrue(index.contains("id=\"my-token-menu-item\""));
+    assertTrue(index.contains("user-menu-item-danger"));
+  }
+
+  @Test
+  void administrationKeepsDetailsInThePopoverAndLinksToMyToken() throws IOException {
+    String javascript = resource("/META-INF/resources/admin/assets/admin.js");
+
+    assertTrue(javascript.contains("function accountSourceLabel(source)"));
+    assertTrue(javascript.contains("currentUser.textContent = userId"));
+    assertTrue(javascript.contains("userMenuSource.textContent = sourceLabel"));
+    assertTrue(javascript.contains(
+        "userMenuTrigger.setAttribute(\"aria-label\", `Account menu for ${qualifiedUser}`)"));
+    assertTrue(javascript.contains("window.location.href = \"/browse/#browse/my-token\""));
+  }
+
+  private String resource(String path) throws IOException {
+    try (InputStream stream = getClass().getResourceAsStream(path)) {
+      return new String(Objects.requireNonNull(stream).readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+}

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/LoginModalIconsContractTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/LoginModalIconsContractTest.java
@@ -1,0 +1,34 @@
+package com.github.klboke.kkrepo.admin.ui;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import org.junit.jupiter.api.Test;
+
+class LoginModalIconsContractTest {
+
+  @Test
+  void signInDialogUsesSharedLucideIconsWithoutObscuringPasswordControls() throws IOException {
+    String javascript = resource("/META-INF/resources/login/assets/login-modal.js");
+    String stylesheet = resource("/META-INF/resources/login/assets/login-modal.css");
+
+    assertFalse(javascript.contains("login-dialog-title-icon"));
+    assertTrue(javascript.contains("login-dialog-field-icon lucide-icon icon-user-round"));
+    assertTrue(javascript.contains("login-dialog-field-icon lucide-icon icon-lock"));
+    assertTrue(javascript.contains("login-dialog-button-icon lucide-icon icon-shield-check"));
+    assertTrue(javascript.contains("login-dialog-submit\" type=\"submit\"><span class=\"login-dialog-button-icon lucide-icon icon-log-in\""));
+    assertTrue(stylesheet.contains(".login-dialog-input-wrap"));
+    assertTrue(stylesheet.contains("padding: 0 42px 0 40px"));
+    assertTrue(stylesheet.contains(".login-dialog-input-wrap:focus-within .login-dialog-field-icon"));
+  }
+
+  private String resource(String path) throws IOException {
+    try (InputStream stream = getClass().getResourceAsStream(path)) {
+      return new String(Objects.requireNonNull(stream).readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+}

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/account-menu.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/account-menu.css
@@ -1,0 +1,270 @@
+/* Shared signed-in account menu for the Browse and Admin workspaces. */
+
+.user-menu {
+  position: relative;
+  align-self: center;
+  margin-right: 10px;
+}
+
+.user-menu-trigger {
+  display: inline-flex;
+  align-items: center;
+  width: 126px;
+  height: 40px;
+  min-width: 126px;
+  max-width: 126px;
+  gap: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.055);
+  color: var(--topbar-ink);
+  cursor: pointer;
+  padding: 4px 9px 4px 5px;
+  text-align: left;
+  transition: background-color 120ms ease, border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.user-menu-trigger:hover,
+.user-menu-trigger[aria-expanded="true"] {
+  border-color: rgba(255, 255, 255, 0.28);
+  background: var(--topbar-hover);
+}
+
+.user-menu-trigger:focus-visible,
+.user-menu-item:focus-visible {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(47, 191, 164, 0.28);
+}
+
+.user-avatar {
+  position: relative;
+  display: grid;
+  width: 30px;
+  height: 30px;
+  flex: 0 0 30px;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 9px;
+  background: linear-gradient(145deg, #22aa95, #0a665b);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
+  color: #ffffff;
+}
+
+.user-avatar-icon {
+  width: 17px;
+  height: 17px;
+}
+
+.user-avatar::after {
+  position: absolute;
+  right: -2px;
+  bottom: -2px;
+  width: 7px;
+  height: 7px;
+  border: 2px solid var(--topbar);
+  border-radius: 50%;
+  background: #51d29d;
+  content: "";
+}
+
+.user-identity,
+.user-menu-summary-copy,
+.user-menu-item-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.user-identity {
+  flex: 1 1 auto;
+  justify-content: center;
+}
+
+.user-name {
+  overflow: hidden;
+  font-size: 13px;
+  font-weight: var(--fw-semibold);
+  line-height: 18px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.user-menu-caret {
+  width: 12px;
+  height: 12px;
+  flex: 0 0 12px;
+  margin-left: auto;
+  color: var(--topbar-muted);
+  transition: transform 140ms ease;
+}
+
+.user-menu-trigger[aria-expanded="true"] .user-menu-caret {
+  transform: rotate(180deg);
+}
+
+.user-menu-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 30;
+  display: none;
+  width: 220px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-lg);
+  background: var(--surface);
+  box-shadow: var(--shadow-pop);
+  padding: 8px;
+}
+
+.user-menu:hover .user-menu-popover,
+.user-menu-popover.is-open {
+  display: block;
+  animation: shared-user-menu-in 120ms ease-out;
+}
+
+@keyframes shared-user-menu-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.user-menu-summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border-radius: var(--r-md);
+  background: var(--surface-muted);
+  padding: 10px;
+}
+
+.user-menu-avatar {
+  width: 36px;
+  height: 36px;
+  flex-basis: 36px;
+  border: 0;
+}
+
+.user-menu-avatar .user-avatar-icon {
+  width: 20px;
+  height: 20px;
+}
+
+.user-menu-avatar::after {
+  border-color: var(--surface-muted);
+}
+
+.user-menu-summary-copy strong {
+  overflow: hidden;
+  color: var(--ink-1);
+  font-size: 13px;
+  line-height: 17px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.user-menu-summary-copy span {
+  overflow: hidden;
+  color: var(--ink-3);
+  font-size: 11px;
+  line-height: 15px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.user-menu-divider {
+  height: 1px;
+  margin: 7px 4px;
+  background: var(--line);
+}
+
+.user-menu-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 48px;
+  gap: 10px;
+  border: 0;
+  border-radius: var(--r-md);
+  background: transparent;
+  color: var(--ink-2);
+  cursor: pointer;
+  padding: 7px 9px;
+  text-align: left;
+}
+
+.user-menu-item:hover {
+  background: var(--brand-tint);
+}
+
+.user-menu-item-icon {
+  width: 17px;
+  height: 17px;
+  flex: 0 0 17px;
+  color: var(--brand);
+}
+
+.user-menu-signout-icon {
+  transform: scaleX(-1);
+}
+
+.user-menu-item-copy strong {
+  color: inherit;
+  font-size: 13px;
+  font-weight: var(--fw-semibold);
+  line-height: 17px;
+}
+
+.user-menu-item-copy span {
+  color: var(--ink-3);
+  font-size: 11px;
+  font-weight: var(--fw-regular);
+  line-height: 15px;
+}
+
+.user-menu-item-danger:hover {
+  background: var(--danger-bg);
+  color: var(--danger);
+}
+
+.user-menu-item-danger .user-menu-item-icon {
+  color: var(--danger);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .user-menu-trigger,
+  .user-menu-caret {
+    transition: none;
+  }
+
+  .user-menu:hover .user-menu-popover,
+  .user-menu-popover.is-open {
+    animation: none;
+  }
+}
+
+@media (max-width: 430px) {
+  .user-menu {
+    margin-right: 8px;
+  }
+
+  .user-menu-trigger {
+    padding-right: 7px;
+  }
+
+  .user-identity {
+    display: none;
+  }
+
+  .user-menu-popover {
+    position: fixed;
+    top: 58px;
+    right: 8px;
+    width: min(220px, calc(100vw - 16px));
+  }
+}

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
@@ -132,8 +132,7 @@ select {
   color: #ffffff;
 }
 
-.top-icon,
-.signout {
+.top-icon {
   display: grid;
   align-items: center;
   justify-items: center;
@@ -162,82 +161,55 @@ select {
   flex: 1;
 }
 
-.user-pill {
-  min-width: 120px;
-  padding: 0 12px;
-  font-weight: 700;
-}
-
-.user-menu {
-  position: relative;
-  align-self: stretch;
-}
-
-.user-menu-trigger {
+.account-login {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  height: 56px;
-  border: 0;
-  background: transparent;
-  color: #ffffff;
+  width: 126px;
+  height: 40px;
+  min-width: 126px;
+  max-width: 126px;
+  gap: 9px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.055);
+  color: var(--topbar-ink);
   cursor: pointer;
+  margin-right: 10px;
   padding: 0 12px;
+  text-align: left;
+  transition: background-color 120ms ease, border-color 120ms ease, box-shadow 120ms ease;
 }
 
-.user-menu-trigger:hover,
-.user-menu-trigger[aria-expanded="true"] {
-  background: rgba(255, 255, 255, 0.08);
+.account-login:hover {
+  border-color: rgba(255, 255, 255, 0.28);
+  background: var(--topbar-hover);
 }
 
-.user-menu-caret {
-  color: rgba(255, 255, 255, 0.72);
-  font-size: 11px;
+.account-login:focus-visible {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(47, 191, 164, 0.28);
 }
 
-.user-menu-popover {
-  position: absolute;
-  top: calc(100% + 6px);
-  right: 8px;
-  z-index: 30;
-  display: none;
-  min-width: 152px;
-  border: 1px solid #cfd8d4;
-  border-radius: 8px;
-  background: #ffffff;
-  box-shadow: var(--shadow-pop);
-  padding: 6px;
+.account-login-icon {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 18px;
+  color: var(--brand-bright);
 }
 
-.user-menu:hover .user-menu-popover,
-.user-menu-popover.is-open {
-  display: block;
-}
-
-.user-menu-item {
-  display: flex;
-  align-items: center;
-  width: 100%;
-  height: 34px;
-  border: 0;
-  border-radius: 6px;
-  background: transparent;
-  color: #22312e;
-  cursor: pointer;
+.account-entry-title {
+  overflow: hidden;
   font-size: 13px;
   font-weight: var(--fw-semibold);
-  padding: 0 10px;
-  text-align: left;
+  line-height: 16px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.user-menu-item:hover {
-  background: #edf3ef;
-}
-
-.signout {
-  min-width: 94px;
-  font-size: 13px;
-  font-weight: 700;
+@media (prefers-reduced-motion: reduce) {
+  .account-login {
+    transition: none;
+  }
 }
 
 .nx-sidebar {
@@ -1704,8 +1676,7 @@ textarea:focus-visible {
   color: var(--topbar-ink);
 }
 
-.top-icon,
-.signout {
+.top-icon {
   height: 56px;
   min-width: 54px;
   color: var(--topbar-muted);
@@ -1717,8 +1688,7 @@ textarea:focus-visible {
   font-size: 21px;
 }
 
-.top-icon:hover,
-.signout:hover {
+.top-icon:hover {
   background: var(--topbar-hover);
   color: var(--topbar-ink);
 }
@@ -1754,16 +1724,6 @@ textarea:focus-visible {
   line-height: 1;
 }
 
-.user-pill,
-.signout {
-  font-size: 13px;
-  font-weight: var(--fw-semibold);
-}
-
-.user-pill {
-  color: var(--topbar-ink);
-}
-
 .user-menu-trigger {
   color: var(--topbar-ink);
 }
@@ -1775,10 +1735,6 @@ textarea:focus-visible {
 
 .user-menu-caret {
   color: var(--topbar-muted);
-}
-
-.signout {
-  min-width: 88px;
 }
 
 .nx-sidebar {
@@ -2684,5 +2640,12 @@ body {
 
   #browse-view .nx-table-frame {
     margin-top: 12px;
+  }
+}
+
+@media (max-width: 430px) {
+  .account-login {
+    margin-right: 8px;
+    padding: 0 10px;
   }
 }

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.js
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.js
@@ -311,6 +311,12 @@ function displaySource(source) {
   return source == null ? "" : String(source);
 }
 
+function accountSourceLabel(source) {
+  const value = displaySource(source).trim();
+  if (!value) return "Authenticated account";
+  return `${value.charAt(0).toUpperCase()}${value.slice(1)} account`;
+}
+
 function readAuthSnapshot() {
   try {
     const raw = sessionStorage.getItem(AUTH_SNAPSHOT_KEY);
@@ -539,7 +545,10 @@ function updateTopbarAuth() {
   const adminLink = document.getElementById("admin-workspace-link");
   const loginButton = document.getElementById("login-button");
   const userMenu = document.getElementById("user-menu");
+  const userMenuTrigger = document.getElementById("user-menu-trigger");
   const currentUser = document.getElementById("current-user");
+  const userMenuName = document.getElementById("user-menu-name");
+  const userMenuSource = document.getElementById("user-menu-source");
   const uploadNav = document.getElementById("upload-nav");
 
   const signedIn = Boolean(currentSession && currentSession.userId);
@@ -550,8 +559,16 @@ function updateTopbarAuth() {
   userMenu.hidden = !signedIn;
   if (!signedIn) closeUserMenu();
   if (signedIn) {
-    const source = currentSession.source ? `${displaySource(currentSession.source)}/` : "";
-    currentUser.textContent = `${source}${currentSession.userId}`;
+    const userId = String(currentSession.userId);
+    const source = displaySource(currentSession.source).trim();
+    const sourceLabel = accountSourceLabel(source);
+    const qualifiedUser = source ? `${source}/${userId}` : userId;
+
+    currentUser.textContent = userId;
+    userMenuName.textContent = userId;
+    userMenuSource.textContent = sourceLabel;
+    userMenuTrigger.title = `Account menu for ${qualifiedUser}`;
+    userMenuTrigger.setAttribute("aria-label", `Account menu for ${qualifiedUser}`);
   }
 
   const uploadVisible = canUseUpload();

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/icons/user-round.svg
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/icons/user-round.svg
@@ -1,0 +1,16 @@
+<!-- @license lucide-static v1.24.0 - ISC -->
+<svg
+  class="lucide lucide-user-round"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="8" r="5" />
+  <path d="M20 21a8 8 0 0 0-16 0" />
+</svg>

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/lucide-icons.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/lucide-icons.css
@@ -45,6 +45,7 @@
 .icon-waypoints { --lucide-icon: url("./icons/waypoints.svg"); }
 .icon-network { --lucide-icon: url("./icons/network.svg"); }
 .icon-log-in { --lucide-icon: url("./icons/log-in.svg"); }
+.icon-user-round { --lucide-icon: url("./icons/user-round.svg"); }
 .icon-user-round-x { --lucide-icon: url("./icons/user-round-x.svg"); }
 .icon-scroll-text { --lucide-icon: url("./icons/scroll-text.svg"); }
 .icon-sliders-horizontal { --lucide-icon: url("./icons/sliders-horizontal.svg"); }

--- a/browse-ui/src/main/resources/META-INF/resources/browse/index.html
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/index.html
@@ -7,10 +7,11 @@
     <link rel="icon" type="image/svg+xml" href="/browse/assets/favicon.svg?v=20260609-kl-logo-1">
     <link rel="stylesheet" href="/browse/assets/tokens.css?v=20260724-visual-upgrade-1">
     <link rel="stylesheet" href="/browse/assets/format-icons.css?v=20260811-conan-1">
-    <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260816-alpine-apk-1">
-    <link rel="stylesheet" href="/browse/assets/browse.css?v=20260816-alpine-apk-1">
+    <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260818-user-round-1">
+    <link rel="stylesheet" href="/browse/assets/browse.css?v=20260818-account-menu-3">
+    <link rel="stylesheet" href="/browse/assets/account-menu.css?v=20260818-shared-account-menu-2">
     <link rel="stylesheet" href="/browse/assets/global-component-search.css?v=20260817-global-search-3">
-    <link rel="stylesheet" href="/login/assets/login-modal.css?v=20260724-visual-upgrade-1">
+    <link rel="stylesheet" href="/login/assets/login-modal.css?v=20260818-login-icons-1">
   </head>
   <body>
     <div class="nx-shell">
@@ -31,15 +32,45 @@
           <span class="global-component-search-icon lucide-icon icon-search" aria-hidden="true"></span>
           <input id="global-component-search-input" name="q" type="search" placeholder="Search components" autocomplete="off">
         </form>
-        <button class="signout" id="login-button" type="button">Sign in</button>
+        <button class="account-login" id="login-button" type="button" aria-label="Sign in to kkRepo">
+          <span class="account-login-icon lucide-icon icon-log-in" aria-hidden="true"></span>
+          <span class="account-entry-title">Sign in</span>
+        </button>
         <div class="user-menu" id="user-menu" hidden>
           <button class="user-menu-trigger" id="user-menu-trigger" type="button" aria-haspopup="menu" aria-expanded="false">
-            <span class="user-pill" id="current-user" title="Current user"></span>
+            <span class="user-avatar" aria-hidden="true">
+              <span class="user-avatar-icon lucide-icon icon-user-round"></span>
+            </span>
+            <span class="user-identity">
+              <span class="user-name" id="current-user"></span>
+            </span>
             <span class="user-menu-caret lucide-icon icon-chevron-down" aria-hidden="true"></span>
           </button>
           <div class="user-menu-popover" id="user-menu-popover" role="menu" aria-hidden="true">
-            <button class="user-menu-item" id="my-token-menu-item" type="button" role="menuitem">My Token</button>
-            <button class="user-menu-item" id="signout-button" type="button" role="menuitem">Sign out</button>
+            <div class="user-menu-summary" role="presentation">
+              <span class="user-avatar user-menu-avatar" aria-hidden="true">
+                <span class="user-avatar-icon lucide-icon icon-user-round"></span>
+              </span>
+              <span class="user-menu-summary-copy">
+                <strong id="user-menu-name"></strong>
+                <span id="user-menu-source"></span>
+              </span>
+            </div>
+            <div class="user-menu-divider" role="separator"></div>
+            <button class="user-menu-item" id="my-token-menu-item" type="button" role="menuitem">
+              <span class="user-menu-item-icon lucide-icon icon-key-round" aria-hidden="true"></span>
+              <span class="user-menu-item-copy">
+                <strong>My Token</strong>
+                <span>Manage access keys</span>
+              </span>
+            </button>
+            <button class="user-menu-item user-menu-item-danger" id="signout-button" type="button" role="menuitem">
+              <span class="user-menu-item-icon user-menu-signout-icon lucide-icon icon-log-in" aria-hidden="true"></span>
+              <span class="user-menu-item-copy">
+                <strong>Sign out</strong>
+                <span>End current session</span>
+              </span>
+            </button>
           </div>
         </div>
       </header>
@@ -443,8 +474,8 @@
     </div>
 
     <script src="/login/assets/ui-i18n.js?v=20260817-global-search-1"></script>
-    <script src="/login/assets/login-modal.js?v=20260812-login-no-reload-1"></script>
+    <script src="/login/assets/login-modal.js?v=20260818-login-icons-3"></script>
     <script src="/browse/assets/global-component-search.js?v=20260817-global-search-2"></script>
-    <script src="/browse/assets/browse.js?v=20260817-global-search-2"></script>
+    <script src="/browse/assets/browse.js?v=20260818-account-menu-2"></script>
   </body>
 </html>

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseAccountMenuContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseAccountMenuContractTest.java
@@ -1,0 +1,61 @@
+package com.github.klboke.kkrepo.browse.ui;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import org.junit.jupiter.api.Test;
+
+class BrowseAccountMenuContractTest {
+
+  @Test
+  void topbarUsesIconLedAccountEntriesForGuestAndSignedInStates() throws IOException {
+    String index = resource("/META-INF/resources/browse/index.html");
+
+    assertTrue(index.contains("class=\"account-login\" id=\"login-button\""));
+    assertTrue(index.contains("account-login-icon lucide-icon icon-log-in"));
+    assertTrue(index.contains("<span class=\"account-entry-title\">Sign in</span>"));
+    assertTrue(index.contains("user-avatar-icon lucide-icon icon-user-round"));
+    assertTrue(index.contains("class=\"user-name\" id=\"current-user\""));
+    assertFalse(index.contains("account-entry-caption"));
+    assertFalse(index.contains("current-user-source"));
+    assertTrue(index.contains("user-menu-item-icon lucide-icon icon-key-round"));
+    assertTrue(index.contains("user-menu-signout-icon lucide-icon icon-log-in"));
+    assertTrue(index.contains("/login/assets/login-modal.css?v=20260818-login-icons-1"));
+    assertTrue(index.contains("/login/assets/login-modal.js?v=20260818-login-icons-3"));
+  }
+
+  @Test
+  void signedInAccountEntryHydratesIdentityAndAccessibleLabel() throws IOException {
+    String javascript = resource("/META-INF/resources/browse/assets/browse.js");
+
+    assertTrue(javascript.contains("function accountSourceLabel(source)"));
+    assertFalse(javascript.contains("function accountInitial(userId)"));
+    assertTrue(javascript.contains("currentUser.textContent = userId"));
+    assertTrue(javascript.contains("userMenuSource.textContent = sourceLabel"));
+    assertTrue(javascript.contains(
+        "userMenuTrigger.setAttribute(\"aria-label\", `Account menu for ${qualifiedUser}`)"));
+  }
+
+  @Test
+  void accountEntrySupportsFocusReducedMotionAndNarrowScreens() throws IOException {
+    String index = resource("/META-INF/resources/browse/index.html");
+    String stylesheet = resource("/META-INF/resources/browse/assets/account-menu.css");
+
+    assertTrue(index.contains("/browse/assets/account-menu.css"));
+    assertTrue(stylesheet.contains("width: 126px;\n  height: 40px;\n  min-width: 126px;\n  max-width: 126px;"));
+    assertTrue(stylesheet.contains(".user-menu-trigger:focus-visible"));
+    assertTrue(stylesheet.contains("@media (prefers-reduced-motion: reduce)"));
+    assertTrue(stylesheet.contains("@media (max-width: 430px)"));
+    assertTrue(stylesheet.contains("width: min(220px, calc(100vw - 16px))"));
+  }
+
+  private String resource(String path) throws IOException {
+    try (InputStream stream = getClass().getResourceAsStream(path)) {
+      return new String(Objects.requireNonNull(stream).readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+}

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseLucideIconsContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseLucideIconsContractTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 
 class BrowseLucideIconsContractTest {
   private static final List<String> REQUIRED_ICONS = List.of(
-      "home", "search", "library", "upload", "key-round", "list-filter",
+      "home", "search", "library", "upload", "key-round", "user-round", "list-filter",
       "boxes", "cloud-download", "package", "folder", "archive", "file-code",
       "files", "file", "file-archive", "file-java-archive", "file-apk", "file-box", "file-json", "file-text",
       "file-key", "file-check", "binary", "layers", "arrow-up-down", "copy", "check", "download", "x",

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseTerraformUploadContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseTerraformUploadContractTest.java
@@ -39,7 +39,7 @@ class BrowseTerraformUploadContractTest {
     assertTrue(javascript.contains("const repoUrl = repositoryBaseUrl().replace(/\\/+$/, \"\")"));
     assertTrue(javascript.contains("crumbIcon: repositoryFormatIcon()"));
     assertTrue(javascript.contains("await activateTreeBranch(entry, toggleExpand)"));
-    assertTrue(index.contains("/browse/assets/browse.js?v=20260817-global-search-2"));
+    assertTrue(index.contains("/browse/assets/browse.js?v=20260818-account-menu-2"));
   }
 
   private String resource(String path) throws IOException {


### PR DESCRIPTION
## Summary

- give signed-out and signed-in topbar account controls the same compact width
- show only the username in the topbar and move account details into a smaller shared popover
- align the Admin account menu with Browse, including My Token and Sign out actions
- replace initial avatars with a Lucide user icon and improve responsive, focus, and reduced-motion states
- enrich the sign-in dialog with field icons and keep the login icon on the primary action
- add contract coverage for the shared account menu, icon assets, and sign-in dialog

## Why

The previous signed-in control grew wider than the signed-out state, left unused space, and differed between Browse and Admin. The sign-in dialog also lacked visual cues. These changes keep the topbar stable while moving secondary identity details into the account popover.

## Validation

- `mvn -pl admin-ui,browse-ui -am test` (49 tests passed)
- `node --check` for the modified Admin, Browse, and login JavaScript
- `git diff --check`
- verified the updated assets from the local dev runtime on port 18090; actuator health remained `UP`
