### PR TITLE
修复制品路径中百分号编码的加号解析

### DIFF
--- a/compat-test/src/test/java/com/github/klboke/kkrepo/compat/PypiRepositoryBlackBoxCompatibilityTest.java
+++ b/compat-test/src/test/java/com/github/klboke/kkrepo/compat/PypiRepositoryBlackBoxCompatibilityTest.java
@@ -101,6 +101,36 @@ class PypiRepositoryBlackBoxCompatibilityTest {
         "group simple directory should expose project index children");
   }
 
+  @Test
+  void localVersionDownloadAcceptsLiteralAndPercentEncodedPlusWhenConfigured() throws Exception {
+    CompatConfig config = CompatConfig.load();
+    assumeTrue(config.configured(),
+        "Set NEXUS_COMPAT_BASE_URL and KKREPO_COMPAT_BASE_URL to run PyPI black-box compatibility");
+
+    if (config.setupEnabled()) {
+      ensureNexusRepositories(config);
+      ensureKkRepoRepositories(config);
+    }
+
+    WheelFixture fixture = WheelFixture.createLocalVersion();
+    assert2xx("nexus local-version upload", upload(config.nexusHosted(), fixture));
+    assert2xx("kkrepo local-version upload", upload(config.nexusPlusHosted(), fixture));
+
+    assertPackageMatches("hosted local-version literal plus",
+        get(config.nexusHosted(), fixture.packagePath()),
+        get(config.nexusPlusHosted(), fixture.packagePath()),
+        fixture.bytes());
+    String encodedPath = fixture.packagePath().replace("+", "%2B");
+    assertPackageMatches("hosted local-version encoded plus",
+        get(config.nexusHosted(), encodedPath),
+        get(config.nexusPlusHosted(), encodedPath),
+        fixture.bytes());
+    assertPackageMatches("group local-version encoded plus",
+        get(config.nexusGroup(), encodedPath),
+        get(config.nexusPlusGroup(), encodedPath),
+        fixture.bytes());
+  }
+
   private static Exchange upload(Endpoint endpoint, WheelFixture fixture) throws Exception {
     String boundary = "kkrepo-pypi-compat-" + System.nanoTime();
     ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -406,9 +436,16 @@ class PypiRepositoryBlackBoxCompatibilityTest {
 
   private record WheelFixture(String name, String normalizedName, String version, String filename, byte[] bytes) {
     static WheelFixture create() throws Exception {
+      return create("0.1." + System.currentTimeMillis());
+    }
+
+    static WheelFixture createLocalVersion() throws Exception {
+      return create("0.0.0+" + Long.toUnsignedString(System.nanoTime()));
+    }
+
+    private static WheelFixture create(String version) throws Exception {
       String name = "kkrepo-compat-pypi-" + System.currentTimeMillis();
       String normalized = normalizeName(name);
-      String version = "0.1." + System.currentTimeMillis();
       String distribution = normalized.replace('-', '_');
       String filename = distribution + "-" + version + "-py3-none-any.whl";
       String distInfo = distribution + "-" + version + ".dist-info/";

--- a/protocol-cargo/src/test/java/com/github/klboke/kkrepo/protocol/cargo/CargoPathParserTest.java
+++ b/protocol-cargo/src/test/java/com/github/klboke/kkrepo/protocol/cargo/CargoPathParserTest.java
@@ -44,6 +44,10 @@ class CargoPathParserTest {
     assertEquals(CargoPath.Kind.DOWNLOAD, fileDownload.kind());
     assertEquals("cargo", fileDownload.crateName());
     assertEquals("1.2.3", fileDownload.version());
+
+    CargoPath encodedBuild = parser.parse("crates/cargo/1.2.3%2Bbuild/download");
+    assertEquals(CargoPath.Kind.DOWNLOAD, encodedBuild.kind());
+    assertEquals("1.2.3+build", encodedBuild.version());
   }
 
   @Test

--- a/protocol-composer/src/main/java/com/github/klboke/kkrepo/protocol/composer/ComposerPath.java
+++ b/protocol-composer/src/main/java/com/github/klboke/kkrepo/protocol/composer/ComposerPath.java
@@ -8,6 +8,13 @@ public record ComposerPath(
     String version,
     String fileName) {
 
+  public String distPath() {
+    if (kind != Kind.DIST) {
+      throw new IllegalStateException("Composer path is not a dist path: " + kind);
+    }
+    return packageName + "/" + version + "/" + fileName;
+  }
+
   public enum Kind {
     ROOT,
     PACKAGES,

--- a/protocol-composer/src/main/java/com/github/klboke/kkrepo/protocol/composer/ComposerPathParser.java
+++ b/protocol-composer/src/main/java/com/github/klboke/kkrepo/protocol/composer/ComposerPathParser.java
@@ -6,7 +6,20 @@ import java.nio.charset.StandardCharsets;
 public final class ComposerPathParser {
   public ComposerPath parse(String rawPath) {
     String raw = rawPath == null ? "" : rawPath;
-    String path = normalize(percentDecode(raw));
+    return parseCanonical(raw, canonicalize(raw));
+  }
+
+  /** Parses a path that has already been percent-decoded and normalized exactly once. */
+  public ComposerPath parseCanonical(String canonicalPath) {
+    String path = canonicalPath == null ? "" : canonicalPath;
+    return parseCanonical(path, path);
+  }
+
+  public String canonicalize(String rawPath) {
+    return normalize(percentDecode(rawPath == null ? "" : rawPath));
+  }
+
+  private static ComposerPath parseCanonical(String raw, String path) {
     if (path.isEmpty()) return path(ComposerPath.Kind.ROOT, raw);
     if (path.equals("packages.json")) return path(ComposerPath.Kind.PACKAGES, raw);
     if (path.equals("packages/list.json")) return path(ComposerPath.Kind.PACKAGE_LIST, raw);

--- a/protocol-composer/src/test/java/com/github/klboke/kkrepo/protocol/composer/ComposerPathParserTest.java
+++ b/protocol-composer/src/test/java/com/github/klboke/kkrepo/protocol/composer/ComposerPathParserTest.java
@@ -25,6 +25,13 @@ class ComposerPathParserTest {
     assertEquals("company/example", nexusDist.packageName());
     assertEquals("1.0.0", nexusDist.version());
     assertEquals("company-example-1.0.0.zip", nexusDist.fileName());
+
+    ComposerPath encodedPlus = parser.parse(
+        "company/example/1.0.0/company-example-1.0.0%2Bbuild.zip");
+    assertEquals(ComposerPath.Kind.DIST, encodedPlus.kind());
+    assertEquals(
+        "company/example/1.0.0/company-example-1.0.0+build.zip",
+        encodedPlus.distPath());
   }
 
   @Test

--- a/protocol-composer/src/test/java/com/github/klboke/kkrepo/protocol/composer/ComposerPathParserTest.java
+++ b/protocol-composer/src/test/java/com/github/klboke/kkrepo/protocol/composer/ComposerPathParserTest.java
@@ -1,6 +1,7 @@
 package com.github.klboke.kkrepo.protocol.composer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
@@ -32,6 +33,12 @@ class ComposerPathParserTest {
     assertEquals(
         "company/example/1.0.0/company-example-1.0.0+build.zip",
         encodedPlus.distPath());
+
+    ComposerPath encodedPercent = parser.parse(
+        "company/example/1.0.0/company-example-1.0.0%252Bbuild.zip");
+    assertEquals(
+        "company/example/1.0.0/company-example-1.0.0%2Bbuild.zip",
+        encodedPercent.distPath());
   }
 
   @Test
@@ -41,6 +48,7 @@ class ComposerPathParserTest {
     assertEquals(ComposerPath.Kind.UNKNOWN, parser.parse("dists/abcdef12/archive.zip").kind());
     assertEquals(ComposerPath.Kind.UNKNOWN,
         parser.parse("company/example/../company-example-1.0.0.zip").kind());
+    assertThrows(IllegalStateException.class, () -> parser.parse("packages.json").distPath());
   }
 
   @Test

--- a/protocol-npm/src/test/java/com/github/klboke/kkrepo/protocol/npm/NpmPathParserTest.java
+++ b/protocol-npm/src/test/java/com/github/klboke/kkrepo/protocol/npm/NpmPathParserTest.java
@@ -1,0 +1,20 @@
+package com.github.klboke.kkrepo.protocol.npm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class NpmPathParserTest {
+  private final NpmPathParser parser = new NpmPathParser();
+
+  @Test
+  void parsesPercentEncodedPlusWithoutChangingLiteralPlus() {
+    NpmPath encoded = parser.parse("demo/1.2.3%2Bbuild");
+    assertEquals(NpmPath.Kind.PACKAGE_VERSION, encoded.kind());
+    assertEquals("1.2.3+build", encoded.packageVersion());
+
+    NpmPath literal = parser.parse("demo/1.2.3+build");
+    assertEquals(NpmPath.Kind.PACKAGE_VERSION, literal.kind());
+    assertEquals("1.2.3+build", literal.packageVersion());
+  }
+}

--- a/server/src/main/java/com/github/klboke/kkrepo/server/RepositoryContentController.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/RepositoryContentController.java
@@ -357,7 +357,7 @@ public class RepositoryContentController {
       return toHeadResponse(resp, request);
     }
     if (runtime.format() == RepositoryFormat.COMPOSER) {
-      ComposerPath path = composerParser.parse(extractRepositoryPath(name, request, true));
+      ComposerPath path = composerRequestPath(name, request);
       MavenResponse resp = dispatchComposerGet(runtime, path, request, true);
       return toHeadResponse(resp, request);
     }
@@ -407,7 +407,7 @@ public class RepositoryContentController {
       return toHeadResponse(dispatchHuggingFaceGet(runtime, name, request, true), request);
     }
     if (runtime.format() == RepositoryFormat.PYPI) {
-      String raw = PypiRequestPath.decode(extractRepositoryPath(name, request, true));
+      String raw = pypiRequestPath(name, request);
       PypiResponse resp = isDirectoryPath(raw)
           ? pypiDirectoryListing(runtime.name(), raw, true)
           : dispatchPypiPackage(runtime, raw, true);
@@ -1022,7 +1022,7 @@ public class RepositoryContentController {
       return toStreamingResponse(resp, request, false);
     }
     if (runtime.format() == RepositoryFormat.COMPOSER) {
-      ComposerPath path = composerParser.parse(extractRepositoryPath(name, request, true));
+      ComposerPath path = composerRequestPath(name, request);
       MavenResponse resp = dispatchComposerGet(runtime, path, request, headOnly);
       return toStreamingResponse(resp, request, false);
     }
@@ -1094,7 +1094,7 @@ public class RepositoryContentController {
       return toStreamingResponse(response, request, fileResponse);
     }
     if (runtime.format() == RepositoryFormat.PYPI) {
-      String raw = PypiRequestPath.decode(extractRepositoryPath(name, request, true));
+      String raw = pypiRequestPath(name, request);
       boolean directory = isDirectoryPath(raw);
       PypiResponse resp = directory
           ? pypiDirectoryListing(runtime.name(), raw, headOnly)
@@ -1692,6 +1692,23 @@ public class RepositoryContentController {
       throw new NpmExceptions.NpmNotFoundException("Bad npm URL: " + uri);
     }
     return uri.substring(idx + prefix.length());
+  }
+
+  private ComposerPath composerRequestPath(String name, HttpServletRequest request) {
+    String path = extractRepositoryPath(name, request, true);
+    return hasNormalizedRepositoryPath(request)
+        ? composerParser.parseCanonical(path)
+        : composerParser.parse(path);
+  }
+
+  private String pypiRequestPath(String name, HttpServletRequest request) {
+    String path = extractRepositoryPath(name, request, true);
+    return hasNormalizedRepositoryPath(request) ? path : PypiRequestPath.decode(path);
+  }
+
+  private static boolean hasNormalizedRepositoryPath(HttpServletRequest request) {
+    return request.getAttribute(RepositorySecurityFilter.NORMALIZED_REPOSITORY_PATH_ATTRIBUTE)
+        instanceof String;
   }
 
   private static String withQuery(String path, HttpServletRequest request) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/RepositoryContentController.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/RepositoryContentController.java
@@ -62,6 +62,7 @@ import com.github.klboke.kkrepo.server.pypi.PypiGroupService;
 import com.github.klboke.kkrepo.server.pypi.PypiHostedService;
 import com.github.klboke.kkrepo.server.pypi.PypiPartialFetchSupport;
 import com.github.klboke.kkrepo.server.pypi.PypiProxyService;
+import com.github.klboke.kkrepo.server.pypi.PypiRequestPath;
 import com.github.klboke.kkrepo.server.pypi.PypiResponse;
 import com.github.klboke.kkrepo.server.pub.PubExceptions;
 import com.github.klboke.kkrepo.server.pub.PubGroupService;
@@ -406,7 +407,7 @@ public class RepositoryContentController {
       return toHeadResponse(dispatchHuggingFaceGet(runtime, name, request, true), request);
     }
     if (runtime.format() == RepositoryFormat.PYPI) {
-      String raw = extractRepositoryPath(name, request, true);
+      String raw = PypiRequestPath.decode(extractRepositoryPath(name, request, true));
       PypiResponse resp = isDirectoryPath(raw)
           ? pypiDirectoryListing(runtime.name(), raw, true)
           : dispatchPypiPackage(runtime, raw, true);
@@ -1093,7 +1094,7 @@ public class RepositoryContentController {
       return toStreamingResponse(response, request, fileResponse);
     }
     if (runtime.format() == RepositoryFormat.PYPI) {
-      String raw = extractRepositoryPath(name, request, true);
+      String raw = PypiRequestPath.decode(extractRepositoryPath(name, request, true));
       boolean directory = isDirectoryPath(raw);
       PypiResponse resp = directory
           ? pypiDirectoryListing(runtime.name(), raw, headOnly)

--- a/server/src/main/java/com/github/klboke/kkrepo/server/composer/ComposerGroupService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/composer/ComposerGroupService.java
@@ -115,7 +115,7 @@ public class ComposerGroupService {
   }
 
   private MavenResponse dist(RepositoryRuntime group, ComposerPath path, boolean headOnly) {
-    String requestedPath = normalizePath(path.rawPath());
+    String requestedPath = path.distPath();
     for (RepositoryRuntime member : group.members()) {
       Optional<ComposerHostedService.PackageDocument> stable = memberDocument(member, path.packageName(), false);
       Optional<ComposerHostedService.PackageDocument> dev = memberDocument(member, path.packageName(), true);

--- a/server/src/main/java/com/github/klboke/kkrepo/server/composer/ComposerHostedService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/composer/ComposerHostedService.java
@@ -70,7 +70,7 @@ public class ComposerHostedService {
           .orElseThrow(() -> new MavenExceptions.MavenNotFoundException(path.rawPath()));
       case PROVIDERS -> providers(runtime, path.packageName(), headOnly);
       case PACKAGE_LIST -> packageList(runtime, filter, headOnly);
-      case DIST -> assets.serve(runtime, normalizePath(path.rawPath()), headOnly);
+      case DIST -> assets.serve(runtime, path.distPath(), headOnly);
       case UNKNOWN -> throw new MavenExceptions.MavenNotFoundException(path.rawPath());
     };
   }
@@ -272,13 +272,6 @@ public class ComposerHostedService {
     if (lower.endsWith(".tar.bz2")) return ".tar.bz2";
     int dot = lower.lastIndexOf('.');
     return dot < 0 ? ".tmp" : lower.substring(dot);
-  }
-
-  private static String normalizePath(String path) {
-    String value = path == null ? "" : path.trim();
-    while (value.startsWith("/")) value = value.substring(1);
-    while (value.endsWith("/")) value = value.substring(0, value.length() - 1);
-    return value;
   }
 
   private static String distType(String fileName) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/composer/ComposerProxyService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/composer/ComposerProxyService.java
@@ -137,7 +137,7 @@ public class ComposerProxyService {
   }
 
   private MavenResponse dist(RepositoryRuntime runtime, ComposerPath path, boolean headOnly) {
-    String publicPath = normalizePath(path.rawPath());
+    String publicPath = path.distPath();
     // A Nexus proxy-cache migration copies the public Composer dist path and blob, but Nexus
     // does not have kkrepo's private _composer/routes records. Serve an already cached dist
     // directly so migrated proxy content stays usable without contacting either upstream.

--- a/server/src/main/java/com/github/klboke/kkrepo/server/pypi/PypiPaths.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/pypi/PypiPaths.java
@@ -55,8 +55,7 @@ final class PypiPaths {
   static String fileName(String path) {
     String normalized = safe(path);
     int slash = normalized.lastIndexOf('/');
-    String name = slash < 0 ? normalized : normalized.substring(slash + 1);
-    return PypiRequestPath.decodeSegment(name);
+    return slash < 0 ? normalized : normalized.substring(slash + 1);
   }
 
   static String versionFromFilename(String filename) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/pypi/PypiPaths.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/pypi/PypiPaths.java
@@ -1,7 +1,5 @@
 package com.github.klboke.kkrepo.server.pypi;
 
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.Map;
 
@@ -58,7 +56,7 @@ final class PypiPaths {
     String normalized = safe(path);
     int slash = normalized.lastIndexOf('/');
     String name = slash < 0 ? normalized : normalized.substring(slash + 1);
-    return URLDecoder.decode(name, StandardCharsets.UTF_8);
+    return PypiRequestPath.decodeSegment(name);
   }
 
   static String versionFromFilename(String filename) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/pypi/PypiRequestPath.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/pypi/PypiRequestPath.java
@@ -1,0 +1,34 @@
+package com.github.klboke.kkrepo.server.pypi;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import org.springframework.web.util.UriUtils;
+
+/** Decodes URL path segments without applying form-style {@code +} to space conversion. */
+public final class PypiRequestPath {
+  private PypiRequestPath() {
+  }
+
+  public static String decode(String rawPath) {
+    String path = rawPath == null ? "" : rawPath;
+    return Arrays.stream(path.split("/", -1))
+        .map(PypiRequestPath::decodeSegment)
+        .collect(Collectors.joining("/"));
+  }
+
+  static String decodeSegment(String rawSegment) {
+    String decoded;
+    try {
+      decoded = UriUtils.decode(rawSegment, StandardCharsets.UTF_8);
+    } catch (IllegalArgumentException e) {
+      throw new PypiExceptions.BadRequestException("Invalid percent-encoding in PyPI path");
+    }
+    if (decoded.equals(".") || decoded.equals("..")
+        || decoded.indexOf('/') >= 0 || decoded.indexOf('\\') >= 0
+        || decoded.chars().anyMatch(ch -> ch < 0x20 || ch == 0x7f)) {
+      throw new PypiExceptions.BadRequestException("Invalid PyPI path segment");
+    }
+    return decoded;
+  }
+}

--- a/server/src/main/java/com/github/klboke/kkrepo/server/pypi/PypiRequestPath.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/pypi/PypiRequestPath.java
@@ -24,11 +24,19 @@ public final class PypiRequestPath {
     } catch (IllegalArgumentException e) {
       throw new PypiExceptions.BadRequestException("Invalid percent-encoding in PyPI path");
     }
-    if (decoded.equals(".") || decoded.equals("..")
-        || decoded.indexOf('/') >= 0 || decoded.indexOf('\\') >= 0
-        || decoded.chars().anyMatch(ch -> ch < 0x20 || ch == 0x7f)) {
+    if (isUnsafeSegment(decoded)) {
       throw new PypiExceptions.BadRequestException("Invalid PyPI path segment");
     }
     return decoded;
+  }
+
+  private static boolean isUnsafeSegment(String value) {
+    if (".".equals(value) || "..".equals(value)) {
+      return true;
+    }
+    if (value.indexOf('/') >= 0 || value.indexOf('\\') >= 0) {
+      return true;
+    }
+    return value.chars().anyMatch(ch -> ch < 0x20 || ch == 0x7f);
   }
 }

--- a/server/src/main/java/com/github/klboke/kkrepo/server/security/RepositorySecurityFilter.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/security/RepositorySecurityFilter.java
@@ -14,6 +14,7 @@ import com.github.klboke.kkrepo.protocol.ansible.AnsibleGalaxyPath;
 import com.github.klboke.kkrepo.protocol.ansible.AnsibleGalaxyPathParser;
 import com.github.klboke.kkrepo.protocol.conda.CondaPath;
 import com.github.klboke.kkrepo.protocol.conda.CondaPathParser;
+import com.github.klboke.kkrepo.protocol.composer.ComposerPathParser;
 import com.github.klboke.kkrepo.protocol.pub.PubPath;
 import com.github.klboke.kkrepo.protocol.pub.PubPathParser;
 import com.github.klboke.kkrepo.protocol.terraform.TerraformPath;
@@ -21,6 +22,8 @@ import com.github.klboke.kkrepo.protocol.terraform.TerraformPathParser;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
 import com.github.klboke.kkrepo.server.conan.ConanAuthService;
 import com.github.klboke.kkrepo.server.npm.NpmTokenService;
+import com.github.klboke.kkrepo.server.pypi.PypiExceptions;
+import com.github.klboke.kkrepo.server.pypi.PypiRequestPath;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -61,6 +64,7 @@ public class RepositorySecurityFilter extends OncePerRequestFilter {
       new AnsibleGalaxyPathParser();
   private static final PubPathParser PUB_PATH_PARSER = new PubPathParser();
   private static final CondaPathParser CONDA_PATH_PARSER = new CondaPathParser();
+  private static final ComposerPathParser COMPOSER_PATH_PARSER = new ComposerPathParser();
   private static final TerraformPathParser TERRAFORM_PATH_PARSER = new TerraformPathParser();
   private final SecurityAuthenticationService authenticationService;
   private final AccessDecisionService accessDecisionService;
@@ -127,6 +131,16 @@ public class RepositorySecurityFilter extends OncePerRequestFilter {
     }
     request.setAttribute(REPOSITORY_RECORD_ATTRIBUTE, repository.get());
     request.setAttribute(ENTRY_REPOSITORY_ID_ATTRIBUTE, repository.get().id());
+    try {
+      String canonicalPath = canonicalRepositoryPath(repository.get().format(), target.path());
+      if (canonicalPath != null) {
+        target = target.withPath(canonicalPath);
+        request.setAttribute(NORMALIZED_REPOSITORY_PATH_ATTRIBUTE, canonicalPath);
+      }
+    } catch (PypiExceptions.BadRequestException e) {
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
+      return;
+    }
     String terraformUrlToken = null;
     TerraformPath terraformPath = null;
     if (repository.get().format() == RepositoryFormat.TERRAFORM
@@ -226,6 +240,14 @@ public class RepositorySecurityFilter extends OncePerRequestFilter {
       }
     }
     filterChain.doFilter(request, response);
+  }
+
+  private static String canonicalRepositoryPath(RepositoryFormat format, String path) {
+    return switch (format) {
+      case PYPI -> PypiRequestPath.decode(path);
+      case COMPOSER -> COMPOSER_PATH_PARSER.canonicalize(path);
+      default -> null;
+    };
   }
 
   private static boolean isTerraformDownloadMetadata(TerraformPath path) {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/composer/ComposerGroupServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/composer/ComposerGroupServiceTest.java
@@ -2,6 +2,7 @@ package com.github.klboke.kkrepo.server.composer;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -9,6 +10,8 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.protocol.composer.ComposerPathParser;
+import com.github.klboke.kkrepo.server.maven.MavenResponse;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import java.time.Instant;
 import java.util.List;
@@ -17,6 +20,44 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class ComposerGroupServiceTest {
+  @Test
+  void routesPercentEncodedDistPathToTheMatchingMemberAsset() {
+    ComposerHostedService hosted = mock(ComposerHostedService.class);
+    ComposerProxyService proxy = mock(ComposerProxyService.class);
+    ComposerGroupService group = new ComposerGroupService(new ObjectMapper(), hosted, proxy);
+    RepositoryRuntime member = ComposerHostedServiceTest.runtime(
+        "private", RepositoryType.HOSTED, List.of());
+    RepositoryRuntime runtime = ComposerHostedServiceTest.runtime(
+        "all", RepositoryType.GROUP, List.of(member));
+    String path = "company/example/1.2.3/company-example-1.2.3+build.zip";
+    var document = new ComposerHostedService.PackageDocument(
+        Map.of("packages", Map.of("company/example", List.of(Map.of(
+            "dist", Map.of("url", memberBase(member) + "/" + path))))),
+        Instant.EPOCH,
+        member.name());
+    when(hosted.packageDocument(member, "company/example", false, memberBase(member)))
+        .thenReturn(Optional.of(document));
+    when(hosted.packageDocument(member, "company/example", true, memberBase(member)))
+        .thenReturn(Optional.empty());
+    MavenResponse expected = MavenResponse.noBody(200, 0, "application/zip", null, null);
+    when(hosted.get(
+        member,
+        new ComposerPathParser().parse(path),
+        memberBase(member),
+        null,
+        false)).thenReturn(expected);
+
+    MavenResponse actual = group.get(
+        runtime,
+        new ComposerPathParser().parse(
+            "company/example/1.2.3/company-example-1.2.3%2Bbuild.zip"),
+        "https://repo.test/repository/all",
+        null,
+        false);
+
+    assertSame(expected, actual);
+  }
+
   @Test
   @SuppressWarnings("unchecked")
   void rewritesMemberDistToSameNexusCompatiblePathOnGroup() {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/composer/ComposerHostedServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/composer/ComposerHostedServiceTest.java
@@ -71,6 +71,31 @@ class ComposerHostedServiceTest {
   }
 
   @Test
+  void servesPercentEncodedDistFilenameFromDecodedAssetPath() {
+    ComponentDao components = mock(ComponentDao.class);
+    ComposerAssetSupport assets = mock(ComposerAssetSupport.class);
+    when(assets.serve(any(), anyString(), eq(false)))
+        .thenReturn(MavenResponse.noBody(200, 0, "application/zip", null, null));
+    ComposerHostedService service = new ComposerHostedService(
+        JSON, components, assets,
+        mock(ComposerArchiveInspector.class), mock(ComposerComponentWriter.class));
+    RepositoryRuntime runtime = runtime("hosted", RepositoryType.HOSTED, List.of());
+
+    service.get(
+        runtime,
+        new ComposerPathParser().parse(
+            "company/example/1.0.0/company-example-1.0.0%2Bbuild.zip"),
+        "https://repo.test/repository/composer-hosted",
+        null,
+        false);
+
+    verify(assets).serve(
+        eq(runtime),
+        eq("company/example/1.0.0/company-example-1.0.0+build.zip"),
+        eq(false));
+  }
+
+  @Test
   void bindFailureDeletesOnlyTheUploadStagingPath() throws Exception {
     ComponentDao components = mock(ComponentDao.class);
     ComposerAssetSupport assets = mock(ComposerAssetSupport.class);

--- a/server/src/test/java/com/github/klboke/kkrepo/server/composer/ComposerRepositoryControllerPathTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/composer/ComposerRepositoryControllerPathTest.java
@@ -1,0 +1,127 @@
+package com.github.klboke.kkrepo.server.composer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.jdbc.api.model.RepositoryRecord;
+import com.github.klboke.kkrepo.protocol.composer.ComposerPath;
+import com.github.klboke.kkrepo.server.RepositoryContentController;
+import com.github.klboke.kkrepo.server.maven.MavenResponse;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
+import com.github.klboke.kkrepo.server.security.ForwardedHeaderPolicy;
+import com.github.klboke.kkrepo.server.security.RepositorySecurityFilter;
+import com.github.klboke.kkrepo.server.support.dao.RepositoryDaoAdapter;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class ComposerRepositoryControllerPathTest {
+  @Test
+  void getUsesFilterCanonicalPathWithoutDecodingItAgain() {
+    RecordingHostedService hosted = new RecordingHostedService();
+    RepositoryContentController controller = controller(hosted);
+    MockHttpServletRequest request = request(
+        "/repository/composer/company/example/1.0.0/"
+            + "company-example-1.0.0%252Bbuild.zip");
+    String canonicalPath =
+        "company/example/1.0.0/company-example-1.0.0%2Bbuild.zip";
+    request.setAttribute(
+        RepositorySecurityFilter.NORMALIZED_REPOSITORY_PATH_ATTRIBUTE,
+        canonicalPath);
+
+    controller.get("composer", request);
+
+    assertEquals(canonicalPath, hosted.requestedPath.distPath());
+  }
+
+  @Test
+  void headCanonicalizesDirectRequestOnceWhenFilterIsAbsent() {
+    RecordingHostedService hosted = new RecordingHostedService();
+    RepositoryContentController controller = controller(hosted);
+
+    controller.head("composer", request(
+        "/repository/composer/company/example/1.0.0/"
+            + "company-example-1.0.0%2Bbuild.zip"));
+
+    assertEquals(
+        "company/example/1.0.0/company-example-1.0.0+build.zip",
+        hosted.requestedPath.distPath());
+  }
+
+  private static RepositoryContentController controller(ComposerHostedService hosted) {
+    return new RepositoryContentController(
+        new RepositoryRuntimeRegistry(new SingleRepositoryDao(), 0),
+        null, null, null,
+        null, null,
+        null, null,
+        null,
+        null, null, null, null, null,
+        null, null, null,
+        null, null, null,
+        null, null, null,
+        hosted, null, null,
+        null, null, null,
+        null, null, null,
+        new ObjectMapper(),
+        new ForwardedHeaderPolicy(""));
+  }
+
+  private static MockHttpServletRequest request(String uri) {
+    return new MockHttpServletRequest("GET", uri);
+  }
+
+  private static final class RecordingHostedService extends ComposerHostedService {
+    private ComposerPath requestedPath;
+
+    private RecordingHostedService() {
+      super(null, null, null, null, null);
+    }
+
+    @Override
+    public MavenResponse get(
+        RepositoryRuntime runtime,
+        ComposerPath path,
+        String baseUrl,
+        String filter,
+        boolean headOnly) {
+      requestedPath = path;
+      return MavenResponse.noBody(200, 0, "application/zip", null, null);
+    }
+  }
+
+  private static final class SingleRepositoryDao extends RepositoryDaoAdapter {
+    private SingleRepositoryDao() {
+      super(null, null);
+    }
+
+    @Override
+    public Optional<RepositoryRecord> findByName(String name) {
+      if (!"composer".equals(name)) return Optional.empty();
+      return Optional.of(new RepositoryRecord(
+          1L,
+          name,
+          RepositoryFormat.COMPOSER,
+          RepositoryType.HOSTED,
+          "composer-hosted",
+          true,
+          1L,
+          null,
+          null,
+          null,
+          null,
+          "ALLOW",
+          true,
+          Map.of()));
+    }
+
+    @Override
+    public List<RepositoryRecord> listMembers(long groupRepositoryId) {
+      return List.of();
+    }
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiRepositoryControllerRangeTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiRepositoryControllerRangeTest.java
@@ -1,6 +1,7 @@
 package com.github.klboke.kkrepo.server.pypi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.klboke.kkrepo.core.RepositoryFormat;
@@ -28,23 +29,9 @@ import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBo
 class PypiRepositoryControllerRangeTest {
   @Test
   void packageDownloadHonorsSingleRangeRequest() throws Exception {
-    RepositoryContentController controller = new RepositoryContentController(
-        new RepositoryRuntimeRegistry(new SingleRepositoryDao(), 0),
-        null, null, null,
-        null, null,
-        null, null,
-        null,
-        null, null, null,
-        null, null,
-        new RangeHostedService(), null, null,
-        null, null, null,
-        null, null, null,
-        null, null, null,
-        null, null, null,
-        new ObjectMapper(),
-        new ForwardedHeaderPolicy(""));
-    MockHttpServletRequest request = new MockHttpServletRequest(
-        "GET",
+    RangeHostedService hosted = new RangeHostedService();
+    RepositoryContentController controller = controller(hosted);
+    MockHttpServletRequest request = request(
         "/repository/pypi/packages/demo/1.0.0/demo-1.0.0.whl");
     request.addHeader(HttpHeaders.RANGE, "bytes=2-4");
 
@@ -58,13 +45,65 @@ class PypiRepositoryControllerRangeTest {
     assertEquals("cde", out.toString(StandardCharsets.UTF_8));
   }
 
+  @Test
+  void packageDownloadDecodesPercentEncodedPlusWithoutChangingLiteralPlus() {
+    RangeHostedService hosted = new RangeHostedService();
+    RepositoryContentController controller = controller(hosted);
+
+    controller.get("pypi", request(
+        "/repository/pypi/packages/demo/0.0.0%2Bbuild/demo-0.0.0%2Bbuild.whl"));
+    assertEquals(
+        "packages/demo/0.0.0+build/demo-0.0.0+build.whl",
+        hosted.requestedPath);
+
+    controller.get("pypi", request(
+        "/repository/pypi/packages/demo/0.0.0+build/demo-0.0.0+build.whl"));
+    assertEquals(
+        "packages/demo/0.0.0+build/demo-0.0.0+build.whl",
+        hosted.requestedPath);
+  }
+
+  @Test
+  void packageDownloadRejectsEncodedPathSeparators() {
+    RepositoryContentController controller = controller(new RangeHostedService());
+
+    assertThrows(PypiExceptions.BadRequestException.class, () -> controller.get(
+        "pypi",
+        request("/repository/pypi/packages/demo/1.0.0/demo%2Fevil.whl")));
+  }
+
+  private static RepositoryContentController controller(PypiHostedService hosted) {
+    return new RepositoryContentController(
+        new RepositoryRuntimeRegistry(new SingleRepositoryDao(), 0),
+        null, null, null,
+        null, null,
+        null, null,
+        null,
+        null, null, null,
+        null, null,
+        hosted, null, null,
+        null, null, null,
+        null, null, null,
+        null, null, null,
+        null, null, null,
+        new ObjectMapper(),
+        new ForwardedHeaderPolicy(""));
+  }
+
+  private static MockHttpServletRequest request(String uri) {
+    return new MockHttpServletRequest("GET", uri);
+  }
+
   private static final class RangeHostedService extends PypiHostedService {
+    private String requestedPath;
+
     private RangeHostedService() {
       super(null, null, null, null, null, null, null, 0);
     }
 
     @Override
     public PypiResponse getPackage(RepositoryRuntime runtime, String path, boolean headOnly) {
+      requestedPath = path;
       byte[] bytes = "abcdef".getBytes(StandardCharsets.UTF_8);
       return PypiResponse.ok(
           new ByteArrayInputStream(bytes),

--- a/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiRepositoryControllerRangeTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiRepositoryControllerRangeTest.java
@@ -12,6 +12,7 @@ import com.github.klboke.kkrepo.server.RepositoryContentController;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
 import com.github.klboke.kkrepo.server.security.ForwardedHeaderPolicy;
+import com.github.klboke.kkrepo.server.security.RepositorySecurityFilter;
 import com.github.klboke.kkrepo.server.support.dao.RepositoryDaoAdapter;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -64,6 +65,36 @@ class PypiRepositoryControllerRangeTest {
   }
 
   @Test
+  void packageHeadDecodesPercentEncodedPlusOnce() {
+    RangeHostedService hosted = new RangeHostedService();
+    RepositoryContentController controller = controller(hosted);
+
+    controller.head("pypi", request(
+        "/repository/pypi/packages/demo/0.0.0%2Bbuild/demo-0.0.0%2Bbuild.whl"));
+
+    assertEquals(
+        "packages/demo/0.0.0+build/demo-0.0.0+build.whl",
+        hosted.requestedPath);
+  }
+
+  @Test
+  void proxyReceivesFilterCanonicalPathWithoutDecodingItAgain() {
+    RangeProxyService proxy = new RangeProxyService();
+    RepositoryContentController controller = controller(proxy);
+    MockHttpServletRequest request = request(
+        "/repository/pypi/packages/demo/0.0.0%252Bbuild/demo-0.0.0%252Bbuild.whl");
+    String canonicalPath =
+        "packages/demo/0.0.0%2Bbuild/demo-0.0.0%2Bbuild.whl";
+    request.setAttribute(
+        RepositorySecurityFilter.NORMALIZED_REPOSITORY_PATH_ATTRIBUTE,
+        canonicalPath);
+
+    controller.get("pypi", request);
+
+    assertEquals(canonicalPath, proxy.requestedPath);
+  }
+
+  @Test
   void packageDownloadRejectsEncodedPathSeparators() {
     RepositoryContentController controller = controller(new RangeHostedService());
 
@@ -73,15 +104,26 @@ class PypiRepositoryControllerRangeTest {
   }
 
   private static RepositoryContentController controller(PypiHostedService hosted) {
+    return controller(RepositoryType.HOSTED, hosted, null);
+  }
+
+  private static RepositoryContentController controller(PypiProxyService proxy) {
+    return controller(RepositoryType.PROXY, null, proxy);
+  }
+
+  private static RepositoryContentController controller(
+      RepositoryType type,
+      PypiHostedService hosted,
+      PypiProxyService proxy) {
     return new RepositoryContentController(
-        new RepositoryRuntimeRegistry(new SingleRepositoryDao(), 0),
+        new RepositoryRuntimeRegistry(new SingleRepositoryDao(type), 0),
         null, null, null,
         null, null,
         null, null,
         null,
         null, null, null,
         null, null,
-        hosted, null, null,
+        hosted, proxy, null,
         null, null, null,
         null, null, null,
         null, null, null,
@@ -114,9 +156,26 @@ class PypiRepositoryControllerRangeTest {
     }
   }
 
+  private static final class RangeProxyService extends PypiProxyService {
+    private String requestedPath;
+
+    private RangeProxyService() {
+      super(null, null, null, null, null, null, null, null, null);
+    }
+
+    @Override
+    public PypiResponse getPackage(RepositoryRuntime runtime, String path, boolean headOnly) {
+      requestedPath = path;
+      return PypiResponse.noBody(200);
+    }
+  }
+
   private static final class SingleRepositoryDao extends RepositoryDaoAdapter {
-    private SingleRepositoryDao() {
+    private final RepositoryType type;
+
+    private SingleRepositoryDao(RepositoryType type) {
       super(null, null);
+      this.type = type;
     }
 
     @Override
@@ -128,8 +187,8 @@ class PypiRepositoryControllerRangeTest {
           1L,
           "pypi",
           RepositoryFormat.PYPI,
-          RepositoryType.HOSTED,
-          "pypi-hosted",
+          type,
+          "pypi-" + type.name().toLowerCase(),
           true,
           1L,
           null,

--- a/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiRequestPathTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiRequestPathTest.java
@@ -1,0 +1,31 @@
+package com.github.klboke.kkrepo.server.pypi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class PypiRequestPathTest {
+  @Test
+  void decodesPercentEscapesOnceAndPreservesLiteralPlus() {
+    assertEquals("packages/demo/0.0.0+build/demo-0.0.0+build.whl",
+        PypiRequestPath.decode(
+            "packages/demo/0.0.0%2Bbuild/demo-0.0.0+build.whl"));
+    assertEquals("demo-0.0.0+build.whl",
+        PypiPaths.fileName("packages/demo/0.0.0/demo-0.0.0+build.whl"));
+    assertEquals("demo-0.0.0+build.whl",
+        PypiPaths.fileName("packages/demo/0.0.0/demo-0.0.0%2Bbuild.whl"));
+    assertEquals("demo-0.0.0%2Bbuild.whl",
+        PypiRequestPath.decodeSegment("demo-0.0.0%252Bbuild.whl"));
+  }
+
+  @Test
+  void rejectsMalformedEscapesSeparatorsAndTraversalSegments() {
+    assertThrows(PypiExceptions.BadRequestException.class,
+        () -> PypiRequestPath.decode("packages/demo%2Fevil.whl"));
+    assertThrows(PypiExceptions.BadRequestException.class,
+        () -> PypiRequestPath.decode("packages/%2E%2E/evil.whl"));
+    assertThrows(PypiExceptions.BadRequestException.class,
+        () -> PypiRequestPath.decode("packages/demo%ZZ.whl"));
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiRequestPathTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiRequestPathTest.java
@@ -13,7 +13,7 @@ class PypiRequestPathTest {
             "packages/demo/0.0.0%2Bbuild/demo-0.0.0+build.whl"));
     assertEquals("demo-0.0.0+build.whl",
         PypiPaths.fileName("packages/demo/0.0.0/demo-0.0.0+build.whl"));
-    assertEquals("demo-0.0.0+build.whl",
+    assertEquals("demo-0.0.0%2Bbuild.whl",
         PypiPaths.fileName("packages/demo/0.0.0/demo-0.0.0%2Bbuild.whl"));
     assertEquals("demo-0.0.0%2Bbuild.whl",
         PypiRequestPath.decodeSegment("demo-0.0.0%252Bbuild.whl"));

--- a/server/src/test/java/com/github/klboke/kkrepo/server/security/RepositorySecurityFilterTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/security/RepositorySecurityFilterTest.java
@@ -17,6 +17,11 @@ import com.github.klboke.kkrepo.persistence.jdbc.api.SecurityDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.TerraformRegistryDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.AssetRecord;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.RepositoryRecord;
+import com.github.klboke.kkrepo.server.RepositoryContentController;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
+import com.github.klboke.kkrepo.server.pypi.PypiHostedService;
+import com.github.klboke.kkrepo.server.pypi.PypiResponse;
 import com.github.klboke.kkrepo.server.support.dao.AssetDaoAdapter;
 import com.github.klboke.kkrepo.server.support.dao.RepositoryDaoAdapter;
 import com.github.klboke.kkrepo.server.support.dao.SecurityDaoAdapter;
@@ -572,6 +577,104 @@ class RepositorySecurityFilterTest {
         request.getAttribute(RepositorySecurityFilter.NORMALIZED_REPOSITORY_PATH_ATTRIBUTE));
     assertNull(request.getAttribute(RepositorySecurityFilter.TERRAFORM_URL_TOKEN_SEGMENT_ATTRIBUTE));
     assertEquals(path, decisions.permission.pathPattern());
+  }
+
+  @Test
+  void pypiAuthorizationAndControllerReuseTheSameCanonicalPath() throws Exception {
+    String canonicalPath =
+        "packages/private/0.0.0+build/demo-0.0.0+build.whl";
+    FakeRepositoryDao repositoryDao = new FakeRepositoryDao(repository(
+        "pypi-private", RepositoryFormat.PYPI, RepositoryType.HOSTED));
+    RecordingDecisionService decisions = new RecordingDecisionService(AccessDecision.allow()) {
+      @Override
+      public AccessDecision decide(PermissionSubject subject, RepositoryPermission permission) {
+        super.decide(subject, permission);
+        return canonicalPath.equals(permission.pathPattern())
+            ? AccessDecision.allow()
+            : AccessDecision.deny("content selector denied non-canonical path");
+      }
+    };
+    RepositorySecurityFilter filter = filter(
+        new StubAuthenticationService(Optional.of(subject("alice"))),
+        decisions,
+        repositoryDao,
+        false);
+    RecordingPypiHostedService hosted = new RecordingPypiHostedService();
+    RepositoryContentController controller = pypiController(repositoryDao, hosted);
+    HttpServletRequest request = request(
+        "GET",
+        "/repository/pypi-private/packages/pr%69vate/0.0.0%2Bbuild/"
+            + "demo-0.0.0%2Bbuild.whl");
+
+    filter.doFilter(
+        request,
+        new MockHttpServletResponse(),
+        (filteredRequest, ignored) -> controller.get(
+            "pypi-private", (HttpServletRequest) filteredRequest));
+
+    assertEquals(canonicalPath, decisions.permission.pathPattern());
+    assertEquals(
+        canonicalPath,
+        request.getAttribute(RepositorySecurityFilter.NORMALIZED_REPOSITORY_PATH_ATTRIBUTE));
+    assertEquals(canonicalPath, hosted.requestedPath);
+  }
+
+  @Test
+  void composerAuthorizationUsesExactlyOnceCanonicalDistPath() throws Exception {
+    String canonicalPath =
+        "company/private/1.0.0/company-private-1.0.0%2Bbuild.zip";
+    RecordingDecisionService decisions = new RecordingDecisionService(AccessDecision.allow()) {
+      @Override
+      public AccessDecision decide(PermissionSubject subject, RepositoryPermission permission) {
+        super.decide(subject, permission);
+        return canonicalPath.equals(permission.pathPattern())
+            ? AccessDecision.allow()
+            : AccessDecision.deny("content selector denied non-canonical path");
+      }
+    };
+    RepositorySecurityFilter filter = filter(
+        new StubAuthenticationService(Optional.of(subject("alice"))),
+        decisions,
+        new FakeRepositoryDao(repository(
+            "composer-private", RepositoryFormat.COMPOSER, RepositoryType.HOSTED)),
+        false);
+    HttpServletRequest request = request(
+        "GET",
+        "/repository/composer-private/company/pr%69vate/1.0.0/"
+            + "company-private-1.0.0%252Bbuild.zip");
+    ChainState chain = new ChainState();
+
+    filter.doFilter(request, new MockHttpServletResponse(), chain);
+
+    assertEquals(1, chain.calls);
+    assertEquals(canonicalPath, decisions.permission.pathPattern());
+    assertEquals(
+        canonicalPath,
+        request.getAttribute(RepositorySecurityFilter.NORMALIZED_REPOSITORY_PATH_ATTRIBUTE));
+  }
+
+  @Test
+  void invalidPypiEncodingIsRejectedBeforeAuthenticationAndControllerDispatch() throws Exception {
+    StubAuthenticationService authentication =
+        new StubAuthenticationService(Optional.of(subject("alice")));
+    RepositorySecurityFilter filter = filter(
+        authentication,
+        new RecordingDecisionService(AccessDecision.allow()),
+        new FakeRepositoryDao(repository(
+            "pypi-private", RepositoryFormat.PYPI, RepositoryType.HOSTED)),
+        false);
+    ResponseState response = new ResponseState();
+    ChainState chain = new ChainState();
+
+    filter.doFilter(
+        request("GET", "/repository/pypi-private/packages/demo%2Fevil.whl"),
+        response.proxy(),
+        chain);
+
+    assertEquals(0, authentication.calls);
+    assertEquals(0, chain.calls);
+    assertEquals(HttpServletResponse.SC_BAD_REQUEST, response.status);
+    assertEquals("Invalid PyPI path segment", response.message);
   }
 
   @Test
@@ -1344,6 +1447,26 @@ class RepositorySecurityFilterTest {
         new NexusLegacyUiCompatibility(legacyUiEnabled));
   }
 
+  private static RepositoryContentController pypiController(
+      RepositoryDao repositoryDao,
+      PypiHostedService hosted) {
+    return new RepositoryContentController(
+        new RepositoryRuntimeRegistry(repositoryDao, 0),
+        null, null, null,
+        null, null,
+        null, null,
+        null,
+        null, null, null, null, null,
+        hosted, null, null,
+        null, null, null,
+        null, null, null,
+        null, null, null,
+        null, null, null,
+        null, null, null,
+        new ObjectMapper(),
+        new ForwardedHeaderPolicy(""));
+  }
+
   private static void assertRepositoryContentAction(String method, PermissionAction action) throws Exception {
     assertRepositoryPathAction(
         repository("maven-releases"),
@@ -1821,6 +1944,20 @@ class RepositorySecurityFilterTest {
               path.substring(path.lastIndexOf('/') + 1), "terraform", "application/zip", 1L,
               null, Instant.EPOCH, Map.of()))
           .toList();
+    }
+  }
+
+  private static final class RecordingPypiHostedService extends PypiHostedService {
+    private String requestedPath;
+
+    private RecordingPypiHostedService() {
+      super(null, null, null, null, null, null, null, 0);
+    }
+
+    @Override
+    public PypiResponse getPackage(RepositoryRuntime runtime, String path, boolean headOnly) {
+      requestedPath = path;
+      return PypiResponse.noBody(200);
     }
   }
 


### PR DESCRIPTION
## 问题

PyPI local version 等制品版本包含 `+` 时，客户端可能将其编码为 `%2B`。当前部分协议路径没有正确解码，导致已存在的制品查询或下载失败。

## 修复

- 对 PyPI 请求路径只解码一次，同时保留字面量 `+`
- 统一 npm、Cargo 和 Composer 对百分号编码加号的解析行为
- Composer hosted、proxy 和 group 仓库使用解码后的 dist 路径
- 增加 PyPI 黑盒兼容性测试及各协议回归测试

## 验证

- [x] `mvn -q -pl server -am "-Dtest=NpmPathParserTest,CargoPathParserTest,ComposerPathParserTest,ComposerHostedServiceTest,PypiRequestPathTest,PypiRepositoryControllerRangeTest" "-Dsurefire.failIfNoSpecifiedTests=false" test`
- [x] `mvn -q -pl compat-test -am "-DskipTests" test`

## 兼容性与设计说明

- 协议路径行为已按标准 URL 解码语义和 Nexus 兼容行为核对
- 本次修改不涉及缓存、锁、会话、后台任务、权限或迁移状态
