### PR TITLE
Release kkRepo 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable public changes to kkrepo are documented in this file.
 
 This project follows a pragmatic early-stage release process. Until a stable `1.0.0` release is announced, minor versions may include behavior changes, but releases should call out migration impact, compatibility changes, and operational notes.
 
+## 0.9.0 - 2026-08-20
+
+### Added
+
+- Nexus-compatible Alpine APK hosted, proxy, and group repositories with canonical APK v2 publication, signed immutable indexes, ordered group resolution, proxy passthrough or verified re-signing, migration, cleanup, security scanning, and real `apk` client coverage. (#215)
+- Hugging Face Models proxy repositories with model, revision, tree, refs, paths-info, and commit-pinned file routes; server-side Git LFS/Xet bridging; bounded shared-database coordination; migration, cleanup, scanning, and real `huggingface_hub`, `hf`, Transformers, and Diffusers coverage. (#224)
+- Permission-aware global component search across Browse and Admin, with repository and content-selector authorization, stable keyset pagination, and adaptive MySQL query planning for large installations. (#222)
+- Product-version update notifications backed by the latest public GitHub Release, with bounded caching and non-blocking UI integration. (#233)
+- Per-repository proxy redirect host allowlists for explicitly trusted upstream domains while retaining the global SSRF and redirect safety policy. (#230)
+
+### Changed
+
+- Node-local TTL caches now use the shared cache module and factory abstraction, preserving rebuildable multi-replica semantics while removing direct server/storage coupling to Caffeine. (#226)
+- Browse repository details, OIDC/LDAP settings, account and sign-in surfaces, topbar controls, and welcome-page product copy were refined for denser operation and clearer navigation. The obsolete README architecture diagram was removed. (#212, #227, #229, #231, #234, #235, #237)
+- Quickstart initializes its data volume with the UID/GID of the selected JVM or Native runtime, and its defaults, Dockerfile packaging, deployment documentation, Helm application version, and optional scanner profile now use `0.9.0`. (#213)
+- zstd-jni, GraalVM Native Build Tools, and the AWS SDK were refreshed. (#216, #217, #218)
+
+### Fixed
+
+- Proxy cache writes now record the triggering client IP, or no IP for background work, instead of placing an upstream URL in the bounded audit column; this prevents valid long proxy URLs from breaking MySQL writes without changing package-client behavior. (#211)
+- MySQL component search no longer makes coordinates unmatchable when they include terms shorter than InnoDB's default full-text token size. (#223)
+- Repository content paths preserve percent-encoded plus signs instead of decoding them as spaces. (#232)
+
+### Compatibility And Validation
+
+- Alpine and Hugging Face include MySQL/PostgreSQL persistence contracts, multi-replica leases and recovery, Nexus-shape-gated migration, protocol-aware cleanup/scanning, real-client E2E coverage, and measured large-data or Nexus performance gates. (#215, #224)
+- Global search authorization is enforced before lookup and remains exact for content selectors; its database paths include million-row MySQL validation and online/concurrent index migrations for both supported databases. (#222)
+- Quickstart ownership checks cover JVM and Native runtimes with both MySQL and PostgreSQL, while the audit, redirect, path-decoding, cache, and UI changes retain existing repository client protocols. (#211, #213, #226, #230, #232)
+
+### Upgrade Notes
+
+- Existing `0.8.0` MySQL and PostgreSQL deployments can upgrade in place through Flyway V46-V48. Back up the relational database and blob store together, allow migrations to complete before serving traffic, and do not run mixed application versions after the new schema is applied.
+- V46 adds Alpine package, index, signing, lease, and migration state; V47 replaces component-search ordering indexes using online/concurrent database operations; V48 adds Hugging Face model, revision, file, cache, lease, and migration state. Apply V47 during a lower-I/O window on installations with large component tables.
+- New repository formats are not created automatically. Import or configure Alpine signing trust before publication, and validate Hugging Face credentials, redirect allowlists, cleanup policies, and scanner scope before production activation.
+
 ## 0.8.0 - 2026-08-13
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:25-jre-jammy
 
 WORKDIR /app
 
-ARG JAR_FILE=server/target/kkrepo-server-0.8.0.jar
+ARG JAR_FILE=server/target/kkrepo-server-0.9.0.jar
 
 RUN groupadd --system kkrepo \
     && useradd --system --gid kkrepo --home-dir /app --shell /usr/sbin/nologin kkrepo

--- a/deploy/helm/kkrepo/Chart.yaml
+++ b/deploy/helm/kkrepo/Chart.yaml
@@ -3,5 +3,5 @@ name: kkrepo
 description: Multi-replica kkRepo artifact repository with an external MySQL or PostgreSQL database
 type: application
 version: 0.2.0
-appVersion: "0.8.0"
+appVersion: "0.9.0"
 kubeVersion: ">=1.27.0-0"

--- a/docker-compose.quickstart-postgresql.yml
+++ b/docker-compose.quickstart-postgresql.yml
@@ -41,7 +41,7 @@ services:
     network_mode: none
 
   kkrepo:
-    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.8.0}
+    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.9.0}
     depends_on:
       postgresql:
         condition: service_healthy
@@ -74,7 +74,7 @@ services:
     restart: unless-stopped
 
   scanner:
-    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.8.0}
+    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.9.0}
     profiles: ["security-scanning"]
     environment:
       KKREPO_SCANNER_SERVICE_CREDENTIAL: ${KKREPO_SECURITY_SCANNING_SERVICE_CREDENTIAL:-}
@@ -104,7 +104,7 @@ services:
     restart: unless-stopped
 
   scanner-database-updater:
-    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.8.0}
+    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.9.0}
     profiles: ["security-scanning"]
     entrypoint: ["/bin/sh", "-ec"]
     command:

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -42,7 +42,7 @@ services:
     network_mode: none
 
   kkrepo:
-    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.8.0}
+    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.9.0}
     depends_on:
       mysql:
         condition: service_healthy
@@ -75,7 +75,7 @@ services:
     restart: unless-stopped
 
   scanner:
-    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.8.0}
+    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.9.0}
     profiles: ["security-scanning"]
     environment:
       KKREPO_SCANNER_SERVICE_CREDENTIAL: ${KKREPO_SECURITY_SCANNING_SERVICE_CREDENTIAL:-}
@@ -105,7 +105,7 @@ services:
     restart: unless-stopped
 
   scanner-database-updater:
-    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.8.0}
+    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.9.0}
     profiles: ["security-scanning"]
     entrypoint: ["/bin/sh", "-ec"]
     command:

--- a/docs/en/build-deployment-guide.md
+++ b/docs/en/build-deployment-guide.md
@@ -40,7 +40,7 @@ curl -fsSL https://raw.githubusercontent.com/klboke/kkrepo/main/scripts/quicksta
   | KKREPO_RUNTIME=native KKREPO_DATABASE_TYPE=postgresql bash
 ```
 
-`KKREPO_RUNTIME=jvm` selects `ghcr.io/klboke/kkrepo:0.8.0`, while `KKREPO_RUNTIME=native` selects `ghcr.io/klboke/kkrepo:0.8.0-native`. Both are published for Linux `amd64` and `arm64`. An explicit `KKREPO_IMAGE_TAG` overrides the runtime's default tag.
+`KKREPO_RUNTIME=jvm` selects `ghcr.io/klboke/kkrepo:0.9.0`, while `KKREPO_RUNTIME=native` selects `ghcr.io/klboke/kkrepo:0.9.0-native`. Both are published for Linux `amd64` and `arm64`. An explicit `KKREPO_IMAGE_TAG` overrides the runtime's default tag.
 
 The script prints each step and:
 
@@ -61,7 +61,7 @@ bash quickstart.sh
 
 By default, it starts:
 
-- The JVM runtime from `ghcr.io/klboke/kkrepo:0.8.0`
+- The JVM runtime from `ghcr.io/klboke/kkrepo:0.9.0`
 - MySQL 8.0
 - Persistent MySQL and File blob storage volumes for local trials
 
@@ -153,7 +153,7 @@ Note: a normal `server` module jar does not contain a Spring Boot executable ent
 Pull the latest public release image:
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:0.8.0
+docker pull ghcr.io/klboke/kkrepo:0.9.0
 ```
 
 You can also use `latest` to follow the latest public release:
@@ -165,7 +165,7 @@ docker pull ghcr.io/klboke/kkrepo:latest
 The Native image is published separately:
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:0.8.0-native
+docker pull ghcr.io/klboke/kkrepo:0.9.0-native
 docker pull ghcr.io/klboke/kkrepo:native-latest
 ```
 

--- a/docs/zh/build-deployment-guide.md
+++ b/docs/zh/build-deployment-guide.md
@@ -40,7 +40,7 @@ curl -fsSL https://raw.githubusercontent.com/klboke/kkrepo/main/scripts/quicksta
   | KKREPO_RUNTIME=native KKREPO_DATABASE_TYPE=postgresql bash
 ```
 
-`KKREPO_RUNTIME=jvm` 选择 `ghcr.io/klboke/kkrepo:0.8.0`，`KKREPO_RUNTIME=native` 选择 `ghcr.io/klboke/kkrepo:0.8.0-native`。两种镜像均发布 Linux `amd64` 和 `arm64` 架构。显式设置 `KKREPO_IMAGE_TAG` 时，会覆盖对应运行时的默认 tag。
+`KKREPO_RUNTIME=jvm` 选择 `ghcr.io/klboke/kkrepo:0.9.0`，`KKREPO_RUNTIME=native` 选择 `ghcr.io/klboke/kkrepo:0.9.0-native`。两种镜像均发布 Linux `amd64` 和 `arm64` 架构。显式设置 `KKREPO_IMAGE_TAG` 时，会覆盖对应运行时的默认 tag。
 
 该脚本会逐步打印日志并执行：
 
@@ -61,7 +61,7 @@ bash quickstart.sh
 
 默认会启动：
 
-- `ghcr.io/klboke/kkrepo:0.8.0` 中的 JVM 运行时
+- `ghcr.io/klboke/kkrepo:0.9.0` 中的 JVM 运行时
 - MySQL 8.0
 - 用于本地试用的持久化 MySQL volume 和 File blob storage volume
 
@@ -153,7 +153,7 @@ server/target/kkrepo-server-<version>.jar
 拉取最新公开发行镜像：
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:0.8.0
+docker pull ghcr.io/klboke/kkrepo:0.9.0
 ```
 
 也可以使用 `latest` 跟随最新公开发行版本：
@@ -165,7 +165,7 @@ docker pull ghcr.io/klboke/kkrepo:latest
 Native 镜像使用独立 tag：
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:0.8.0-native
+docker pull ghcr.io/klboke/kkrepo:0.9.0-native
 docker pull ghcr.io/klboke/kkrepo:native-latest
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
   </modules>
 
   <properties>
-    <revision>0.8.0</revision>
+    <revision>0.9.0</revision>
     <java.version>25</java.version>
     <spring.boot.version>4.1.0</spring.boot.version>
     <native-build-tools-plugin.version>1.1.9</native-build-tools-plugin.version>

--- a/scripts/ci/test-quickstart-runtime.sh
+++ b/scripts/ci/test-quickstart-runtime.sh
@@ -58,22 +58,22 @@ run_quickstart() {
 
 run_quickstart default-jvm
 grep -qx 'KKREPO_RUNTIME=jvm' "$TMP_ROOT/default-jvm/.env"
-grep -qx 'KKREPO_IMAGE_TAG=0.8.0' "$TMP_ROOT/default-jvm/.env"
-grep -qx 'jvm|0.8.0' "$TMP_ROOT/default-jvm.log"
+grep -qx 'KKREPO_IMAGE_TAG=0.9.0' "$TMP_ROOT/default-jvm/.env"
+grep -qx 'jvm|0.9.0' "$TMP_ROOT/default-jvm.log"
 
 run_quickstart native KKREPO_RUNTIME=native
 grep -qx 'KKREPO_RUNTIME=native' "$TMP_ROOT/native/.env"
-grep -qx 'KKREPO_IMAGE_TAG=0.8.0-native' "$TMP_ROOT/native/.env"
-grep -qx 'native|0.8.0-native' "$TMP_ROOT/native.log"
+grep -qx 'KKREPO_IMAGE_TAG=0.9.0-native' "$TMP_ROOT/native/.env"
+grep -qx 'native|0.9.0-native' "$TMP_ROOT/native.log"
 
 mkdir -p "$TMP_ROOT/existing-jvm"
-# Simulate a persisted v0.7.0 JVM quickstart before explicitly switching runtimes.
+# Simulate a persisted v0.8.0 JVM quickstart before explicitly switching runtimes.
 cat >"$TMP_ROOT/existing-jvm/.env" <<'EOF'
 KKREPO_RUNTIME=jvm
-KKREPO_IMAGE_TAG=0.7.0
+KKREPO_IMAGE_TAG=0.8.0
 EOF
 run_quickstart existing-jvm KKREPO_RUNTIME=native
-grep -qx 'native|0.8.0-native' "$TMP_ROOT/existing-jvm.log"
+grep -qx 'native|0.9.0-native' "$TMP_ROOT/existing-jvm.log"
 
 run_quickstart custom-native \
   KKREPO_RUNTIME=native \

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -186,10 +186,10 @@ fi
 KKREPO_RUNTIME="${KKREPO_RUNTIME:-jvm}"
 case "$KKREPO_RUNTIME" in
   jvm)
-    DEFAULT_IMAGE_TAG="0.8.0"
+    DEFAULT_IMAGE_TAG="0.9.0"
     ;;
   native)
-    DEFAULT_IMAGE_TAG="0.8.0-native"
+    DEFAULT_IMAGE_TAG="0.9.0-native"
     ;;
   *)
     fail "KKREPO_RUNTIME must be jvm or native, got: $KKREPO_RUNTIME"


### PR DESCRIPTION
## Summary

- bump the Maven, Docker, Helm, Quickstart, scanner, and deployment defaults to 0.9.0
- document Alpine APK, Hugging Face Models, global component search, update notifications, UI/security fixes, and dependency updates shipped since v0.8.0
- document the MySQL/PostgreSQL V46-V48 upgrade path and the V47 lower-I/O-window recommendation

## Validation

- `mvn -B -ntp -N validate`
- project version resolves to `0.9.0`
- `helm lint deploy/helm/kkrepo`
- both Quickstart Compose files validate with and without the `security-scanning` profile
- `scripts/ci/test-quickstart-runtime.sh`
- `scripts/ci/test-quickstart-data-permissions.sh`
- `bash scripts/ci/check-flyway-parity.sh` (V48)
- shell syntax checks and `git diff --check`