### PR TITLE
Align topbar search and account controls

### DIFF
--- a/admin-ui/src/main/resources/META-INF/resources/admin/index.html
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260818-user-round-1">
     <link rel="stylesheet" href="./assets/admin.css?v=20260818-security-provider-layout-8">
     <link rel="stylesheet" href="/browse/assets/account-menu.css?v=20260818-shared-account-menu-2">
-    <link rel="stylesheet" href="/browse/assets/global-component-search.css?v=20260817-global-search-3">
+    <link rel="stylesheet" href="/browse/assets/global-component-search.css?v=20260819-topbar-control-height-1">
   </head>
   <body>
     <div class="nx-shell">

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminGlobalComponentSearchContractTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminGlobalComponentSearchContractTest.java
@@ -21,7 +21,8 @@ class AdminGlobalComponentSearchContractTest {
         < index.indexOf("<form class=\"global-component-search\""));
     assertTrue(index.contains("placeholder=\"Search components\""));
     assertFalse(index.contains("<button type=\"submit\">Search</button>"));
-    assertTrue(index.contains("/browse/assets/global-component-search.css"));
+    assertTrue(index.contains(
+        "/browse/assets/global-component-search.css?v=20260819-topbar-control-height-1"));
     assertTrue(index.contains("/browse/assets/global-component-search.js"));
     assertTrue(translations.contains("\"Search components\": \"搜索组件\""));
     assertTrue(translations.contains("\"All formats\": \"全部格式\""));

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/global-component-search.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/global-component-search.css
@@ -5,7 +5,7 @@
   align-items: center;
   width: clamp(220px, 30vw, 360px);
   min-width: 180px;
-  height: 34px;
+  height: 40px;
   margin: 0 12px 0 24px;
   color: var(--topbar-muted);
 }
@@ -31,7 +31,7 @@
 
 .global-component-search input {
   width: 100%;
-  height: 34px;
+  height: 40px;
   min-width: 0;
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: var(--r-sm);

--- a/browse-ui/src/main/resources/META-INF/resources/browse/index.html
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260818-user-round-1">
     <link rel="stylesheet" href="/browse/assets/browse.css?v=20260818-account-menu-3">
     <link rel="stylesheet" href="/browse/assets/account-menu.css?v=20260818-shared-account-menu-2">
-    <link rel="stylesheet" href="/browse/assets/global-component-search.css?v=20260817-global-search-3">
+    <link rel="stylesheet" href="/browse/assets/global-component-search.css?v=20260819-topbar-control-height-1">
     <link rel="stylesheet" href="/login/assets/login-modal.css?v=20260818-login-icons-1">
   </head>
   <body>

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseGlobalComponentSearchContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseGlobalComponentSearchContractTest.java
@@ -1,5 +1,6 @@
 package com.github.klboke.kkrepo.browse.ui;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -19,6 +20,8 @@ class BrowseGlobalComponentSearchContractTest {
         resource("/META-INF/resources/browse/assets/global-component-search.js");
     String sharedStylesheet =
         resource("/META-INF/resources/browse/assets/global-component-search.css");
+    String accountMenuStylesheet =
+        resource("/META-INF/resources/browse/assets/account-menu.css");
 
     assertTrue(index.contains("data-global-component-search action=\"/browse/\""));
     assertTrue(index.indexOf("class=\"top-spacer\"")
@@ -29,7 +32,8 @@ class BrowseGlobalComponentSearchContractTest {
     assertTrue(index.contains("<span>All formats</span>"));
     assertTrue(index.contains("<form class=\"search-form\" id=\"component-search-form\">"));
     assertTrue(index.contains("<span id=\"component-search-format\">Maven</span>"));
-    assertTrue(index.contains("/browse/assets/global-component-search.css"));
+    assertTrue(index.contains(
+        "/browse/assets/global-component-search.css?v=20260819-topbar-control-height-1"));
     assertTrue(index.contains("/browse/assets/global-component-search.js"));
 
     assertTrue(javascript.contains("custom: \"custom\""));
@@ -42,6 +46,13 @@ class BrowseGlobalComponentSearchContractTest {
     assertTrue(sharedJavascript.contains("/browse/#browse/search/custom"));
     assertTrue(sharedJavascript.contains("locationRef.assign(destination)"));
     assertTrue(sharedStylesheet.contains(".global-component-search input:focus-visible"));
+    assertFalse(sharedStylesheet.contains("height: 34px;"));
+    assertEquals(2L, sharedStylesheet.lines()
+        .filter(line -> line.trim().equals("height: 40px;"))
+        .count());
+    assertEquals(1L, accountMenuStylesheet.lines()
+        .filter(line -> line.trim().equals("height: 40px;"))
+        .count());
     assertTrue(sharedStylesheet.contains("margin: 0 12px 0 24px"));
     assertTrue(sharedStylesheet.contains("@media (max-width: 760px)"));
   }


### PR DESCRIPTION
## Summary

- align the shared global search control with the signed-in and signed-out account controls
- increase the search wrapper and input height from 34px to 40px in both Browse and Admin
- bump the shared stylesheet cache key so browsers pick up the corrected dimensions
- extend the UI contract tests to keep the search and account control heights aligned

## Root cause

The account controls use a 40px height while the shared global search wrapper and input were still set to 34px. The 6px CSS difference becomes a visible 12px mismatch on a 2x display.

## Impact

The topbar search and account controls now share the same vertical dimensions in Browse and Admin. Search behavior is unchanged.

## Validation

- `mvn -pl admin-ui,browse-ui -am test` (50 tests passed)
- `git diff --check`
