### PR TITLE
Add per-repository proxy redirect host allowlists

### DIFF
--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js
@@ -2740,7 +2740,7 @@ function repositoryFormPayload() {
     const metadata = document.getElementById("repository-metadata-max-age").value;
     const minimumReleaseAge = document.getElementById("repository-minimum-release-age").value;
     const allowedRedirectHosts = document.getElementById("repository-allowed-redirect-hosts").value
-      .split(/[\n,]/).map((value) => value.trim()).filter(Boolean);
+      .split(",").map((value) => value.trim()).filter(Boolean);
     payload.proxy = {
       remoteUrl: document.getElementById("repository-remote-url").value.trim(),
       allowedRedirectHosts,
@@ -2947,7 +2947,7 @@ function showEditRepositoryForm(name) {
   if (repo.proxy) {
     document.getElementById("repository-remote-url").value = repo.proxy.remoteUrl || "";
     document.getElementById("repository-allowed-redirect-hosts").value =
-      Array.isArray(repo.proxy.allowedRedirectHosts) ? repo.proxy.allowedRedirectHosts.join("\n") : "";
+      Array.isArray(repo.proxy.allowedRedirectHosts) ? repo.proxy.allowedRedirectHosts.join(", ") : "";
     document.getElementById("repository-remote-username").value = repo.proxy.remoteUsername || "";
     document.getElementById("repository-remote-password").value = "";
     document.getElementById("repository-remote-password").placeholder =

--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js
@@ -2739,8 +2739,11 @@ function repositoryFormPayload() {
     const content = document.getElementById("repository-content-max-age").value;
     const metadata = document.getElementById("repository-metadata-max-age").value;
     const minimumReleaseAge = document.getElementById("repository-minimum-release-age").value;
+    const allowedRedirectHosts = document.getElementById("repository-allowed-redirect-hosts").value
+      .split(/[\n,]/).map((value) => value.trim()).filter(Boolean);
     payload.proxy = {
       remoteUrl: document.getElementById("repository-remote-url").value.trim(),
+      allowedRedirectHosts,
       contentMaxAgeMinutes: content === "" ? null : Number(content),
       metadataMaxAgeMinutes: metadata === "" ? null : Number(metadata),
       minimumReleaseAgeMinutes: recipe.format === "npm"
@@ -2829,6 +2832,7 @@ function setRepositoryFormDefaults() {
   document.getElementById("repository-version-policy").value = "RELEASE";
   document.getElementById("repository-layout-policy").value = "STRICT";
   document.getElementById("repository-remote-url").value = "";
+  document.getElementById("repository-allowed-redirect-hosts").value = "";
   document.getElementById("repository-remote-username").value = "";
   document.getElementById("repository-remote-password").value = "";
   document.getElementById("repository-remote-password").placeholder = "";
@@ -2942,6 +2946,8 @@ function showEditRepositoryForm(name) {
   }
   if (repo.proxy) {
     document.getElementById("repository-remote-url").value = repo.proxy.remoteUrl || "";
+    document.getElementById("repository-allowed-redirect-hosts").value =
+      Array.isArray(repo.proxy.allowedRedirectHosts) ? repo.proxy.allowedRedirectHosts.join("\n") : "";
     document.getElementById("repository-remote-username").value = repo.proxy.remoteUsername || "";
     document.getElementById("repository-remote-password").value = "";
     document.getElementById("repository-remote-password").placeholder =

--- a/admin-ui/src/main/resources/META-INF/resources/admin/index.html
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/index.html
@@ -232,13 +232,13 @@
               <label>
                 <span class="field-label">Allowed redirect host
                   <span class="field-help" tabindex="0" role="note"
-                    aria-label="Optional. Cross-host redirects are denied by default. Enter an exact host name, such as plugins-artifacts.gradle.org. To allow more than one, separate hosts with commas. Source repository credentials are never forwarded, and outbound DNS and SSRF validation still applies. Schemes, ports, paths, and wildcards are not allowed."
-                    data-tooltip="Optional. Cross-host redirects are denied by default. Enter an exact host name, such as plugins-artifacts.gradle.org. To allow more than one, separate hosts with commas. Source repository credentials are never forwarded, and outbound DNS and SSRF validation still applies. Schemes, ports, paths, and wildcards are not allowed.">
+                    aria-label="Optional. Cross-host redirects are denied by default. Enter an exact host name, such as artifacts.example.com. To allow more than one, separate hosts with commas. Source repository credentials are never forwarded, and outbound DNS and SSRF validation still applies. Schemes, ports, paths, and wildcards are not allowed."
+                    data-tooltip="Optional. Cross-host redirects are denied by default. Enter an exact host name, such as artifacts.example.com. To allow more than one, separate hosts with commas. Source repository credentials are never forwarded, and outbound DNS and SSRF validation still applies. Schemes, ports, paths, and wildcards are not allowed.">
                     <span class="lucide-icon icon-info" aria-hidden="true"></span>
                   </span>
                 </span>
                 <input id="repository-allowed-redirect-hosts" type="text" spellcheck="false"
-                  autocomplete="off" placeholder="plugins-artifacts.gradle.org">
+                  autocomplete="off" placeholder="artifacts.example.com">
               </label>
               <label>
                 <span>Remote username</span>

--- a/admin-ui/src/main/resources/META-INF/resources/admin/index.html
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/index.html
@@ -229,6 +229,16 @@
                 <span>Remote URL <span class="required-mark">*</span></span>
                 <input id="repository-remote-url" type="url" placeholder="https://repo.maven.apache.org/maven2/">
               </label>
+              <label class="full-width">
+                <span>Allowed redirect hosts</span>
+                <textarea id="repository-allowed-redirect-hosts" rows="3" spellcheck="false"
+                  placeholder="plugins-artifacts.gradle.org"></textarea>
+              </label>
+              <p class="form-note full-width">
+                Optional exact host names, separated by commas or new lines. Cross-host redirects
+                are denied by default, never receive the source repository credentials, and still
+                pass outbound DNS and SSRF validation. Schemes, ports, paths, and wildcards are not allowed.
+              </p>
               <label>
                 <span>Remote username</span>
                 <input id="repository-remote-username" type="text" autocomplete="off">

--- a/admin-ui/src/main/resources/META-INF/resources/admin/index.html
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/index.html
@@ -229,16 +229,17 @@
                 <span>Remote URL <span class="required-mark">*</span></span>
                 <input id="repository-remote-url" type="url" placeholder="https://repo.maven.apache.org/maven2/">
               </label>
-              <label class="full-width">
-                <span>Allowed redirect hosts</span>
-                <textarea id="repository-allowed-redirect-hosts" rows="3" spellcheck="false"
-                  placeholder="plugins-artifacts.gradle.org"></textarea>
+              <label>
+                <span class="field-label">Allowed redirect host
+                  <span class="field-help" tabindex="0" role="note"
+                    aria-label="Optional. Cross-host redirects are denied by default. Enter an exact host name, such as plugins-artifacts.gradle.org. To allow more than one, separate hosts with commas. Source repository credentials are never forwarded, and outbound DNS and SSRF validation still applies. Schemes, ports, paths, and wildcards are not allowed."
+                    data-tooltip="Optional. Cross-host redirects are denied by default. Enter an exact host name, such as plugins-artifacts.gradle.org. To allow more than one, separate hosts with commas. Source repository credentials are never forwarded, and outbound DNS and SSRF validation still applies. Schemes, ports, paths, and wildcards are not allowed.">
+                    <span class="lucide-icon icon-info" aria-hidden="true"></span>
+                  </span>
+                </span>
+                <input id="repository-allowed-redirect-hosts" type="text" spellcheck="false"
+                  autocomplete="off" placeholder="plugins-artifacts.gradle.org">
               </label>
-              <p class="form-note full-width">
-                Optional exact host names, separated by commas or new lines. Cross-host redirects
-                are denied by default, never receive the source repository credentials, and still
-                pass outbound DNS and SSRF validation. Schemes, ports, paths, and wildcards are not allowed.
-              </p>
               <label>
                 <span>Remote username</span>
                 <input id="repository-remote-username" type="text" autocomplete="off">

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminProxyRedirectHostsContractTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminProxyRedirectHostsContractTest.java
@@ -1,5 +1,6 @@
 package com.github.klboke.kkrepo.admin.ui;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -20,6 +21,8 @@ class AdminProxyRedirectHostsContractTest {
     assertTrue(index.contains("class=\"field-help\""));
     assertTrue(index.contains("class=\"lucide-icon icon-info\""));
     assertTrue(index.contains("data-tooltip=\"Optional."));
+    assertTrue(index.contains("placeholder=\"artifacts.example.com\""));
+    assertFalse(index.contains("plugins-artifacts.gradle.org"));
     assertTrue(index.contains("Cross-host redirects"));
     assertTrue(index.contains("denied by default"));
     assertTrue(index.contains("Source repository credentials are never forwarded"));

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminProxyRedirectHostsContractTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminProxyRedirectHostsContractTest.java
@@ -1,0 +1,36 @@
+package com.github.klboke.kkrepo.admin.ui;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import org.junit.jupiter.api.Test;
+
+class AdminProxyRedirectHostsContractTest {
+
+  @Test
+  void proxyFormExplainsPersistsResetsAndReloadsRedirectHosts() throws IOException {
+    String index = resource("/META-INF/resources/admin/index.html");
+    String javascript = resource("/META-INF/resources/admin/assets/admin.js");
+
+    assertTrue(index.contains("id=\"repository-allowed-redirect-hosts\""));
+    assertTrue(index.contains("Cross-host redirects"));
+    assertTrue(index.contains("denied by default"));
+    assertTrue(index.contains("never receive the source repository credentials"));
+    assertTrue(index.contains("DNS and SSRF validation"));
+    assertTrue(index.contains("wildcards are not allowed"));
+    assertTrue(javascript.contains(".split(/[\\n,]/)"));
+    assertTrue(javascript.contains("allowedRedirectHosts,"));
+    assertTrue(javascript.contains(
+        "document.getElementById(\"repository-allowed-redirect-hosts\").value = \"\";"));
+    assertTrue(javascript.contains("repo.proxy.allowedRedirectHosts.join(\"\\n\")"));
+  }
+
+  private String resource(String path) throws IOException {
+    try (InputStream stream = getClass().getResourceAsStream(path)) {
+      return new String(Objects.requireNonNull(stream).readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+}

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminProxyRedirectHostsContractTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminProxyRedirectHostsContractTest.java
@@ -15,17 +15,21 @@ class AdminProxyRedirectHostsContractTest {
     String index = resource("/META-INF/resources/admin/index.html");
     String javascript = resource("/META-INF/resources/admin/assets/admin.js");
 
-    assertTrue(index.contains("id=\"repository-allowed-redirect-hosts\""));
+    assertTrue(index.contains("<input id=\"repository-allowed-redirect-hosts\" type=\"text\""));
+    assertTrue(index.contains("Allowed redirect host"));
+    assertTrue(index.contains("class=\"field-help\""));
+    assertTrue(index.contains("class=\"lucide-icon icon-info\""));
+    assertTrue(index.contains("data-tooltip=\"Optional."));
     assertTrue(index.contains("Cross-host redirects"));
     assertTrue(index.contains("denied by default"));
-    assertTrue(index.contains("never receive the source repository credentials"));
+    assertTrue(index.contains("Source repository credentials are never forwarded"));
     assertTrue(index.contains("DNS and SSRF validation"));
     assertTrue(index.contains("wildcards are not allowed"));
-    assertTrue(javascript.contains(".split(/[\\n,]/)"));
+    assertTrue(javascript.contains(".split(\",\")"));
     assertTrue(javascript.contains("allowedRedirectHosts,"));
     assertTrue(javascript.contains(
         "document.getElementById(\"repository-allowed-redirect-hosts\").value = \"\";"));
-    assertTrue(javascript.contains("repo.proxy.allowedRedirectHosts.join(\"\\n\")"));
+    assertTrue(javascript.contains("repo.proxy.allowedRedirectHosts.join(\", \")"));
   }
 
   private String resource(String path) throws IOException {

--- a/compat-test/src/test/java/com/github/klboke/kkrepo/compat/MavenRepositoryBlackBoxCompatibilityTest.java
+++ b/compat-test/src/test/java/com/github/klboke/kkrepo/compat/MavenRepositoryBlackBoxCompatibilityTest.java
@@ -32,6 +32,8 @@ import org.junit.jupiter.api.Test;
  * {@link CompatConfig} settings.
  */
 class MavenRepositoryBlackBoxCompatibilityTest {
+  private static final String GRADLE_PLUGIN_PORTAL_ARTIFACT =
+      "com/bmuschko/gradle-docker-plugin/3.6.1/gradle-docker-plugin-3.6.1.pom";
   private static final DateTimeFormatter DOTTED =
       DateTimeFormatter.ofPattern("yyyyMMdd.HHmmss").withZone(ZoneOffset.UTC);
   private static final DateTimeFormatter DOTLESS =
@@ -66,6 +68,32 @@ class MavenRepositoryBlackBoxCompatibilityTest {
     assertSameExchange("proxy GET", referenceGet, candidateGet, true);
     assertSameExchange("proxy HEAD", referenceHead, candidateHead, false);
     assertSameExchange("proxy checksum", referenceSha1, candidateSha1, true);
+  }
+
+  @Test
+  void gradlePluginPortalCrossHostRedirectMatchesNexusWhenConfigured() throws Exception {
+    CompatConfig config = CompatConfig.load();
+    assumeTrue(config.configured(),
+        "Set NEXUS_COMPAT_BASE_URL and KKREPO_COMPAT_BASE_URL to run black-box compatibility");
+    assumeTrue(Boolean.parseBoolean(setting(
+        "compat.gradlePluginPortalRedirect.enabled",
+        "COMPAT_GRADLE_PLUGIN_PORTAL_REDIRECT_ENABLED").orElse("false")),
+        "Set COMPAT_GRADLE_PLUGIN_PORTAL_REDIRECT_ENABLED=true after configuring the candidate "
+            + "proxy with allowedRedirectHosts=[plugins-artifacts.gradle.org]");
+
+    Endpoint nexus = config.nexus().withRepository(setting(
+        "compat.nexus.gradlePluginPortalRepository",
+        "NEXUS_COMPAT_GRADLE_PLUGIN_PORTAL_REPOSITORY").orElse("gradle-plugins"));
+    Endpoint candidate = config.nexusPlus().withRepository(setting(
+        "compat.nexusPlus.gradlePluginPortalRepository",
+        "KKREPO_COMPAT_GRADLE_PLUGIN_PORTAL_REPOSITORY").orElse("gradle-plugins"));
+
+    Exchange reference = get(nexus, GRADLE_PLUGIN_PORTAL_ARTIFACT);
+    Exchange actual = get(candidate, GRADLE_PLUGIN_PORTAL_ARTIFACT);
+
+    assertSameExchange("Gradle Plugin Portal redirected artifact", reference, actual, true);
+    assertEquals(200, actual.status(),
+        "the redirected Gradle Plugin Portal artifact must be cached and served");
   }
 
   @Test

--- a/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClient.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClient.java
@@ -9,6 +9,7 @@ import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import com.github.klboke.kkrepo.server.metrics.KkRepoMetrics;
 import com.github.klboke.kkrepo.server.proxy.ProxiedHttpClientFactory;
 import com.github.klboke.kkrepo.server.security.OutboundRequestPolicy;
+import com.github.klboke.kkrepo.server.security.SecurityValidationException;
 import io.micrometer.core.instrument.Timer;
 import java.io.IOException;
 import java.net.URI;
@@ -167,6 +168,7 @@ public class DockerRemoteRegistryClient {
           throw new IOException("Too many redirects fetching Docker remote " + url);
         }
         URI redirected = uri.resolve(location);
+        requireAllowedRedirect(runtime, uri, redirected);
         boolean forwardCredentials = sendCredentials && sameOrigin(uri, redirected);
         recordRemote(runtime, "GET", url, status, null, sample);
         recorded = true;
@@ -311,6 +313,24 @@ public class DockerRemoteRegistryClient {
       return effectivePort(from) == effectivePort(to);
     }
     return isHttpToHttpsUpgrade(from, to);
+  }
+
+  private static void requireAllowedRedirect(
+      RepositoryRuntime runtime, URI current, URI redirected) {
+    if (sameOrigin(current, redirected)) {
+      return;
+    }
+    String host = redirected == null || redirected.getHost() == null
+        ? ""
+        : redirected.getHost().trim().toLowerCase(java.util.Locale.ROOT);
+    while (host.endsWith(".")) {
+      host = host.substring(0, host.length() - 1);
+    }
+    if (runtime != null && runtime.allowsRedirectHost(host)) {
+      return;
+    }
+    throw new SecurityValidationException(
+        "remote redirect URL host is not allowed: " + host);
   }
 
   private static boolean isHttpToHttpsUpgrade(URI from, URI to) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcher.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcher.java
@@ -473,7 +473,7 @@ public class HttpRemoteFetcher {
           runtime == null || runtime.format() == null ? null : runtime.format().name(),
           trusted,
           includeAuthorization && trusted != null ? remoteAuthorizationHeader(runtime) : null,
-          Set.of(),
+          runtime == null ? Set.of() : runtime.allowedRedirectHosts(),
           runtime == null ? null : runtime.outboundProxy(),
           accept,
           requestBody,
@@ -502,7 +502,9 @@ public class HttpRemoteFetcher {
           runtime == null || runtime.format() == null ? null : runtime.format().name(),
           trusted,
           includeAuthorization && trusted != null ? remoteAuthorizationHeader(runtime) : null,
-          allowedUnsignedRedirectHosts,
+          runtime == null
+              ? allowedUnsignedRedirectHosts
+              : runtime.allowedRedirectHostsWith(allowedUnsignedRedirectHosts),
           runtime == null ? null : runtime.outboundProxy(),
           accept,
           requestBody,
@@ -579,6 +581,9 @@ public class HttpRemoteFetcher {
       String value = host == null ? "" : host.trim().toLowerCase(Locale.ROOT);
       if (value.startsWith("[") && value.endsWith("]")) {
         value = value.substring(1, value.length() - 1);
+      }
+      while (value.endsWith(".")) {
+        value = value.substring(0, value.length() - 1);
       }
       return value;
     }

--- a/server/src/main/java/com/github/klboke/kkrepo/server/maven/RepositoryRuntime.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/maven/RepositoryRuntime.java
@@ -4,7 +4,9 @@ import com.github.klboke.kkrepo.core.RepositoryFormat;
 import com.github.klboke.kkrepo.core.RepositoryType;
 import com.github.klboke.kkrepo.server.proxy.OutboundProxyConfig;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -38,7 +40,60 @@ public record RepositoryRuntime(
     Boolean cargoRequireAuthentication,
     List<RepositoryRuntime> members,
     OutboundProxyConfig outboundProxy,
-    Integer minimumReleaseAgeMinutes) {
+    Integer minimumReleaseAgeMinutes,
+    Set<String> allowedRedirectHosts) {
+
+  public RepositoryRuntime {
+    if (allowedRedirectHosts == null || allowedRedirectHosts.isEmpty()) {
+      allowedRedirectHosts = Set.of();
+    } else {
+      LinkedHashSet<String> normalized = new LinkedHashSet<>();
+      for (String host : allowedRedirectHosts) {
+        String value = normalizeRedirectHost(host);
+        // Operator configuration is exact-host only. The wildcard is reserved for explicit,
+        // protocol-owned integrity-pinned download flows and must never be activated from stored
+        // repository attributes, even if those attributes bypass RepositoryService validation.
+        if (!value.isBlank() && !"*".equals(value)) normalized.add(value);
+      }
+      allowedRedirectHosts = Set.copyOf(normalized);
+    }
+  }
+
+  /** Compatibility constructor for runtime snapshots created before redirect-host allowlisting. */
+  public RepositoryRuntime(
+      long id,
+      String name,
+      RepositoryFormat format,
+      RepositoryType type,
+      String recipeName,
+      boolean online,
+      Long blobStoreId,
+      String writePolicy,
+      String versionPolicy,
+      String layoutPolicy,
+      boolean strictContentTypeValidation,
+      String proxyRemoteUrl,
+      Integer contentMaxAgeMinutes,
+      Integer metadataMaxAgeMinutes,
+      Boolean autoBlock,
+      String proxyRemoteUsername,
+      String proxyRemotePassword,
+      String proxyRemoteBearerToken,
+      String rawContentDisposition,
+      Boolean dockerConnectorEnabled,
+      Integer dockerConnectorPort,
+      String dockerConnectorPublicUrl,
+      Boolean cargoRequireAuthentication,
+      List<RepositoryRuntime> members,
+      OutboundProxyConfig outboundProxy,
+      Integer minimumReleaseAgeMinutes) {
+    this(id, name, format, type, recipeName, online, blobStoreId, writePolicy,
+        versionPolicy, layoutPolicy, strictContentTypeValidation, proxyRemoteUrl,
+        contentMaxAgeMinutes, metadataMaxAgeMinutes, autoBlock, proxyRemoteUsername,
+        proxyRemotePassword, proxyRemoteBearerToken, rawContentDisposition,
+        dockerConnectorEnabled, dockerConnectorPort, dockerConnectorPublicUrl,
+        cargoRequireAuthentication, members, outboundProxy, minimumReleaseAgeMinutes, Set.of());
+  }
 
   /** Compatibility constructor for runtime snapshots created before npm release-age protection. */
   public RepositoryRuntime(
@@ -390,6 +445,29 @@ public record RepositoryRuntime(
     return format == RepositoryFormat.NPM
         && isProxy()
         && minimumReleaseAgeMinutesOrDefault() > 0;
+  }
+
+  /** Combines operator-configured hosts with protocol-owned redirect destinations. */
+  public Set<String> allowedRedirectHostsWith(Set<String> protocolRedirectHosts) {
+    if (protocolRedirectHosts == null || protocolRedirectHosts.isEmpty()) {
+      return allowedRedirectHosts;
+    }
+    LinkedHashSet<String> merged = new LinkedHashSet<>(allowedRedirectHosts);
+    for (String host : protocolRedirectHosts) {
+      String value = normalizeRedirectHost(host);
+      if (!value.isBlank()) merged.add(value);
+    }
+    return Set.copyOf(merged);
+  }
+
+  public boolean allowsRedirectHost(String host) {
+    return allowedRedirectHosts.contains(normalizeRedirectHost(host));
+  }
+
+  private static String normalizeRedirectHost(String host) {
+    String value = host == null ? "" : host.trim().toLowerCase(Locale.ROOT);
+    while (value.endsWith(".")) value = value.substring(0, value.length() - 1);
+    return value;
   }
 
   public String rawContentDispositionOrDefault() {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/maven/RepositoryRuntimeRegistry.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/maven/RepositoryRuntimeRegistry.java
@@ -13,6 +13,7 @@ import com.github.klboke.kkrepo.server.catalog.CatalogCacheBroadcaster;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -327,6 +328,7 @@ public class RepositoryRuntimeRegistry {
     String proxyRemoteUsername = null;
     String proxyRemotePassword = null;
     String proxyRemoteBearerToken = null;
+    Set<String> allowedRedirectHosts = Set.of();
     com.github.klboke.kkrepo.server.proxy.OutboundProxyConfig outboundProxy = null;
     if (proxyRaw instanceof Map<?, ?> proxyMap) {
       contentMaxAge = asInt(proxyMap.get("contentMaxAgeMinutes"));
@@ -345,6 +347,7 @@ public class RepositoryRuntimeRegistry {
       if (bearerToken != null && !bearerToken.toString().isBlank()) {
         proxyRemoteBearerToken = bearerToken.toString();
       }
+      allowedRedirectHosts = asStringSet(proxyMap.get("allowedRedirectHosts"));
       outboundProxy = readOutboundProxy(proxyMap);
     }
     String rawContentDisposition = null;
@@ -414,7 +417,8 @@ public class RepositoryRuntimeRegistry {
         cargoRequireAuthentication,
         members,
         outboundProxy,
-        minimumReleaseAge);
+        minimumReleaseAge,
+        allowedRedirectHosts);
   }
 
   private static com.github.klboke.kkrepo.server.proxy.OutboundProxyConfig readOutboundProxy(Map<?, ?> proxyMap) {
@@ -435,6 +439,15 @@ public class RepositoryRuntimeRegistry {
     if (value == null) return null;
     if (value instanceof Boolean b) return b;
     return Boolean.parseBoolean(value.toString());
+  }
+
+  private static Set<String> asStringSet(Object value) {
+    if (!(value instanceof Iterable<?> values)) return Set.of();
+    LinkedHashSet<String> result = new LinkedHashSet<>();
+    for (Object item : values) {
+      if (item != null && !item.toString().isBlank()) result.add(item.toString());
+    }
+    return Set.copyOf(result);
   }
 
   private static boolean containsProxySecret(RepositoryRuntime runtime) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/repositories/RepositoryCommands.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/repositories/RepositoryCommands.java
@@ -122,7 +122,34 @@ public final class RepositoryCommands {
       String outboundProxyUsername,
       String outboundProxyPassword,
       Boolean outboundProxyPasswordConfigured,
-      Integer minimumReleaseAgeMinutes) {
+      Integer minimumReleaseAgeMinutes,
+      List<String> allowedRedirectHosts) {
+    /** Compatibility constructor for callers that predate redirect-host allowlisting. */
+    public ProxySettings(
+        String remoteUrl,
+        Integer contentMaxAgeMinutes,
+        Integer metadataMaxAgeMinutes,
+        Boolean autoBlock,
+        String remoteUsername,
+        String remotePassword,
+        Boolean remotePasswordConfigured,
+        String remoteBearerToken,
+        Boolean remoteBearerTokenConfigured,
+        String outboundProxyType,
+        String outboundProxyHost,
+        Integer outboundProxyPort,
+        String outboundProxyUsername,
+        String outboundProxyPassword,
+        Boolean outboundProxyPasswordConfigured,
+        Integer minimumReleaseAgeMinutes) {
+      this(remoteUrl, contentMaxAgeMinutes, metadataMaxAgeMinutes, autoBlock,
+          remoteUsername, remotePassword, remotePasswordConfigured,
+          remoteBearerToken, remoteBearerTokenConfigured,
+          outboundProxyType, outboundProxyHost, outboundProxyPort,
+          outboundProxyUsername, outboundProxyPassword, outboundProxyPasswordConfigured,
+          minimumReleaseAgeMinutes, null);
+    }
+
     /** Compatibility constructor for callers that predate npm release-age protection. */
     public ProxySettings(
         String remoteUrl,

--- a/server/src/main/java/com/github/klboke/kkrepo/server/repositories/RepositoryService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/repositories/RepositoryService.java
@@ -43,6 +43,7 @@ import com.github.klboke.kkrepo.server.security.SecurityCatalogCache;
 import com.github.klboke.kkrepo.server.security.SecurityValidationException;
 import com.github.klboke.kkrepo.protocol.alpine.AlpinePathParser;
 import com.github.klboke.kkrepo.protocol.alpine.AlpineSignature;
+import java.net.IDN;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -50,6 +51,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -68,6 +70,9 @@ public class RepositoryService {
   private static final Set<String> MAVEN_VERSION_POLICIES = Set.of("RELEASE", "SNAPSHOT", "MIXED");
   private static final Set<String> MAVEN_LAYOUT_POLICIES = Set.of("STRICT", "PERMISSIVE");
   private static final Set<String> RAW_CONTENT_DISPOSITIONS = Set.of("INLINE", "ATTACHMENT");
+  private static final int MAX_PROXY_REDIRECT_HOSTS = 64;
+  private static final Pattern REDIRECT_HOST_LABEL_PATTERN =
+      Pattern.compile("^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$");
 
   private final RepositoryDao repositoryDao;
   private final BlobStoreDao blobStoreDao;
@@ -1180,6 +1185,8 @@ public class RepositoryService {
     if (format == RepositoryFormat.ANSIBLEGALAXY) {
       settings = withRemoteUrl(settings, normalizeAnsibleGalaxyRemoteUrl(settings.remoteUrl()));
     }
+    settings = withAllowedRedirectHosts(
+        settings, normalizeAllowedRedirectHosts(settings.allowedRedirectHosts()));
     validateProxy(settings, format);
     return normalizeOutboundProxyType(settings);
   }
@@ -1216,7 +1223,8 @@ public class RepositoryService {
         settings.outboundProxyUsername(),
         settings.outboundProxyPassword(),
         settings.outboundProxyPasswordConfigured(),
-        settings.minimumReleaseAgeMinutes());
+        settings.minimumReleaseAgeMinutes(),
+        settings.allowedRedirectHosts());
   }
 
   private static String defaultRemoteUrl(RepositoryFormat format) {
@@ -1253,7 +1261,30 @@ public class RepositoryService {
         settings.outboundProxyUsername(),
         settings.outboundProxyPassword(),
         settings.outboundProxyPasswordConfigured(),
-        settings.minimumReleaseAgeMinutes());
+        settings.minimumReleaseAgeMinutes(),
+        settings.allowedRedirectHosts());
+  }
+
+  private static ProxySettings withAllowedRedirectHosts(
+      ProxySettings settings, List<String> allowedRedirectHosts) {
+    return new ProxySettings(
+        settings.remoteUrl(),
+        settings.contentMaxAgeMinutes(),
+        settings.metadataMaxAgeMinutes(),
+        settings.autoBlock(),
+        settings.remoteUsername(),
+        settings.remotePassword(),
+        settings.remotePasswordConfigured(),
+        settings.remoteBearerToken(),
+        settings.remoteBearerTokenConfigured(),
+        settings.outboundProxyType(),
+        settings.outboundProxyHost(),
+        settings.outboundProxyPort(),
+        settings.outboundProxyUsername(),
+        settings.outboundProxyPassword(),
+        settings.outboundProxyPasswordConfigured(),
+        settings.minimumReleaseAgeMinutes(),
+        allowedRedirectHosts);
   }
 
   private void validateProxy(ProxySettings settings, RepositoryFormat format) {
@@ -1284,6 +1315,44 @@ public class RepositoryService {
     if (format == RepositoryFormat.SWIFT) {
       normalizeSwiftRemoteUrl(settings.remoteUrl());
     }
+  }
+
+  private static List<String> normalizeAllowedRedirectHosts(List<String> hosts) {
+    if (hosts == null || hosts.isEmpty()) return List.of();
+    LinkedHashSet<String> normalized = new LinkedHashSet<>();
+    for (String host : hosts) {
+      if (host == null || host.isBlank()) {
+        throw invalidRedirectHost();
+      }
+      String candidate = host.trim();
+      while (candidate.endsWith(".")) {
+        candidate = candidate.substring(0, candidate.length() - 1);
+      }
+      final String ascii;
+      try {
+        ascii = IDN.toASCII(candidate, IDN.USE_STD3_ASCII_RULES)
+            .toLowerCase(Locale.ROOT);
+      } catch (IllegalArgumentException e) {
+        throw invalidRedirectHost();
+      }
+      if (ascii.isBlank() || ascii.length() > 253) throw invalidRedirectHost();
+      for (String label : ascii.split("\\.", -1)) {
+        if (!REDIRECT_HOST_LABEL_PATTERN.matcher(label).matches()) {
+          throw invalidRedirectHost();
+        }
+      }
+      normalized.add(ascii);
+      if (normalized.size() > MAX_PROXY_REDIRECT_HOSTS) {
+        throw new RepositoryValidationException(
+            "proxy.allowedRedirectHosts supports at most " + MAX_PROXY_REDIRECT_HOSTS + " hosts");
+      }
+    }
+    return List.copyOf(normalized);
+  }
+
+  private static RepositoryValidationException invalidRedirectHost() {
+    return new RepositoryValidationException(
+        "proxy.allowedRedirectHosts entries must be exact host names without a scheme, port, path, or wildcard");
   }
 
   private OutboundProxyConfig validateOutboundProxy(ProxySettings settings) {
@@ -1401,7 +1470,10 @@ public class RepositoryService {
         null,
         incoming.minimumReleaseAgeMinutes() == null
             ? base.minimumReleaseAgeMinutes()
-            : incoming.minimumReleaseAgeMinutes());
+            : incoming.minimumReleaseAgeMinutes(),
+        incoming.allowedRedirectHosts() == null
+            ? base.allowedRedirectHosts()
+            : incoming.allowedRedirectHosts());
   }
 
   private static String mergedOutboundProxyPassword(ProxySettings base, ProxySettings incoming) {
@@ -1441,6 +1513,9 @@ public class RepositoryService {
     if (proxy.metadataMaxAgeMinutes() != null) map.put("metadataMaxAgeMinutes", proxy.metadataMaxAgeMinutes());
     if (proxy.minimumReleaseAgeMinutes() != null) {
       map.put("minimumReleaseAgeMinutes", proxy.minimumReleaseAgeMinutes());
+    }
+    if (proxy.allowedRedirectHosts() != null && !proxy.allowedRedirectHosts().isEmpty()) {
+      map.put("allowedRedirectHosts", List.copyOf(proxy.allowedRedirectHosts()));
     }
     if (proxy.autoBlock() != null) map.put("autoBlock", proxy.autoBlock());
     if (proxy.remoteUsername() != null && !proxy.remoteUsername().isBlank()) {
@@ -1865,7 +1940,8 @@ public class RepositoryService {
         blankToNull(stringOrNull(proxyMap.get("outboundProxyUsername"))),
         blankToNull(stringOrNull(proxyMap.get("outboundProxyPassword"))),
         null,
-        intValue(proxyMap.get("minimumReleaseAgeMinutes")));
+        intValue(proxyMap.get("minimumReleaseAgeMinutes")),
+        stringList(proxyMap.get("allowedRedirectHosts")));
   }
 
   private static ProxySettings readProxyAttributesOrDefaults(RepositoryRecord record) {
@@ -1890,7 +1966,8 @@ public class RepositoryService {
         effective.outboundProxyUsername(),
         null,
         outboundPassword != null && !outboundPassword.isBlank(),
-        effective.minimumReleaseAgeMinutes() == null ? 0 : effective.minimumReleaseAgeMinutes());
+        effective.minimumReleaseAgeMinutes() == null ? 0 : effective.minimumReleaseAgeMinutes(),
+        effective.allowedRedirectHosts() == null ? List.of() : effective.allowedRedirectHosts());
   }
 
   private static String stringOrNull(Object value) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/swift/SwiftGitHubClient.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/swift/SwiftGitHubClient.java
@@ -633,7 +633,8 @@ final class SwiftGitHubClient {
         runtime.format().name(),
         "api.github.com",
         authorization(runtime),
-        allowCodeloadRedirect ? Set.of("codeload.github.com") : Set.of(),
+        runtime.allowedRedirectHostsWith(
+            allowCodeloadRedirect ? Set.of("codeload.github.com") : Set.of()),
         runtime.outboundProxy());
   }
 
@@ -652,7 +653,8 @@ final class SwiftGitHubClient {
         runtime.format().name(),
         "github.com",
         null,
-        allowCodeloadRedirect ? Set.of("codeload.github.com") : Set.of(),
+        runtime.allowedRedirectHostsWith(
+            allowCodeloadRedirect ? Set.of("codeload.github.com") : Set.of()),
         runtime.outboundProxy());
   }
 

--- a/server/src/test/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClientTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClientTest.java
@@ -3,6 +3,7 @@ package com.github.klboke.kkrepo.server.docker;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -21,6 +22,7 @@ import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import com.github.klboke.kkrepo.server.proxy.OutboundProxyConfig;
 import com.github.klboke.kkrepo.server.proxy.ProxiedHttpClientFactory;
 import com.github.klboke.kkrepo.server.security.OutboundRequestPolicy;
+import com.github.klboke.kkrepo.server.security.SecurityValidationException;
 import com.github.klboke.kkrepo.server.support.FakeHttpProxyServer;
 import com.github.klboke.kkrepo.server.support.InMemorySharedCache;
 import com.sun.net.httpserver.HttpServer;
@@ -36,6 +38,7 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -378,6 +381,33 @@ class DockerRemoteRegistryClientTest {
   }
 
   @Test
+  void crossOriginRedirectIsDeniedUnlessItsHostIsConfigured() throws Exception {
+    try (TestRegistry registry = TestRegistry.start(); TestRegistry storage = TestRegistry.start()) {
+      AtomicInteger storageCalls = new AtomicInteger();
+      registry.server.createContext("/v2/library/nginx/blobs/sha256:abc", exchange -> {
+        exchange.getResponseHeaders().add("Location", storage.baseUrl + "/layers/abc");
+        exchange.sendResponseHeaders(307, -1);
+        exchange.close();
+      });
+      storage.server.createContext("/layers/abc", exchange -> {
+        storageCalls.incrementAndGet();
+        exchange.sendResponseHeaders(200, -1);
+        exchange.close();
+      });
+
+      SecurityValidationException error = assertThrows(
+          SecurityValidationException.class,
+          () -> client().get(
+              runtime(registry.baseUrl, "robot", "secret"),
+              "library/nginx/blobs/sha256:abc",
+              "application/octet-stream"));
+
+      assertEquals("remote redirect URL host is not allowed: 127.0.0.1", error.getMessage());
+      assertEquals(0, storageCalls.get());
+    }
+  }
+
+  @Test
   void crossOriginRedirectStripsRegistryCredentials() throws Exception {
     try (TestRegistry registry = TestRegistry.start(); TestRegistry storage = TestRegistry.start()) {
       List<String> registryAuthorizations = new ArrayList<>();
@@ -399,7 +429,7 @@ class DockerRemoteRegistryClientTest {
       DockerRemoteRegistryClient client = client();
 
       try (HttpRemoteFetcher.Result result = client.get(
-          runtime(registry.baseUrl, "robot", "secret"),
+          runtimeAllowingRedirectHost(registry.baseUrl, "robot", "secret", "127.0.0.1"),
           "library/nginx/blobs/sha256:abc",
           "application/octet-stream")) {
         assertEquals(200, result.status());
@@ -438,7 +468,7 @@ class DockerRemoteRegistryClientTest {
       DockerRemoteRegistryClient client = client();
 
       try (HttpRemoteFetcher.Result result = client.get(
-          runtime(registry.baseUrl, "robot", "secret"),
+          runtimeAllowingRedirectHost(registry.baseUrl, "robot", "secret", "127.0.0.1"),
           "library/nginx/blobs/sha256:abc",
           "application/octet-stream")) {
         assertEquals(401, result.status());
@@ -486,7 +516,7 @@ class DockerRemoteRegistryClientTest {
       DockerRemoteRegistryClient client = client();
 
       try (HttpRemoteFetcher.Result result = client.get(
-          runtime(registry.baseUrl, "robot", "secret"),
+          runtimeAllowingRedirectHost(registry.baseUrl, "robot", "secret", "127.0.0.1"),
           "library/nginx/blobs/sha256:abc",
           "application/octet-stream")) {
         assertEquals(200, result.status());
@@ -607,7 +637,8 @@ class DockerRemoteRegistryClientTest {
           300,
           null,
           directFactory);
-      RepositoryRuntime runtime = runtime(registry.baseUrl, "robot", "secret");
+      RepositoryRuntime runtime = runtimeAllowingRedirectHost(
+          registry.baseUrl, "robot", "secret", "127.0.0.1");
 
       try (HttpRemoteFetcher.Result result = client.get(
           runtime,
@@ -712,7 +743,7 @@ class DockerRemoteRegistryClientTest {
 
       try (HttpRemoteFetcher.Result result = client.get(
           proxiedRuntime("http://localhost", "robot", "secret",
-              outboundProxy(proxy.port())),
+              outboundProxy(proxy.port()), Set.of("127.0.0.1")),
           "library/nginx/blobs/sha256:abc",
           "application/octet-stream")) {
         assertEquals(200, result.status());
@@ -844,6 +875,15 @@ class DockerRemoteRegistryClientTest {
 
   private static RepositoryRuntime proxiedRuntime(
       String remoteUrl, String username, String password, OutboundProxyConfig outboundProxy) {
+    return proxiedRuntime(remoteUrl, username, password, outboundProxy, Set.of());
+  }
+
+  private static RepositoryRuntime proxiedRuntime(
+      String remoteUrl,
+      String username,
+      String password,
+      OutboundProxyConfig outboundProxy,
+      Set<String> allowedRedirectHosts) {
     return new RepositoryRuntime(
         10L,
         "docker-proxy",
@@ -869,7 +909,9 @@ class DockerRemoteRegistryClientTest {
         null,
         null,
         List.of(),
-        outboundProxy);
+        outboundProxy,
+        null,
+        allowedRedirectHosts);
   }
 
   private DockerRemoteRegistryClient client() {
@@ -901,6 +943,38 @@ class DockerRemoteRegistryClientTest {
         null,
         null,
         List.of());
+  }
+
+  private static RepositoryRuntime runtimeAllowingRedirectHost(
+      String remoteUrl, String username, String password, String allowedRedirectHost) {
+    return new RepositoryRuntime(
+        10L,
+        "docker-proxy",
+        RepositoryFormat.DOCKER,
+        RepositoryType.PROXY,
+        "docker-proxy",
+        true,
+        1L,
+        null,
+        null,
+        null,
+        true,
+        remoteUrl,
+        1440,
+        1440,
+        true,
+        username,
+        password,
+        null,
+        null,
+        false,
+        null,
+        null,
+        null,
+        List.of(),
+        null,
+        null,
+        Set.of(allowedRedirectHost));
   }
 
   private static String basic(String username, String password) {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClientTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/docker/DockerRemoteRegistryClientTest.java
@@ -408,6 +408,52 @@ class DockerRemoteRegistryClientTest {
   }
 
   @Test
+  void redirectWithoutAHostIsDenied() throws Exception {
+    try (TestRegistry registry = TestRegistry.start()) {
+      registry.server.createContext("/v2/library/nginx/blobs/sha256:abc", exchange -> {
+        exchange.getResponseHeaders().add("Location", "mailto:artifact");
+        exchange.sendResponseHeaders(307, -1);
+        exchange.close();
+      });
+
+      SecurityValidationException error = assertThrows(
+          SecurityValidationException.class,
+          () -> client().get(
+              runtime(registry.baseUrl, "robot", "secret"),
+              "library/nginx/blobs/sha256:abc",
+              "application/octet-stream"));
+
+      assertEquals("remote redirect URL host is not allowed: ", error.getMessage());
+    }
+  }
+
+  @Test
+  void allowlistedRedirectHostWithTrailingDotIsNormalized() throws Exception {
+    try (TestRegistry registry = TestRegistry.start(); TestRegistry storage = TestRegistry.start()) {
+      String storageUrl = storage.baseUrl.replace("127.0.0.1", "localhost.");
+      registry.server.createContext("/v2/library/nginx/blobs/sha256:abc", exchange -> {
+        exchange.getResponseHeaders().add("Location", storageUrl + "/layers/abc");
+        exchange.sendResponseHeaders(307, -1);
+        exchange.close();
+      });
+      storage.server.createContext("/layers/abc", exchange -> {
+        byte[] body = "layer".getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(200, body.length);
+        exchange.getResponseBody().write(body);
+        exchange.close();
+      });
+
+      try (HttpRemoteFetcher.Result result = client().get(
+          runtimeAllowingRedirectHost(registry.baseUrl, "robot", "secret", "localhost"),
+          "library/nginx/blobs/sha256:abc",
+          "application/octet-stream")) {
+        assertEquals(200, result.status());
+        assertEquals("layer", new String(result.body().readAllBytes(), StandardCharsets.UTF_8));
+      }
+    }
+  }
+
+  @Test
   void crossOriginRedirectStripsRegistryCredentials() throws Exception {
     try (TestRegistry registry = TestRegistry.start(); TestRegistry storage = TestRegistry.start()) {
       List<String> registryAuthorizations = new ArrayList<>();

--- a/server/src/test/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcherTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcherTest.java
@@ -504,6 +504,20 @@ class HttpRemoteFetcherTest {
   }
 
   @Test
+  void explicitRedirectAllowlistDoesNotEstablishTrustWithoutRepositoryRuntime() {
+    HttpRemoteFetcher.Request request = HttpRemoteFetcher.Request
+        .get("https://repo.example.com/maven2/com/example/app.jar")
+        .withRepositoryAllowingUnsignedRedirects(
+            null, false, Set.of("cdn.example.net"));
+    URI current = URI.create("https://repo.example.com/maven2/com/example/app.jar");
+    URI redirected = URI.create("https://cdn.example.net/app.jar");
+
+    assertNull(request.authorizationHeader());
+    assertNull(request.trustedHost());
+    assertNull(request.trustedHostForRedirect(current, redirected));
+  }
+
+  @Test
   void repositoryRequestsCanFollowAllowlistedCrossOriginRedirectsWithoutAuthorization() {
     RepositoryRuntime runtime = runtime(null, null, null);
     HttpRemoteFetcher.Request request = HttpRemoteFetcher.Request

--- a/server/src/test/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcherTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/maven/HttpRemoteFetcherTest.java
@@ -456,12 +456,18 @@ class HttpRemoteFetcherTest {
 
   @Test
   void repositoryRequestsCanDropAuthorizationForAllowedUnsignedCrossOriginRedirects() {
-    RepositoryRuntime runtime = runtime("robot", "secret", null);
+    RepositoryRuntime runtime = runtime(
+        "https://repo.example.com/maven2",
+        "robot",
+        "secret",
+        null,
+        Set.of("configured-cdn.example.net"));
     HttpRemoteFetcher.Request request = HttpRemoteFetcher.Request
         .get("https://repo.example.com/maven2/com/example/app.jar")
         .withRepositoryAllowingUnsignedRedirects(runtime, true, Set.of("storage.example.net"));
     URI current = URI.create("https://repo.example.com/maven2/com/example/app.jar");
     URI storage = URI.create("https://storage.example.net/app.jar");
+    URI configuredCdn = URI.create("https://configured-cdn.example.net/app.jar");
 
     assertEquals("repo.example.com", request.trustedHost());
     assertNotNull(request.authorizationHeader());
@@ -470,6 +476,31 @@ class HttpRemoteFetcherTest {
         request.authorizationHeaderForRedirect(current, URI.create("https://repo.example.com/maven2/redirect.jar")));
     assertNull(request.authorizationHeaderForRedirect(current, storage));
     assertEquals("storage.example.net", request.trustedHostForRedirect(current, storage));
+    assertNull(request.authorizationHeaderForRedirect(current, configuredCdn));
+    assertEquals(
+        "configured-cdn.example.net",
+        request.trustedHostForRedirect(current, configuredCdn));
+  }
+
+  @Test
+  void repositoryRequestsUseConfiguredRedirectHostsAndDropAuthorization() {
+    RepositoryRuntime runtime = runtime(
+        "https://plugins.gradle.org/m2/",
+        "robot",
+        "secret",
+        null,
+        Set.of("PLUGINS-ARTIFACTS.GRADLE.ORG."));
+    HttpRemoteFetcher.Request request = HttpRemoteFetcher.Request
+        .get("https://plugins.gradle.org/m2/com/example/app.pom")
+        .withRepository(runtime);
+    URI current = URI.create("https://plugins.gradle.org/m2/com/example/app.pom");
+    URI redirected = URI.create("https://plugins-artifacts.gradle.org./com/example/app.pom");
+
+    assertNotNull(request.authorizationHeader());
+    assertNull(request.authorizationHeaderForRedirect(current, redirected));
+    assertEquals(
+        "plugins-artifacts.gradle.org",
+        request.trustedHostForRedirect(current, redirected));
   }
 
   @Test
@@ -618,6 +649,15 @@ class HttpRemoteFetcherTest {
 
   private static RepositoryRuntime runtime(
       String remoteUrl, String username, String password, String bearerToken) {
+    return runtime(remoteUrl, username, password, bearerToken, Set.of());
+  }
+
+  private static RepositoryRuntime runtime(
+      String remoteUrl,
+      String username,
+      String password,
+      String bearerToken,
+      Set<String> allowedRedirectHosts) {
     return new RepositoryRuntime(
         1,
         "maven-proxy",
@@ -643,7 +683,9 @@ class HttpRemoteFetcherTest {
         null,
         null,
         List.of(),
-        null);
+        null,
+        null,
+        allowedRedirectHosts);
   }
 
   private static class SequencedFetcher extends HttpRemoteFetcher {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/maven/MavenProxyServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/maven/MavenProxyServiceTest.java
@@ -8,10 +8,17 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import com.github.klboke.kkrepo.core.BlobObjectMetadata;
 import com.github.klboke.kkrepo.core.BlobReference;
@@ -25,6 +32,9 @@ import com.github.klboke.kkrepo.persistence.jdbc.api.model.AssetRecord;
 import com.github.klboke.kkrepo.protocol.maven.path.MavenPath;
 import com.github.klboke.kkrepo.protocol.maven.path.MavenPathParser;
 import com.github.klboke.kkrepo.server.cache.AssetMetadataCache;
+import com.github.klboke.kkrepo.server.proxy.OutboundProxyConfig;
+import com.github.klboke.kkrepo.server.proxy.ProxiedHttpClientFactory;
+import com.github.klboke.kkrepo.server.security.OutboundRequestPolicy;
 import com.github.klboke.kkrepo.server.securityscan.ArtifactDownloadPolicy;
 import com.github.klboke.kkrepo.server.support.InMemorySharedCache;
 import com.github.klboke.kkrepo.server.support.dao.AssetDaoAdapter;
@@ -32,15 +42,18 @@ import com.github.klboke.kkrepo.server.support.dao.ProxyStateDaoAdapter;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
+import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -182,6 +195,75 @@ class MavenProxyServiceTest {
     assertEquals(1, proxyState.successCount);
     assertNotNull(fetcher.request);
     assertNull(fetcher.request.timeout());
+  }
+
+  @Test
+  void gradlePluginPortalRedirectCanBeAllowlistedAndCachedUnderTheRequestedMavenPath()
+      throws Exception {
+    String requestedPath =
+        "com/bmuschko/gradle-docker-plugin/3.6.1/gradle-docker-plugin-3.6.1.pom";
+    URI pluginPortal = URI.create("https://plugins.gradle.org/m2/" + requestedPath);
+    URI artifactHost = URI.create(
+        "https://plugins-artifacts.gradle.org/com.bmuschko/gradle-docker-plugin/3.6.1/"
+            + "5fe2ae0bf2f5be95c6d0e4ee5f36dce5fe935a5712dcb309ffd862b42a90c301/"
+            + "gradle-docker-plugin-3.6.1.pom");
+    byte[] pom = "<project><modelVersion>4.0.0</modelVersion></project>"
+        .getBytes(StandardCharsets.UTF_8);
+    ProxiedHttpClientFactory transport = mock(ProxiedHttpClientFactory.class);
+    List<URI> targets = new ArrayList<>();
+    List<String> authorizations = new ArrayList<>();
+    when(transport.execute(
+        anyString(),
+        any(OutboundProxyConfig.class),
+        eq("GET"),
+        any(OutboundRequestPolicy.ResolvedHttpTarget.class),
+        anyMap(),
+        nullable(byte[].class),
+        anyLong())).thenAnswer(invocation -> {
+          OutboundRequestPolicy.ResolvedHttpTarget target = invocation.getArgument(3);
+          Map<String, String> headers = invocation.getArgument(4);
+          targets.add(target.uri());
+          authorizations.add(headers.get("Authorization"));
+          if (target.uri().equals(pluginPortal)) {
+            return proxiedResponse(303, Map.of("Location", artifactHost.toString()), new byte[0]);
+          }
+          return proxiedResponse(200, Map.of("Content-Type", "application/xml"), pom);
+        });
+    HttpRemoteFetcher fetcher = new HttpRemoteFetcher(
+        new OutboundRequestPolicy(false, ""),
+        null,
+        transport,
+        "HTTP_1_1",
+        30,
+        60,
+        300,
+        5,
+        1);
+    CountingBlobStorage storage = new CountingBlobStorage();
+    TempFileWriter writer = new TempFileWriter();
+    RecordingProxyStateDao proxyState = new RecordingProxyStateDao();
+    MavenProxyService service = new MavenProxyService(
+        new EmptyAssetDao(),
+        new FixedBlobStorageRegistry(storage),
+        writer,
+        proxyState,
+        fetcher,
+        null,
+        new AssetMetadataCache(new InMemorySharedCache(), false, 0, 0));
+
+    MavenResponse response = service.get(gradlePluginPortalRuntime(), path(requestedPath), false);
+
+    assertEquals(200, response.status());
+    try (InputStream body = response.body()) {
+      assertArrayEquals(pom, body.readAllBytes());
+    }
+    assertEquals(List.of(pluginPortal, artifactHost), targets);
+    assertNotNull(authorizations.get(0));
+    assertNull(authorizations.get(1), "repository credentials must not cross redirect origins");
+    assertTrue(writer.keepResponseFile);
+    assertEquals(requestedPath, writer.writtenPath.path());
+    assertEquals(0, storage.getCalls);
+    assertEquals(1, proxyState.successCount);
   }
 
   @Test
@@ -432,8 +514,58 @@ class MavenProxyServiceTest {
         true, null, List.of());
   }
 
+  private static RepositoryRuntime gradlePluginPortalRuntime() {
+    return new RepositoryRuntime(
+        10,
+        "gradle-plugins",
+        RepositoryFormat.MAVEN2,
+        RepositoryType.PROXY,
+        "maven2-proxy",
+        true,
+        1L,
+        null,
+        "MIXED",
+        "PERMISSIVE",
+        true,
+        "https://plugins.gradle.org/m2/",
+        1440,
+        1440,
+        true,
+        "robot",
+        "secret",
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        List.of(),
+        new OutboundProxyConfig(
+            OutboundProxyConfig.Type.HTTP, "proxy.example", 8080, null, null),
+        null,
+        Set.of("plugins-artifacts.gradle.org"));
+  }
+
   private static MavenPath path(String rawPath) {
     return PARSER.parsePath(rawPath);
+  }
+
+  private static ProxiedHttpClientFactory.ProxiedResponse proxiedResponse(
+      int status, Map<String, String> headers, byte[] body) throws IOException {
+    ProxiedHttpClientFactory.ProxiedResponse response =
+        mock(ProxiedHttpClientFactory.ProxiedResponse.class);
+    when(response.status()).thenReturn(status);
+    when(response.headers()).thenReturn(headers);
+    when(response.header(anyString())).thenAnswer(invocation -> {
+      String name = invocation.getArgument(0);
+      return headers.entrySet().stream()
+          .filter(entry -> entry.getKey().equalsIgnoreCase(name))
+          .map(Map.Entry::getValue)
+          .findFirst()
+          .orElse(null);
+    });
+    when(response.body()).thenAnswer(ignored -> new java.io.ByteArrayInputStream(body));
+    return response;
   }
 
   private static class EmptyAssetDao extends AssetDaoAdapter {
@@ -600,6 +732,7 @@ class MavenProxyServiceTest {
   private static class TempFileWriter extends MavenAssetWriter {
     boolean keepResponseFile;
     String createdByIp;
+    MavenPath writtenPath;
 
     TempFileWriter() {
       super(null, null, null, new AssetMetadataCache(new InMemorySharedCache(), false, 0, 0), null);
@@ -620,6 +753,7 @@ class MavenProxyServiceTest {
         boolean keepResponseFile) {
       this.keepResponseFile = keepResponseFile;
       this.createdByIp = createdByIp;
+      this.writtenPath = path;
       try {
         Path tmp = Files.createTempFile("kkrepo-test-", ".bin");
         long size = Files.copy(body, tmp, java.nio.file.StandardCopyOption.REPLACE_EXISTING);

--- a/server/src/test/java/com/github/klboke/kkrepo/server/maven/RepositoryRuntimeRegistryTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/maven/RepositoryRuntimeRegistryTest.java
@@ -187,6 +187,25 @@ class RepositoryRuntimeRegistryTest {
   }
 
   @Test
+  void resolveReadsConfiguredProxyRedirectHosts() {
+    FakeRepositoryDao dao = new FakeRepositoryDao();
+    dao.add(mavenProxyRepo(11, "gradle-plugins", Map.of(
+        "remoteUrl", "https://plugins.gradle.org/m2/",
+        "allowedRedirectHosts", List.of(
+            "plugins-artifacts.gradle.org",
+            "CDN.EXAMPLE.ORG.",
+            "*"))), List.of());
+
+    RepositoryRuntime runtime = new RepositoryRuntimeRegistry(dao, 0)
+        .resolve("gradle-plugins")
+        .orElseThrow();
+
+    assertEquals(
+        java.util.Set.of("plugins-artifacts.gradle.org", "cdn.example.org"),
+        runtime.allowedRedirectHosts());
+  }
+
+  @Test
   void runtimeWithProxyBearerTokenIsNotWrittenToSharedCache() {
     FakeRepositoryDao dao = new FakeRepositoryDao();
     dao.add(cargoProxyRepo(6, "cargo-private-proxy", "upstream-token"), List.of());

--- a/server/src/test/java/com/github/klboke/kkrepo/server/repositories/RepositoryServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/repositories/RepositoryServiceTest.java
@@ -46,6 +46,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class RepositoryServiceTest {
@@ -666,6 +667,101 @@ class RepositoryServiceTest {
         new ProxySettings("https://registry.npmjs.org/", 1440, 1440, true),
         null, null, null, null));
     assertEquals(0, defaulted.proxy().minimumReleaseAgeMinutes());
+  }
+
+  @Test
+  void proxyRedirectHostsRoundTripNormalizePreserveAndClear() {
+    StubRepositoryDao repositories = new StubRepositoryDao(repository(1L));
+    RepositoryService service = service(repositories);
+
+    RepositoryView created = service.create(new CreateCommand(
+        "gradle-plugins",
+        "maven2-proxy",
+        true,
+        "default",
+        true,
+        null,
+        proxyWithRedirectHosts(
+            "http://127.0.0.1/m2/",
+            List.of(
+                " Plugins-Artifacts.Gradle.org. ",
+                "cdn.example.org",
+                "plugins-artifacts.gradle.org")),
+        null,
+        null,
+        null,
+        null));
+
+    assertEquals(
+        List.of("plugins-artifacts.gradle.org", "cdn.example.org"),
+        created.proxy().allowedRedirectHosts());
+    Map<?, ?> storedProxy = (Map<?, ?>) repositories.repository.attributes().get("proxy");
+    assertEquals(created.proxy().allowedRedirectHosts(), storedProxy.get("allowedRedirectHosts"));
+    assertEquals(
+        Set.of("plugins-artifacts.gradle.org", "cdn.example.org"),
+        new RepositoryRuntimeRegistry(repositories, 0)
+            .resolve("gradle-plugins")
+            .orElseThrow()
+            .allowedRedirectHosts());
+
+    RepositoryView preserved = service.update(
+        "gradle-plugins",
+        new UpdateCommand(
+            true,
+            null,
+            null,
+            null,
+            new ProxySettings(null, null, null, null),
+            null,
+            null,
+            null,
+            null));
+    assertEquals(created.proxy().allowedRedirectHosts(), preserved.proxy().allowedRedirectHosts());
+
+    RepositoryView cleared = service.update(
+        "gradle-plugins",
+        new UpdateCommand(
+            true,
+            null,
+            null,
+            null,
+            proxyWithRedirectHosts(null, List.of()),
+            null,
+            null,
+            null,
+            null));
+    assertEquals(List.of(), cleared.proxy().allowedRedirectHosts());
+    Map<?, ?> clearedProxy = (Map<?, ?>) repositories.updated.attributes().get("proxy");
+    assertEquals(false, clearedProxy.containsKey("allowedRedirectHosts"));
+  }
+
+  @Test
+  void proxyRedirectHostsRejectUrlsPortsPathsAndWildcards() {
+    RepositoryService service = service(new StubRepositoryDao(repository(1L)));
+
+    for (String invalid : List.of(
+        "https://plugins-artifacts.gradle.org",
+        "plugins-artifacts.gradle.org:443",
+        "plugins-artifacts.gradle.org/files",
+        "*.gradle.org")) {
+      RepositoryValidationException error = assertThrows(
+          RepositoryValidationException.class,
+          () -> service.create(new CreateCommand(
+              "gradle-plugins",
+              "maven2-proxy",
+              true,
+              "default",
+              true,
+              null,
+              proxyWithRedirectHosts("http://127.0.0.1/m2/", List.of(invalid)),
+              null,
+              null,
+              null,
+              null)));
+      assertEquals(
+          "proxy.allowedRedirectHosts entries must be exact host names without a scheme, port, path, or wildcard",
+          error.getMessage());
+    }
   }
 
   @Test
@@ -1882,6 +1978,28 @@ class RepositoryServiceTest {
 
   private static RepositoryRecord mavenProxyWithOutboundProxy(String outboundPassword) {
     return mavenProxyWithOutboundProxy(1L, "maven-proxy", outboundPassword);
+  }
+
+  private static ProxySettings proxyWithRedirectHosts(
+      String remoteUrl, List<String> allowedRedirectHosts) {
+    return new ProxySettings(
+        remoteUrl,
+        1440,
+        1440,
+        true,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        allowedRedirectHosts);
   }
 
   private static RepositoryRecord mavenProxyWithOutboundProxy(

--- a/server/src/test/java/com/github/klboke/kkrepo/server/repositories/RepositoryServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/repositories/RepositoryServiceTest.java
@@ -765,6 +765,53 @@ class RepositoryServiceTest {
   }
 
   @Test
+  void proxyRedirectHostsRejectBlankNullAndExcessEntries() {
+    RepositoryService service = service(new StubRepositoryDao(repository(1L)));
+    List<String> nullHost = new ArrayList<>();
+    nullHost.add(null);
+
+    for (List<String> invalidHosts : List.of(List.of(" "), nullHost)) {
+      RepositoryValidationException error = assertThrows(
+          RepositoryValidationException.class,
+          () -> service.create(new CreateCommand(
+              "gradle-plugins",
+              "maven2-proxy",
+              true,
+              "default",
+              true,
+              null,
+              proxyWithRedirectHosts("http://127.0.0.1/m2/", invalidHosts),
+              null,
+              null,
+              null,
+              null)));
+      assertEquals(
+          "proxy.allowedRedirectHosts entries must be exact host names without a scheme, port, path, or wildcard",
+          error.getMessage());
+    }
+
+    List<String> tooManyHosts = new ArrayList<>();
+    for (int i = 0; i < 65; i++) {
+      tooManyHosts.add("cdn-" + i + ".example.org");
+    }
+    RepositoryValidationException error = assertThrows(
+        RepositoryValidationException.class,
+        () -> service.create(new CreateCommand(
+            "gradle-plugins",
+            "maven2-proxy",
+            true,
+            "default",
+            true,
+            null,
+            proxyWithRedirectHosts("http://127.0.0.1/m2/", tooManyHosts),
+            null,
+            null,
+            null,
+            null)));
+    assertEquals("proxy.allowedRedirectHosts supports at most 64 hosts", error.getMessage());
+  }
+
+  @Test
   void minimumReleaseAgeRejectsNegativeAndNonNpmValues() {
     RepositoryService service = service(new StubRepositoryDao(repository(1L)));
 


### PR DESCRIPTION
## Summary

- add a common per-repository `proxy.allowedRedirectHosts` setting for proxy repositories
- expose exact redirect-host configuration in the admin UI and preserve it through create/update/read flows
- apply the allowlist to the shared remote fetcher and the Docker/Swift-specific redirect paths
- keep cross-host redirects denied by default, strip source repository credentials, and retain outbound DNS/SSRF validation
- cache the normalized host set in the repository runtime snapshot without requiring a database migration

## Root cause

kkRepo intentionally rejected cross-host redirects, but it did not expose a repository-scoped way for operators to trust expected redirect destinations. This blocked repositories such as the Gradle Plugin Portal, whose artifact flow redirects from `plugins.gradle.org` to `plugins-artifacts.gradle.org`.

## Validation

- added an Issue #228 acceptance test using the reported Maven path and the current Gradle Plugin Portal `303` destination
- verified the redirected response is cached under the original Maven repository path
- verified source repository credentials are not forwarded across origins
- verified invalid URLs, ports, paths, and wildcard entries are rejected
- `mvn -pl server,admin-ui -am test` — full 33-module reactor passed; server ran 2,574 tests
- after rebasing onto the latest `main`: admin UI suite passed 29 tests, and the focused server suite passed 170 tests

## Related issues

Related to #210 and #228.

These issues should remain open when this PR is merged. After the change is deployed, we will ask both reporters to verify their original scenarios and only then decide whether to close the issues manually.

