### PR TITLE
Add version update notifications

### DIFF
--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
@@ -309,6 +309,69 @@ select {
   white-space: nowrap;
 }
 
+.product-update-link {
+  position: relative;
+  z-index: 90;
+  display: inline-grid;
+  width: 22px;
+  height: 22px;
+  place-items: center;
+  margin-left: 3px;
+  border-radius: var(--r-xs);
+  color: var(--brand-bright);
+  font-size: 15px;
+  line-height: 1;
+  text-decoration: none;
+  vertical-align: -5px;
+  transition: background-color 120ms ease, color 120ms ease;
+}
+
+.product-update-link:hover {
+  background: var(--topbar-hover);
+  color: var(--topbar-ink);
+}
+
+.product-update-link:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 1px;
+}
+
+.product-update-icon {
+  width: 15px;
+  height: 15px;
+}
+
+.product-update-tooltip {
+  position: absolute;
+  top: calc(100% + 7px);
+  left: 50%;
+  width: max-content;
+  max-width: 260px;
+  padding: 7px 9px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  box-shadow: var(--shadow-pop);
+  color: var(--ink-2);
+  font-size: 12px;
+  font-weight: var(--fw-medium);
+  line-height: 1.35;
+  opacity: 0;
+  pointer-events: none;
+  text-align: left;
+  transform: translate(-50%, -2px);
+  transition: opacity 120ms ease, transform 120ms ease, visibility 120ms ease;
+  visibility: hidden;
+  white-space: nowrap;
+}
+
+.product-update-link:hover .product-update-tooltip,
+.product-update-link:focus-visible .product-update-tooltip {
+  opacity: 1;
+  transform: translate(-50%, 0);
+  visibility: visible;
+}
+
 .product-copy {
   min-width: 0;
 }

--- a/admin-ui/src/main/resources/META-INF/resources/admin/index.html
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/index.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="/browse/assets/tokens.css?v=20260724-visual-upgrade-1">
     <link rel="stylesheet" href="/browse/assets/format-icons.css?v=20260811-conan-1">
     <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260818-user-round-1">
-    <link rel="stylesheet" href="./assets/admin.css?v=20260818-security-provider-layout-8">
+    <link rel="stylesheet" href="./assets/admin.css?v=20260819-version-update-1">
     <link rel="stylesheet" href="/browse/assets/account-menu.css?v=20260818-shared-account-menu-2">
     <link rel="stylesheet" href="/browse/assets/global-component-search.css?v=20260819-topbar-control-height-1">
   </head>
@@ -18,7 +18,7 @@
         <div class="product">
           <a class="logo-mark product-home-link" href="https://github.com/klboke/kkRepo" target="_blank" rel="noopener noreferrer" aria-label="kkRepo GitHub repository">KL</a>
           <div class="product-copy">
-            <div class="product-name" data-i18n-skip><a class="product-link" href="https://github.com/klboke/kkRepo" target="_blank" rel="noopener noreferrer">kkRepo</a> <a class="product-version" href="https://github.com/klboke/kkRepo/releases" target="_blank" rel="noopener noreferrer">v@project.version@</a><br><a class="product-link" href="https://github.com/klboke/kkRepo" target="_blank" rel="noopener noreferrer">Repository Manager</a></div>
+            <div class="product-name" data-i18n-skip><a class="product-link" href="https://github.com/klboke/kkRepo" target="_blank" rel="noopener noreferrer">kkRepo</a> <a class="product-version" data-current-version="@project.version@" href="https://github.com/klboke/kkRepo/releases" target="_blank" rel="noopener noreferrer">v@project.version@</a><a class="product-update-link" data-product-update hidden target="_blank" rel="noopener noreferrer" aria-label="New version available. View release." aria-describedby="admin-product-update-tooltip"><span class="lucide-icon icon-cloud-download product-update-icon" aria-hidden="true"></span><span class="product-update-tooltip" id="admin-product-update-tooltip" data-product-update-tooltip role="tooltip">New version available. View release.</span></a><br><a class="product-link" href="https://github.com/klboke/kkRepo" target="_blank" rel="noopener noreferrer">Repository Manager</a></div>
           </div>
         </div>
         <nav class="workspace-tabs" aria-label="Workspace">
@@ -1814,7 +1814,8 @@
       </main>
     </div>
 
-    <script src="/login/assets/ui-i18n.js?v=20260818-security-provider-layout-4"></script>
+    <script src="/login/assets/ui-i18n.js?v=20260819-version-update-1"></script>
+    <script src="/login/assets/product-update.js?v=20260819-version-update-1"></script>
     <script src="./assets/admin-filter.js?v=20260706-wildcard-filter-1"></script>
     <script src="/browse/assets/global-component-search.js?v=20260817-global-search-2"></script>
     <script src="./assets/admin.js?v=20260818-shared-account-menu-1"></script>

--- a/admin-ui/src/main/resources/META-INF/resources/login/assets/product-update.js
+++ b/admin-ui/src/main/resources/META-INF/resources/login/assets/product-update.js
@@ -1,0 +1,108 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === "object" && module.exports) module.exports = api;
+  root.kkrepoProductUpdate = api;
+  if (root.document && typeof root.fetch === "function") {
+    api.bind(root.document, root);
+  }
+}(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  const ENDPOINT = "/internal/version-update";
+  const POLL_INTERVAL_MS = 30_000;
+  const RELEASE_PATH_PREFIX = "/klboke/kkrepo/releases/tag/";
+
+  function releaseDetails(payload) {
+    if (!payload || payload.status !== "ok" || payload.updateAvailable !== true) return null;
+    const latestVersion = String(payload.latestVersion || "").trim();
+    const releaseUrl = String(payload.releaseUrl || "").trim();
+    if (!latestVersion || latestVersion.length > 64 || !releaseUrl) return null;
+    try {
+      const parsed = new URL(releaseUrl);
+      if (parsed.protocol !== "https:"
+          || parsed.hostname.toLowerCase() !== "github.com"
+          || !parsed.pathname.toLowerCase().startsWith(RELEASE_PATH_PREFIX)) {
+        return null;
+      }
+    } catch {
+      return null;
+    }
+    return { latestVersion, releaseUrl };
+  }
+
+  function updateMessage(latestVersion) {
+    return `New version v${latestVersion} available. View release.`;
+  }
+
+  function render(link, details, windowRef) {
+    const englishMessage = updateMessage(details.latestVersion);
+    const translate = windowRef.kkrepoI18n?.text;
+    const message = typeof translate === "function"
+      ? translate(englishMessage)
+      : englishMessage;
+    link.setAttribute("href", details.releaseUrl);
+    link.setAttribute("aria-label", message);
+    const tooltip = link.querySelector("[data-product-update-tooltip]");
+    if (tooltip) tooltip.textContent = message;
+    link.hidden = false;
+  }
+
+  function hide(link) {
+    link.hidden = true;
+    link.removeAttribute("href");
+  }
+
+  function bind(documentRef, windowRef) {
+    const link = documentRef.querySelector("[data-product-update]");
+    const version = documentRef.querySelector("[data-current-version]")
+        ?.dataset.currentVersion?.trim();
+    if (!link || !version) return null;
+
+    let inFlight = false;
+    let latestDetails = null;
+    async function check() {
+      if (inFlight) return false;
+      inFlight = true;
+      try {
+        const response = await windowRef.fetch(
+          `${ENDPOINT}?currentVersion=${encodeURIComponent(version)}`,
+          {
+            cache: "no-store",
+            headers: { Accept: "application/json" }
+          }
+        );
+        if (!response.ok) return false;
+        const payload = await response.json();
+        if (payload.status !== "ok") return false;
+        if (payload.updateAvailable === false) {
+          latestDetails = null;
+          hide(link);
+          return true;
+        }
+        const nextDetails = releaseDetails(payload);
+        if (!nextDetails) return false;
+        latestDetails = nextDetails;
+        render(link, latestDetails, windowRef);
+        return true;
+      } catch {
+        return false;
+      } finally {
+        inFlight = false;
+      }
+    }
+
+    const initialCheck = check();
+    const intervalId = windowRef.setInterval(() => {
+      void check();
+    }, POLL_INTERVAL_MS);
+    windowRef.addEventListener?.("kkrepo:i18n-change", () => {
+      if (latestDetails) render(link, latestDetails, windowRef);
+    });
+    return { check, initialCheck, intervalId };
+  }
+
+  return {
+    bind,
+    pollIntervalMs: POLL_INTERVAL_MS,
+    releaseDetails,
+    updateMessage
+  };
+}));

--- a/admin-ui/src/main/resources/META-INF/resources/login/assets/ui-i18n.js
+++ b/admin-ui/src/main/resources/META-INF/resources/login/assets/ui-i18n.js
@@ -711,6 +711,8 @@
     if (match) return `默认语言：${translateBody(match[1])}。当前语言：${translateBody(match[2])}。`;
     match = body.match(/^Current language: (.+)$/);
     if (match) return `当前语言：${translateBody(match[1])}`;
+    match = body.match(/^New version (v[^ ]+) available\. View release\.$/);
+    if (match) return `有新版本 ${match[1]} 可更新，查看发布页面。`;
     return body;
   }
 

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminProductVersionContractTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminProductVersionContractTest.java
@@ -15,8 +15,8 @@ class AdminProductVersionContractTest {
   private static final String RELEASES_URL = PROJECT_URL + "/releases";
   private static final String EXTERNAL_LINK_ATTRIBUTES = "target=\"_blank\" rel=\"noopener noreferrer\"";
   private static final Pattern VERSION_BADGE = Pattern.compile(
-      "<a class=\"product-version\" href=\"" + Pattern.quote(RELEASES_URL)
-          + "\" " + EXTERNAL_LINK_ATTRIBUTES + ">v[^<@]+</a>");
+      "<a class=\"product-version\" data-current-version=\"([^\"@]+)\" href=\""
+          + Pattern.quote(RELEASES_URL) + "\" " + EXTERNAL_LINK_ATTRIBUTES + ">v\\1</a>");
 
   @Test
   void headerLinksBrandAndFilteredVersion() throws IOException {
@@ -29,6 +29,12 @@ class AdminProductVersionContractTest {
         + EXTERNAL_LINK_ATTRIBUTES + ">kkRepo</a>"));
     assertTrue(index.contains("class=\"product-link\" href=\"" + PROJECT_URL + "\" "
         + EXTERNAL_LINK_ATTRIBUTES + ">Repository Manager</a>"));
+    assertTrue(index.contains("class=\"product-update-link\" data-product-update hidden "
+        + EXTERNAL_LINK_ATTRIBUTES));
+    assertTrue(index.contains("class=\"lucide-icon icon-cloud-download product-update-icon\""));
+    assertTrue(index.contains("data-product-update-tooltip role=\"tooltip\""));
+    assertTrue(index.contains("/login/assets/product-update.js?v=20260819-version-update-1"));
+    assertFalse(index.contains("/releases/tag/v0.9.0"));
     assertFalse(index.contains("@project.version@"));
     assertTrue(index.contains("value=\"${dn}\""));
   }

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/ProductUpdateJavascriptTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/ProductUpdateJavascriptTest.java
@@ -1,0 +1,53 @@
+package com.github.klboke.kkrepo.admin.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class ProductUpdateJavascriptTest {
+  @Test
+  void productUpdateJavascriptContract() throws Exception {
+    assumeTrue(nodeIsAvailable(), "Node.js is required for admin-ui JavaScript tests");
+
+    Process process = new ProcessBuilder(
+        "node",
+        "--test",
+        Path.of("src/test/js/product-update.test.js").toString())
+        .redirectErrorStream(true)
+        .start();
+
+    if (!process.waitFor(30, TimeUnit.SECONDS)) {
+      process.destroyForcibly();
+      process.waitFor(5, TimeUnit.SECONDS);
+      String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+      fail("Timed out running product update JavaScript tests:\n" + output);
+    }
+    String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    assertEquals(0, process.exitValue(), () -> output);
+  }
+
+  private static boolean nodeIsAvailable() {
+    try {
+      Process process = new ProcessBuilder("node", "--version")
+          .redirectErrorStream(true)
+          .start();
+      boolean exited = process.waitFor(5, TimeUnit.SECONDS);
+      if (!exited) {
+        process.destroyForcibly();
+        return false;
+      }
+      return process.exitValue() == 0;
+    } catch (IOException exception) {
+      return false;
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      return false;
+    }
+  }
+}

--- a/admin-ui/src/test/js/product-update.test.js
+++ b/admin-ui/src/test/js/product-update.test.js
@@ -1,0 +1,167 @@
+const assert = require("node:assert/strict");
+const { resolve } = require("node:path");
+const test = require("node:test");
+
+const productUpdate = require(resolve(
+  __dirname,
+  "../../main/resources/META-INF/resources/login/assets/product-update.js",
+));
+
+function fixture(responses) {
+  const attributes = new Map();
+  const tooltip = { textContent: "" };
+  const link = {
+    hidden: true,
+    querySelector(selector) {
+      return selector === "[data-product-update-tooltip]" ? tooltip : null;
+    },
+    removeAttribute(name) { attributes.delete(name); },
+    setAttribute(name, value) { attributes.set(name, value); },
+  };
+  const version = { dataset: { currentVersion: "0.8.0" } };
+  const documentRef = {
+    querySelector(selector) {
+      if (selector === "[data-product-update]") return link;
+      if (selector === "[data-current-version]") return version;
+      return null;
+    },
+  };
+  let requestIndex = 0;
+  const requests = [];
+  let intervalDelay = null;
+  let intervalCallback = null;
+  const listeners = new Map();
+  const windowRef = {
+    addEventListener(type, listener) { listeners.set(type, listener); },
+    async fetch(url, options) {
+      requests.push({ url, options });
+      const response = responses[Math.min(requestIndex, responses.length - 1)];
+      requestIndex += 1;
+      if (response instanceof Error) throw response;
+      return {
+        ok: response.ok !== false,
+        async json() { return response.payload; },
+      };
+    },
+    setInterval(callback, delay) {
+      intervalCallback = callback;
+      intervalDelay = delay;
+      return 17;
+    },
+  };
+  return {
+    attributes,
+    documentRef,
+    interval: () => ({ callback: intervalCallback, delay: intervalDelay }),
+    link,
+    listeners,
+    requests,
+    tooltip,
+    windowRef,
+  };
+}
+
+test("checks immediately, polls every 30 seconds, and links the exact latest release", async () => {
+  const releaseUrl = "https://github.com/klboke/kkRepo/releases/tag/v0.10.0";
+  const view = fixture([{
+    payload: {
+      status: "ok",
+      latestVersion: "0.10.0",
+      releaseUrl,
+      updateAvailable: true,
+    },
+  }]);
+
+  const binding = productUpdate.bind(view.documentRef, view.windowRef);
+  await binding.initialCheck;
+
+  assert.equal(view.requests.length, 1);
+  assert.equal(view.requests[0].url, "/internal/version-update?currentVersion=0.8.0");
+  assert.equal(view.requests[0].options.cache, "no-store");
+  assert.equal(view.interval().delay, 30_000);
+  assert.equal(binding.intervalId, 17);
+  assert.equal(view.link.hidden, false);
+  assert.equal(view.attributes.get("href"), releaseUrl);
+  assert.equal(
+    view.tooltip.textContent,
+    "New version v0.10.0 available. View release.",
+  );
+});
+
+test("keeps the last successful update when a later request fails", async () => {
+  const releaseUrl = "https://github.com/klboke/kkRepo/releases/tag/v0.9.0";
+  const view = fixture([
+    {
+      payload: {
+        status: "ok",
+        latestVersion: "0.9.0",
+        releaseUrl,
+        updateAvailable: true,
+      },
+    },
+    new Error("network unavailable"),
+  ]);
+  const binding = productUpdate.bind(view.documentRef, view.windowRef);
+  await binding.initialCheck;
+
+  assert.equal(await binding.check(), false);
+  assert.equal(view.link.hidden, false);
+  assert.equal(view.attributes.get("href"), releaseUrl);
+});
+
+test("keeps the last successful update when kkRepo cannot reach GitHub", async () => {
+  const releaseUrl = "https://github.com/klboke/kkRepo/releases/tag/v0.9.0";
+  const view = fixture([
+    {
+      payload: {
+        status: "ok",
+        latestVersion: "0.9.0",
+        releaseUrl,
+        updateAvailable: true,
+      },
+    },
+    { payload: { status: "unavailable" } },
+  ]);
+  const binding = productUpdate.bind(view.documentRef, view.windowRef);
+  await binding.initialCheck;
+
+  assert.equal(await binding.check(), false);
+  assert.equal(view.link.hidden, false);
+  assert.equal(view.attributes.get("href"), releaseUrl);
+});
+
+test("hides a previously visible update after the current version catches up", async () => {
+  const view = fixture([
+    {
+      payload: {
+        status: "ok",
+        latestVersion: "0.9.0",
+        releaseUrl: "https://github.com/klboke/kkRepo/releases/tag/v0.9.0",
+        updateAvailable: true,
+      },
+    },
+    {
+      payload: {
+        status: "ok",
+        latestVersion: "0.8.0",
+        releaseUrl: "https://github.com/klboke/kkRepo/releases/tag/v0.8.0",
+        updateAvailable: false,
+      },
+    },
+  ]);
+  const binding = productUpdate.bind(view.documentRef, view.windowRef);
+  await binding.initialCheck;
+
+  assert.equal(await binding.check(), true);
+  assert.equal(view.link.hidden, true);
+  assert.equal(view.attributes.has("href"), false);
+});
+
+test("rejects non-GitHub release links", () => {
+  assert.equal(productUpdate.releaseDetails({
+    status: "ok",
+    latestVersion: "9.9.9",
+    releaseUrl: "https://example.com/fake-release",
+    updateAvailable: true,
+  }), null);
+});

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
@@ -76,6 +76,69 @@ select {
   white-space: nowrap;
 }
 
+.product-update-link {
+  position: relative;
+  z-index: 90;
+  display: inline-grid;
+  width: 22px;
+  height: 22px;
+  place-items: center;
+  margin-left: 3px;
+  border-radius: var(--r-xs);
+  color: var(--brand-bright);
+  font-size: 15px;
+  line-height: 1;
+  text-decoration: none;
+  vertical-align: -5px;
+  transition: background-color 120ms ease, color 120ms ease;
+}
+
+.product-update-link:hover {
+  background: var(--topbar-hover);
+  color: var(--topbar-ink);
+}
+
+.product-update-link:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 1px;
+}
+
+.product-update-icon {
+  width: 15px;
+  height: 15px;
+}
+
+.product-update-tooltip {
+  position: absolute;
+  top: calc(100% + 7px);
+  left: 50%;
+  width: max-content;
+  max-width: 260px;
+  padding: 7px 9px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  box-shadow: var(--shadow-pop);
+  color: var(--ink-2);
+  font-size: 12px;
+  font-weight: var(--fw-medium);
+  line-height: 1.35;
+  opacity: 0;
+  pointer-events: none;
+  text-align: left;
+  transform: translate(-50%, -2px);
+  transition: opacity 120ms ease, transform 120ms ease, visibility 120ms ease;
+  visibility: hidden;
+  white-space: nowrap;
+}
+
+.product-update-link:hover .product-update-tooltip,
+.product-update-link:focus-visible .product-update-tooltip {
+  opacity: 1;
+  transform: translate(-50%, 0);
+  visibility: visible;
+}
+
 .product-copy {
   min-width: 0;
 }

--- a/browse-ui/src/main/resources/META-INF/resources/browse/index.html
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/index.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="/browse/assets/tokens.css?v=20260724-visual-upgrade-1">
     <link rel="stylesheet" href="/browse/assets/format-icons.css?v=20260811-conan-1">
     <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260818-user-round-1">
-    <link rel="stylesheet" href="/browse/assets/browse.css?v=20260818-account-menu-3">
+    <link rel="stylesheet" href="/browse/assets/browse.css?v=20260819-version-update-1">
     <link rel="stylesheet" href="/browse/assets/account-menu.css?v=20260818-shared-account-menu-2">
     <link rel="stylesheet" href="/browse/assets/global-component-search.css?v=20260819-topbar-control-height-1">
     <link rel="stylesheet" href="/login/assets/login-modal.css?v=20260818-login-icons-1">
@@ -19,7 +19,7 @@
         <div class="product">
           <a class="logo-mark product-home-link" href="https://github.com/klboke/kkRepo" target="_blank" rel="noopener noreferrer" aria-label="kkRepo GitHub repository">KL</a>
           <div class="product-copy">
-            <div class="product-name" data-i18n-skip><a class="product-link" href="https://github.com/klboke/kkRepo" target="_blank" rel="noopener noreferrer">kkRepo</a> <a class="product-version" href="https://github.com/klboke/kkRepo/releases" target="_blank" rel="noopener noreferrer">v@project.version@</a><br><a class="product-link" href="https://github.com/klboke/kkRepo" target="_blank" rel="noopener noreferrer">Repository Manager</a></div>
+            <div class="product-name" data-i18n-skip><a class="product-link" href="https://github.com/klboke/kkRepo" target="_blank" rel="noopener noreferrer">kkRepo</a> <a class="product-version" data-current-version="@project.version@" href="https://github.com/klboke/kkRepo/releases" target="_blank" rel="noopener noreferrer">v@project.version@</a><a class="product-update-link" data-product-update hidden target="_blank" rel="noopener noreferrer" aria-label="New version available. View release." aria-describedby="browse-product-update-tooltip"><span class="lucide-icon icon-cloud-download product-update-icon" aria-hidden="true"></span><span class="product-update-tooltip" id="browse-product-update-tooltip" data-product-update-tooltip role="tooltip">New version available. View release.</span></a><br><a class="product-link" href="https://github.com/klboke/kkRepo" target="_blank" rel="noopener noreferrer">Repository Manager</a></div>
           </div>
         </div>
         <nav class="workspace-tabs" aria-label="Workspace">
@@ -473,7 +473,8 @@
       </main>
     </div>
 
-    <script src="/login/assets/ui-i18n.js?v=20260817-global-search-1"></script>
+    <script src="/login/assets/ui-i18n.js?v=20260819-version-update-1"></script>
+    <script src="/login/assets/product-update.js?v=20260819-version-update-1"></script>
     <script src="/login/assets/login-modal.js?v=20260818-login-icons-3"></script>
     <script src="/browse/assets/global-component-search.js?v=20260817-global-search-2"></script>
     <script src="/browse/assets/browse.js?v=20260818-account-menu-2"></script>

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseProductVersionContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseProductVersionContractTest.java
@@ -15,8 +15,8 @@ class BrowseProductVersionContractTest {
   private static final String RELEASES_URL = PROJECT_URL + "/releases";
   private static final String EXTERNAL_LINK_ATTRIBUTES = "target=\"_blank\" rel=\"noopener noreferrer\"";
   private static final Pattern VERSION_BADGE = Pattern.compile(
-      "<a class=\"product-version\" href=\"" + Pattern.quote(RELEASES_URL)
-          + "\" " + EXTERNAL_LINK_ATTRIBUTES + ">v[^<@]+</a>");
+      "<a class=\"product-version\" data-current-version=\"([^\"@]+)\" href=\""
+          + Pattern.quote(RELEASES_URL) + "\" " + EXTERNAL_LINK_ATTRIBUTES + ">v\\1</a>");
 
   @Test
   void headerLinksBrandAndFilteredVersion() throws IOException {
@@ -29,6 +29,12 @@ class BrowseProductVersionContractTest {
         + EXTERNAL_LINK_ATTRIBUTES + ">kkRepo</a>"));
     assertTrue(index.contains("class=\"product-link\" href=\"" + PROJECT_URL + "\" "
         + EXTERNAL_LINK_ATTRIBUTES + ">Repository Manager</a>"));
+    assertTrue(index.contains("class=\"product-update-link\" data-product-update hidden "
+        + EXTERNAL_LINK_ATTRIBUTES));
+    assertTrue(index.contains("class=\"lucide-icon icon-cloud-download product-update-icon\""));
+    assertTrue(index.contains("data-product-update-tooltip role=\"tooltip\""));
+    assertTrue(index.contains("/login/assets/product-update.js?v=20260819-version-update-1"));
+    assertFalse(index.contains("/releases/tag/v0.9.0"));
     assertFalse(index.contains("@project.version@"));
   }
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -41,6 +41,10 @@
       <artifactId>httpclient5</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-devtools</artifactId>
       <optional>true</optional>

--- a/server/src/main/java/com/github/klboke/kkrepo/server/security/SecurityManagementFilter.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/security/SecurityManagementFilter.java
@@ -106,6 +106,9 @@ public class SecurityManagementFilter extends OncePerRequestFilter {
           ? Optional.empty()
           : Optional.of("nexus:settings:update");
     }
+    if (uri.equals("/internal/version-update") && "GET".equals(method)) {
+      return Optional.empty();
+    }
     if (uri.startsWith("/internal/security/")) {
       return internalSecurityPermission(method, uri);
     }

--- a/server/src/main/java/com/github/klboke/kkrepo/server/version/GitHubLatestReleaseClient.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/version/GitHubLatestReleaseClient.java
@@ -1,0 +1,192 @@
+package com.github.klboke.kkrepo.server.version;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.klboke.kkrepo.cache.LocalCache;
+import com.github.klboke.kkrepo.cache.LocalCacheFactory;
+import com.github.klboke.kkrepo.cache.SharedCache;
+import com.github.klboke.kkrepo.server.version.LatestReleaseSource.LatestRelease;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Locale;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Reads the latest public kkRepo release with a disposable node-local hot cache.
+ *
+ * <p>Each replica refreshes independently after the TTL. Losing the cache only causes the next
+ * request on that replica to reload from GitHub; no correctness or durable state depends on it.
+ */
+@Component
+final class GitHubLatestReleaseClient implements LatestReleaseSource {
+  private static final URI LATEST_RELEASE_URI =
+      URI.create("https://api.github.com/repos/klboke/kkRepo/releases/latest");
+  private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
+  private static final Duration DEFAULT_CACHE_TTL = Duration.ofMinutes(5);
+  private static final String RELEASE_PATH_PREFIX = "/klboke/kkrepo/releases/tag/";
+  private static final String CACHE_KEY = "latest";
+  private static final String BACKOFF_NAMESPACE = "version-update";
+  private static final String BACKOFF_KEY = "github-refresh-failed";
+
+  private final HttpClient httpClient;
+  private final ObjectMapper objectMapper;
+  private final URI latestReleaseUri;
+  private final LocalCache<String, LatestRelease> releases;
+  private final SharedCache sharedCache;
+  private final Duration cacheTtl;
+
+  @Autowired
+  GitHubLatestReleaseClient(
+      ObjectMapper objectMapper,
+      SharedCache sharedCache,
+      @Value("${kkrepo.cache.version-update.ttl-seconds:300}") long cacheTtlSeconds) {
+    this(
+        HttpClient.newBuilder()
+            .connectTimeout(REQUEST_TIMEOUT)
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build(),
+        objectMapper,
+        LATEST_RELEASE_URI,
+        Duration.ofSeconds(Math.max(1, cacheTtlSeconds)),
+        sharedCache);
+  }
+
+  GitHubLatestReleaseClient(
+      HttpClient httpClient,
+      ObjectMapper objectMapper,
+      URI latestReleaseUri,
+      Duration cacheTtl,
+      SharedCache sharedCache) {
+    this.httpClient = httpClient;
+    this.objectMapper = objectMapper;
+    this.latestReleaseUri = latestReleaseUri;
+    this.sharedCache = sharedCache;
+    this.cacheTtl = cacheTtl == null ? DEFAULT_CACHE_TTL : cacheTtl;
+    this.releases = LocalCacheFactory.standard()
+        .<String, LatestRelease>builder("version-update-latest-release")
+        .maximumSize(1)
+        .expireAfterWrite(this.cacheTtl)
+        .build();
+  }
+
+  @Override
+  public LatestRelease fetch() throws IOException {
+    LatestRelease cached = releases.getIfPresent(CACHE_KEY);
+    if (cached != null) {
+      return cached;
+    }
+    if (refreshBackedOff()) {
+      throw new IOException("GitHub latest release refresh is temporarily backed off");
+    }
+    try {
+      return releases.get(CACHE_KEY, ignored -> fetchUnchecked());
+    } catch (LatestReleaseLoadException exception) {
+      throw exception.ioException();
+    }
+  }
+
+  private LatestRelease fetchUnchecked() {
+    try {
+      LatestRelease release = fetchFromGitHub();
+      clearRefreshBackoff();
+      return release;
+    } catch (IOException exception) {
+      recordRefreshFailure();
+      throw new LatestReleaseLoadException(exception);
+    }
+  }
+
+  private boolean refreshBackedOff() {
+    try {
+      return sharedCache.getString(BACKOFF_NAMESPACE, BACKOFF_KEY).isPresent();
+    } catch (RuntimeException ignored) {
+      return false;
+    }
+  }
+
+  private void recordRefreshFailure() {
+    try {
+      sharedCache.putString(BACKOFF_NAMESPACE, BACKOFF_KEY, "1", cacheTtl);
+    } catch (RuntimeException ignored) {
+      // Cache loss is harmless; the next request can retry GitHub directly.
+    }
+  }
+
+  private void clearRefreshBackoff() {
+    try {
+      sharedCache.evict(BACKOFF_NAMESPACE, BACKOFF_KEY);
+    } catch (RuntimeException ignored) {
+      // A stale marker expires by TTL and never affects a cached successful result.
+    }
+  }
+
+  private LatestRelease fetchFromGitHub() throws IOException {
+    HttpRequest request = HttpRequest.newBuilder(latestReleaseUri)
+        .timeout(REQUEST_TIMEOUT)
+        .header("Accept", "application/vnd.github+json")
+        .header("User-Agent", "kkRepo-version-update-check")
+        .GET()
+        .build();
+    HttpResponse<String> response;
+    try {
+      response = httpClient.send(
+          request,
+          HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      throw new IOException("GitHub release request was interrupted", exception);
+    }
+    if (response.statusCode() != 200) {
+      throw new IOException("GitHub latest release returned HTTP " + response.statusCode());
+    }
+
+    JsonNode release = objectMapper.readTree(response.body());
+    String version = requiredText(release, "tag_name");
+    URI releaseUrl = releaseUrl(requiredText(release, "html_url"));
+    return new LatestRelease(version, releaseUrl);
+  }
+
+  private String requiredText(JsonNode release, String field) throws IOException {
+    String value = release.path(field).asText("").trim();
+    if (value.isEmpty() || value.length() > 256) {
+      throw new IOException("GitHub latest release is missing " + field);
+    }
+    return value;
+  }
+
+  private URI releaseUrl(String value) throws IOException {
+    URI uri;
+    try {
+      uri = URI.create(value);
+    } catch (IllegalArgumentException exception) {
+      throw new IOException("GitHub latest release has an invalid html_url", exception);
+    }
+    String path = uri.getPath() == null ? "" : uri.getPath().toLowerCase(Locale.ROOT);
+    if (!"https".equalsIgnoreCase(uri.getScheme())
+        || !"github.com".equalsIgnoreCase(uri.getHost())
+        || !path.startsWith(RELEASE_PATH_PREFIX)) {
+      throw new IOException("GitHub latest release has an unexpected html_url");
+    }
+    return uri;
+  }
+
+  private static final class LatestReleaseLoadException extends RuntimeException {
+    private final IOException ioException;
+
+    private LatestReleaseLoadException(IOException ioException) {
+      super(ioException);
+      this.ioException = ioException;
+    }
+
+    private IOException ioException() {
+      return ioException;
+    }
+  }
+}

--- a/server/src/main/java/com/github/klboke/kkrepo/server/version/LatestReleaseSource.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/version/LatestReleaseSource.java
@@ -1,0 +1,10 @@
+package com.github.klboke.kkrepo.server.version;
+
+import java.io.IOException;
+import java.net.URI;
+
+interface LatestReleaseSource {
+  LatestRelease fetch() throws IOException;
+
+  record LatestRelease(String version, URI url) {}
+}

--- a/server/src/main/java/com/github/klboke/kkrepo/server/version/VersionUpdateController.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/version/VersionUpdateController.java
@@ -1,0 +1,85 @@
+package com.github.klboke.kkrepo.server.version;
+
+import com.github.klboke.kkrepo.server.version.LatestReleaseSource.LatestRelease;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import org.apache.maven.artifact.versioning.ComparableVersion;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+public class VersionUpdateController {
+  private static final Pattern VERSION =
+      Pattern.compile("^[0-9]+(?:\\.[0-9]+)*(?:[-+][0-9A-Za-z.-]+)?$");
+
+  private final LatestReleaseSource latestReleaseSource;
+
+  VersionUpdateController(LatestReleaseSource latestReleaseSource) {
+    this.latestReleaseSource = latestReleaseSource;
+  }
+
+  @GetMapping("/internal/version-update")
+  public ResponseEntity<VersionUpdateResponse> check(
+      @RequestParam("currentVersion") String currentVersion) {
+    String current = normalizeVersion(currentVersion)
+        .orElseThrow(() -> new ResponseStatusException(
+            HttpStatus.BAD_REQUEST,
+            "Invalid release version"));
+    LatestRelease latest;
+    try {
+      latest = latestReleaseSource.fetch();
+    } catch (IOException ignored) {
+      return unavailableResponse();
+    }
+    Optional<String> normalizedLatest = normalizeVersion(latest.version());
+    if (normalizedLatest.isEmpty()) {
+      return unavailableResponse();
+    }
+    String latestVersion = normalizedLatest.get();
+    boolean updateAvailable =
+        new ComparableVersion(latestVersion).compareTo(new ComparableVersion(current)) > 0;
+    VersionUpdateResponse response = new VersionUpdateResponse(
+        "ok",
+        current,
+        latestVersion,
+        updateAvailable,
+        latest.url().toString());
+    return noStore(response);
+  }
+
+  private ResponseEntity<VersionUpdateResponse> unavailableResponse() {
+    return noStore(new VersionUpdateResponse("unavailable", null, null, null, null));
+  }
+
+  private ResponseEntity<VersionUpdateResponse> noStore(VersionUpdateResponse response) {
+    return ResponseEntity.ok()
+        .cacheControl(CacheControl.noStore())
+        .body(response);
+  }
+
+  private Optional<String> normalizeVersion(String value) {
+    String normalized = value == null ? "" : value.trim();
+    if (normalized.length() > 1
+        && (normalized.charAt(0) == 'v' || normalized.charAt(0) == 'V')
+        && Character.isDigit(normalized.charAt(1))) {
+      normalized = normalized.substring(1);
+    }
+    if (normalized.length() > 64 || !VERSION.matcher(normalized).matches()) {
+      return Optional.empty();
+    }
+    return Optional.of(normalized);
+  }
+
+  public record VersionUpdateResponse(
+      String status,
+      String currentVersion,
+      String latestVersion,
+      Boolean updateAvailable,
+      String releaseUrl) {}
+}

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -2,6 +2,7 @@ app.id=infra-kkrepo
 
 server.port=8080
 server.shutdown=graceful
+spring.web.error.include-stacktrace=never
 server.tomcat.threads.max=${KKREPO_TOMCAT_THREADS_MAX:100}
 server.tomcat.threads.min-spare=${KKREPO_TOMCAT_THREADS_MIN_SPARE:10}
 server.tomcat.max-connections=${KKREPO_TOMCAT_MAX_CONNECTIONS:2000}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/security/SecurityManagementFilterTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/security/SecurityManagementFilterTest.java
@@ -647,6 +647,44 @@ class SecurityManagementFilterTest {
   }
 
   @Test
+  void versionUpdateReadBypassesManagementPermissions() throws Exception {
+    StubAuthenticationService authentication = new StubAuthenticationService(Optional.empty());
+    RecordingSecurityService security = new RecordingSecurityService(AccessDecision.deny("should not be checked"));
+    SecurityManagementFilter filter = filter(authentication, security, false);
+    ResponseState response = new ResponseState();
+    ChainState chain = new ChainState();
+
+    filter.doFilter(
+        request("GET", "/internal/version-update"),
+        response.proxy(),
+        chain);
+
+    assertEquals(0, authentication.calls);
+    assertEquals(0, security.decisions);
+    assertEquals(1, chain.calls);
+    assertEquals(0, response.status);
+  }
+
+  @Test
+  void versionUpdateWritesRemainFailClosed() throws Exception {
+    StubAuthenticationService authentication = new StubAuthenticationService(Optional.empty());
+    RecordingSecurityService security = new RecordingSecurityService(AccessDecision.allow());
+    SecurityManagementFilter filter = filter(authentication, security, false);
+    ResponseState response = new ResponseState();
+    ChainState chain = new ChainState();
+
+    filter.doFilter(
+        request("POST", "/internal/version-update"),
+        response.proxy(),
+        chain);
+
+    assertEquals(1, authentication.calls);
+    assertEquals(0, security.decisions);
+    assertEquals(0, chain.calls);
+    assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.status);
+  }
+
+  @Test
   void unknownInternalPathsAreFailClosedToAuthenticatedSubjects() throws Exception {
     StubAuthenticationService authentication = new StubAuthenticationService(Optional.empty());
     RecordingSecurityService security = new RecordingSecurityService(AccessDecision.allow());

--- a/server/src/test/java/com/github/klboke/kkrepo/server/version/GitHubLatestReleaseClientTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/version/GitHubLatestReleaseClientTest.java
@@ -2,8 +2,13 @@ package com.github.klboke.kkrepo.server.version;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.klboke.kkrepo.cache.SharedCache;
 import com.github.klboke.kkrepo.server.version.LatestReleaseSource.LatestRelease;
 import com.github.klboke.kkrepo.server.support.InMemorySharedCache;
 import com.sun.net.httpserver.HttpExchange;
@@ -12,8 +17,11 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
@@ -64,6 +72,29 @@ class GitHubLatestReleaseClientTest {
         """, exchange -> {});
 
     assertThrows(IOException.class, () -> client(endpoint).fetch());
+  }
+
+  @Test
+  void rejectsMissingReleaseFields() throws Exception {
+    URI endpoint = serve(200, "{\"tag_name\":\"v0.10.0\"}", exchange -> {});
+
+    IOException exception = assertThrows(IOException.class, () -> client(endpoint).fetch());
+
+    assertEquals("GitHub latest release is missing html_url", exception.getMessage());
+  }
+
+  @Test
+  void rejectsMalformedReleaseUrls() throws Exception {
+    URI endpoint = serve(200, """
+        {
+          "tag_name": "v0.10.0",
+          "html_url": "https://github.com/%"
+        }
+        """, exchange -> {});
+
+    IOException exception = assertThrows(IOException.class, () -> client(endpoint).fetch());
+
+    assertEquals("GitHub latest release has an invalid html_url", exception.getMessage());
   }
 
   @Test
@@ -126,20 +157,116 @@ class GitHubLatestReleaseClientTest {
         backedOff.getMessage());
   }
 
+  @Test
+  void continuesWhenTheBackoffCacheReadFails() throws Exception {
+    URI endpoint = serve(200, """
+        {
+          "tag_name": "v0.10.0",
+          "html_url": "https://github.com/klboke/kkRepo/releases/tag/v0.10.0"
+        }
+        """, exchange -> {});
+    SharedCache cache = new InMemorySharedCache() {
+      @Override
+      public Optional<String> getString(String namespace, String key) {
+        throw new IllegalStateException("cache unavailable");
+      }
+    };
+
+    LatestRelease release = client(endpoint, Duration.ofMinutes(5), cache).fetch();
+
+    assertEquals("v0.10.0", release.version());
+  }
+
+  @Test
+  void preservesTheUpstreamFailureWhenTheBackoffCacheWriteFails() throws Exception {
+    URI endpoint = serve(403, "{\"message\":\"rate limit exceeded\"}", exchange -> {});
+    SharedCache cache = new InMemorySharedCache() {
+      @Override
+      public void putString(String namespace, String key, String value, Duration ttl) {
+        throw new IllegalStateException("cache unavailable");
+      }
+    };
+
+    IOException exception = assertThrows(
+        IOException.class,
+        () -> client(endpoint, Duration.ofMinutes(5), cache).fetch());
+
+    assertEquals("GitHub latest release returned HTTP 403", exception.getMessage());
+  }
+
+  @Test
+  void returnsTheReleaseWhenTheBackoffCacheClearFails() throws Exception {
+    URI endpoint = serve(200, """
+        {
+          "tag_name": "v0.10.0",
+          "html_url": "https://github.com/klboke/kkRepo/releases/tag/v0.10.0"
+        }
+        """, exchange -> {});
+    SharedCache cache = new InMemorySharedCache() {
+      @Override
+      public void evict(String namespace, String key) {
+        throw new IllegalStateException("cache unavailable");
+      }
+    };
+
+    LatestRelease release = client(endpoint, Duration.ofMinutes(5), cache).fetch();
+
+    assertEquals("v0.10.0", release.version());
+  }
+
+  @Test
+  void restoresTheInterruptFlagWhenTheGitHubRequestIsInterrupted() throws Exception {
+    HttpClient httpClient = mock(HttpClient.class);
+    when(httpClient.send(
+        any(HttpRequest.class),
+        org.mockito.ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+        .thenThrow(new InterruptedException("interrupted"));
+    GitHubLatestReleaseClient client = client(
+        httpClient,
+        URI.create("https://api.github.com/repos/klboke/kkRepo/releases/latest"),
+        Duration.ofMinutes(5),
+        new InMemorySharedCache());
+
+    try {
+      IOException exception = assertThrows(IOException.class, client::fetch);
+
+      assertEquals("GitHub release request was interrupted", exception.getMessage());
+      assertTrue(Thread.currentThread().isInterrupted());
+    } finally {
+      Thread.interrupted();
+    }
+  }
+
   private GitHubLatestReleaseClient client(URI endpoint) {
     return client(endpoint, Duration.ofMinutes(5));
   }
 
   private GitHubLatestReleaseClient client(URI endpoint, Duration cacheTtl) {
-    HttpClient httpClient = HttpClient.newBuilder()
-        .connectTimeout(Duration.ofSeconds(2))
-        .build();
+    return client(endpoint, cacheTtl, new InMemorySharedCache());
+  }
+
+  private GitHubLatestReleaseClient client(
+      URI endpoint,
+      Duration cacheTtl,
+      SharedCache sharedCache) {
+    return client(
+        HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(2)).build(),
+        endpoint,
+        cacheTtl,
+        sharedCache);
+  }
+
+  private GitHubLatestReleaseClient client(
+      HttpClient httpClient,
+      URI endpoint,
+      Duration cacheTtl,
+      SharedCache sharedCache) {
     return new GitHubLatestReleaseClient(
         httpClient,
         new ObjectMapper(),
         endpoint,
         cacheTtl,
-        new InMemorySharedCache());
+        sharedCache);
   }
 
   private URI serve(int status, String body, ExchangeAssertion assertion) throws IOException {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/version/GitHubLatestReleaseClientTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/version/GitHubLatestReleaseClientTest.java
@@ -1,0 +1,169 @@
+package com.github.klboke.kkrepo.server.version;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.klboke.kkrepo.server.version.LatestReleaseSource.LatestRelease;
+import com.github.klboke.kkrepo.server.support.InMemorySharedCache;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class GitHubLatestReleaseClientTest {
+  private HttpServer server;
+
+  @AfterEach
+  void stopServer() {
+    if (server != null) {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void readsLatestTagAndExactReleaseUrl() throws Exception {
+    AtomicReference<String> accept = new AtomicReference<>();
+    AtomicReference<String> userAgent = new AtomicReference<>();
+    URI endpoint = serve(200, """
+        {
+          "tag_name": "v0.10.0",
+          "html_url": "https://github.com/klboke/kkRepo/releases/tag/v0.10.0"
+        }
+        """, exchange -> {
+          accept.set(exchange.getRequestHeaders().getFirst("Accept"));
+          userAgent.set(exchange.getRequestHeaders().getFirst("User-Agent"));
+        });
+    GitHubLatestReleaseClient client = client(endpoint);
+
+    LatestRelease release = client.fetch();
+
+    assertEquals("v0.10.0", release.version());
+    assertEquals(
+        URI.create("https://github.com/klboke/kkRepo/releases/tag/v0.10.0"),
+        release.url());
+    assertEquals("application/vnd.github+json", accept.get());
+    assertEquals("kkRepo-version-update-check", userAgent.get());
+  }
+
+  @Test
+  void rejectsUnexpectedReleaseLinks() throws Exception {
+    URI endpoint = serve(200, """
+        {
+          "tag_name": "v0.10.0",
+          "html_url": "https://example.com/releases/tag/v0.10.0"
+        }
+        """, exchange -> {});
+
+    assertThrows(IOException.class, () -> client(endpoint).fetch());
+  }
+
+  @Test
+  void rejectsUpstreamErrors() throws Exception {
+    URI endpoint = serve(403, "{\"message\":\"rate limit exceeded\"}", exchange -> {});
+
+    IOException exception = assertThrows(IOException.class, () -> client(endpoint).fetch());
+
+    assertEquals("GitHub latest release returned HTTP 403", exception.getMessage());
+  }
+
+  @Test
+  void reusesTheCachedReleaseWithinTheTtl() throws Exception {
+    AtomicInteger requests = new AtomicInteger();
+    URI endpoint = serve(200, """
+        {
+          "tag_name": "v0.10.0",
+          "html_url": "https://github.com/klboke/kkRepo/releases/tag/v0.10.0"
+        }
+        """, exchange -> requests.incrementAndGet());
+    GitHubLatestReleaseClient client = client(endpoint);
+
+    client.fetch();
+    client.fetch();
+
+    assertEquals(1, requests.get());
+  }
+
+  @Test
+  void reloadsTheReleaseAfterTheTtl() throws Exception {
+    AtomicInteger requests = new AtomicInteger();
+    URI endpoint = serve(200, """
+        {
+          "tag_name": "v0.10.0",
+          "html_url": "https://github.com/klboke/kkRepo/releases/tag/v0.10.0"
+        }
+        """, exchange -> requests.incrementAndGet());
+    GitHubLatestReleaseClient client = client(endpoint, Duration.ofMillis(20));
+
+    client.fetch();
+    Thread.sleep(50);
+    client.fetch();
+
+    assertEquals(2, requests.get());
+  }
+
+  @Test
+  void backsOffAfterAnUpstreamFailure() throws Exception {
+    AtomicInteger requests = new AtomicInteger();
+    URI endpoint = serve(403, "{\"message\":\"rate limit exceeded\"}",
+        exchange -> requests.incrementAndGet());
+    GitHubLatestReleaseClient client = client(endpoint);
+
+    assertThrows(IOException.class, client::fetch);
+    IOException backedOff = assertThrows(IOException.class, client::fetch);
+
+    assertEquals(1, requests.get());
+    assertEquals(
+        "GitHub latest release refresh is temporarily backed off",
+        backedOff.getMessage());
+  }
+
+  private GitHubLatestReleaseClient client(URI endpoint) {
+    return client(endpoint, Duration.ofMinutes(5));
+  }
+
+  private GitHubLatestReleaseClient client(URI endpoint, Duration cacheTtl) {
+    HttpClient httpClient = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(2))
+        .build();
+    return new GitHubLatestReleaseClient(
+        httpClient,
+        new ObjectMapper(),
+        endpoint,
+        cacheTtl,
+        new InMemorySharedCache());
+  }
+
+  private URI serve(int status, String body, ExchangeAssertion assertion) throws IOException {
+    server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext("/latest", exchange -> respond(exchange, status, body, assertion));
+    server.start();
+    return URI.create("http://127.0.0.1:" + server.getAddress().getPort() + "/latest");
+  }
+
+  private void respond(
+      HttpExchange exchange,
+      int status,
+      String body,
+      ExchangeAssertion assertion) throws IOException {
+    assertion.accept(exchange);
+    byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+    exchange.getResponseHeaders().set("Content-Type", "application/json");
+    exchange.sendResponseHeaders(status, bytes.length);
+    exchange.getResponseBody().write(bytes);
+    exchange.close();
+  }
+
+  @FunctionalInterface
+  private interface ExchangeAssertion {
+    void accept(HttpExchange exchange) throws IOException;
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/version/VersionUpdateControllerTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/version/VersionUpdateControllerTest.java
@@ -1,0 +1,98 @@
+package com.github.klboke.kkrepo.server.version;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.klboke.kkrepo.server.version.LatestReleaseSource.LatestRelease;
+import com.github.klboke.kkrepo.server.version.VersionUpdateController.VersionUpdateResponse;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Objects;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
+
+class VersionUpdateControllerTest {
+  @Test
+  void reportsNewestReleaseWhenSeveralVersionsWereSkipped() {
+    String releaseUrl = "https://github.com/klboke/kkRepo/releases/tag/v0.10.0";
+    VersionUpdateController controller = controller("v0.10.0", releaseUrl);
+
+    ResponseEntity<VersionUpdateResponse> entity = controller.check("0.8.0");
+    VersionUpdateResponse response = Objects.requireNonNull(entity.getBody());
+
+    assertEquals("ok", response.status());
+    assertEquals("0.8.0", response.currentVersion());
+    assertEquals("0.10.0", response.latestVersion());
+    assertTrue(response.updateAvailable());
+    assertEquals(releaseUrl, response.releaseUrl());
+    assertEquals("no-store", entity.getHeaders().getCacheControl());
+  }
+
+  @Test
+  void doesNotReportAnUpdateForTheCurrentRelease() {
+    VersionUpdateController controller = controller(
+        "v0.8.0",
+        "https://github.com/klboke/kkRepo/releases/tag/v0.8.0");
+
+    VersionUpdateResponse response = Objects.requireNonNull(controller.check("v0.8.0").getBody());
+
+    assertEquals("ok", response.status());
+    assertFalse(response.updateAvailable());
+    assertEquals("0.8.0", response.currentVersion());
+    assertEquals("0.8.0", response.latestVersion());
+  }
+
+  @Test
+  void rejectsInvalidCurrentVersionBeforeCallingGitHub() {
+    VersionUpdateController controller = new VersionUpdateController(() -> {
+      throw new AssertionError("GitHub should not be called");
+    });
+
+    ResponseStatusException exception = assertThrows(
+        ResponseStatusException.class,
+        () -> controller.check("not a version"));
+
+    assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+  }
+
+  @Test
+  void reportsGitHubFailuresAsUnavailable() {
+    VersionUpdateController controller = new VersionUpdateController(() -> {
+      throw new IOException("GitHub unavailable");
+    });
+
+    ResponseEntity<VersionUpdateResponse> entity = controller.check("0.8.0");
+    VersionUpdateResponse response = Objects.requireNonNull(entity.getBody());
+
+    assertEquals(HttpStatus.OK, entity.getStatusCode());
+    assertEquals("unavailable", response.status());
+    assertNull(response.currentVersion());
+    assertNull(response.latestVersion());
+    assertNull(response.updateAvailable());
+    assertNull(response.releaseUrl());
+    assertEquals("no-store", entity.getHeaders().getCacheControl());
+  }
+
+  @Test
+  void reportsMalformedGitHubReleaseVersionsAsUnavailable() {
+    VersionUpdateController controller = controller(
+        "not-a-version",
+        "https://github.com/klboke/kkRepo/releases/tag/not-a-version");
+
+    ResponseEntity<VersionUpdateResponse> entity = controller.check("0.8.0");
+    VersionUpdateResponse response = Objects.requireNonNull(entity.getBody());
+
+    assertEquals(HttpStatus.OK, entity.getStatusCode());
+    assertEquals("unavailable", response.status());
+  }
+
+  private VersionUpdateController controller(String version, String releaseUrl) {
+    return new VersionUpdateController(
+        () -> new LatestRelease(version, URI.create(releaseUrl)));
+  }
+}


### PR DESCRIPTION
## Summary

- add a version update indicator beside the current version in the Admin and Browse headers
- poll kkRepo every 30 seconds and link the indicator to the exact latest GitHub release
- cache successful release lookups for five minutes and back off failed GitHub refreshes through the cache module
- return a stable `200` response with `status: "ok"` or `status: "unavailable"`, preserving the last successful UI state when GitHub is unavailable
- suppress server exception stack traces in HTTP error responses

## Why

Users currently have to discover new kkRepo releases manually. This adds a lightweight, non-blocking update hint while keeping GitHub failures isolated from the main UI and avoiding unauthenticated API rate-limit pressure.

## Impact

The update check is anonymous and read-only. Each replica keeps only rebuildable TTL state; no durable correctness depends on the cache. Admin and Browse pages remain usable when GitHub is unavailable, and an unavailable check does not clear an update indicator obtained by an earlier successful request.

## Validation

- `mvn -pl admin-ui,browse-ui,server -am -Dtest=AdminProductVersionContractTest,BrowseProductVersionContractTest,ProductUpdateJavascriptTest,VersionUpdateControllerTest,GitHubLatestReleaseClientTest,SecurityManagementFilterTest,CacheAbstractionBoundaryTest -Dsurefire.failIfNoSpecifiedTests=false test -q`
- `node --test admin-ui/src/test/js/product-update.test.js`
- DEV endpoint verified at `GET /internal/version-update?currentVersion=0.8.0` with `HTTP 200`, `Cache-Control: no-store`, and the expected status payload
