### PR TITLE
更新欢迎页产品文案

### DIFF
--- a/admin-ui/src/main/resources/META-INF/resources/login/assets/ui-i18n.js
+++ b/admin-ui/src/main/resources/META-INF/resources/login/assets/ui-i18n.js
@@ -315,7 +315,7 @@
     "Save UI settings": "保存界面设置",
     "This preference is stored in MySQL and applies to the administration, browse, and sign-in UI on every replica.": "此设置存储在 MySQL 中，对所有副本的管理、浏览和登录界面均生效。",
     "Welcome": "欢迎",
-    "Nexus-compatible repository access for internal packages": "面向内部包的 Nexus 兼容仓库访问",
+    "Enterprise-grade artifact repository for internal packages": "面向内部包的企业级制品仓库",
     "Initial administrator setup": "初始管理员设置",
     "Administrator": "管理员",
     "Confirm password": "确认密码",

--- a/browse-ui/src/main/resources/META-INF/resources/browse/index.html
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/index.html
@@ -124,7 +124,7 @@
           <div class="page-heading">
             <span class="heading-icon"><span class="lucide-icon icon-home" aria-hidden="true"></span></span>
             <h1>Welcome</h1>
-            <span class="heading-copy">Nexus-compatible repository access for internal packages</span>
+            <span class="heading-copy">Enterprise-grade artifact repository for internal packages</span>
           </div>
           <form class="admin-bootstrap-panel" id="admin-bootstrap-panel" hidden novalidate>
             <div class="admin-bootstrap-title">Initial administrator setup</div>


### PR DESCRIPTION
## 改动

- 将欢迎页副标题从 Nexus 兼容性表述调整为 kkRepo 自身的企业级制品仓库定位
- 同步更新中文界面文案

## 原因

kkRepo 当前已具备成熟的多格式制品仓库能力，欢迎页不再需要以 Nexus 兼容性作为主要产品定位。

## 用户影响

欢迎页将显示更独立、成熟的 kkRepo 产品文案，仓库协议与运行行为不变。

## 验证

- `git diff --check`
- `mvn -pl admin-ui,browse-ui test`（51 tests passed）
