### PR TITLE
Broaden the welcome page product messaging

### DIFF
--- a/admin-ui/src/main/resources/META-INF/resources/login/assets/ui-i18n.js
+++ b/admin-ui/src/main/resources/META-INF/resources/login/assets/ui-i18n.js
@@ -315,7 +315,7 @@
     "Save UI settings": "保存界面设置",
     "This preference is stored in MySQL and applies to the administration, browse, and sign-in UI on every replica.": "此设置存储在 MySQL 中，对所有副本的管理、浏览和登录界面均生效。",
     "Welcome": "欢迎",
-    "Enterprise-grade artifact repository for internal packages": "面向内部包的企业级制品仓库",
+    "Enterprise-grade artifact management for modern software delivery": "面向现代软件交付的企业级制品管理",
     "Initial administrator setup": "初始管理员设置",
     "Administrator": "管理员",
     "Confirm password": "确认密码",

--- a/browse-ui/src/main/resources/META-INF/resources/browse/index.html
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/index.html
@@ -124,7 +124,7 @@
           <div class="page-heading">
             <span class="heading-icon"><span class="lucide-icon icon-home" aria-hidden="true"></span></span>
             <h1>Welcome</h1>
-            <span class="heading-copy">Enterprise-grade artifact repository for internal packages</span>
+            <span class="heading-copy">Enterprise-grade artifact management for modern software delivery</span>
           </div>
           <form class="admin-bootstrap-panel" id="admin-bootstrap-panel" hidden novalidate>
             <div class="admin-bootstrap-title">Initial administrator setup</div>


### PR DESCRIPTION
## Summary

- Replace the welcome-page tagline with `Enterprise-grade artifact management for modern software delivery`
- Update the corresponding Chinese translation

## Rationale

The previous reference to internal packages could imply that kkRepo is focused only on hosted artifacts. The broader wording better represents its hosted, proxy, and group repository workflows without tying the product identity to a single usage model.

## User impact

The welcome page now presents kkRepo as a complete artifact management platform for modern software delivery. Repository behavior and protocol compatibility are unchanged.

## Validation

- `git diff --check`
- `mvn -pl admin-ui,browse-ui test` (51 tests passed)
