### PR TITLE
fix: parse Maven timestamped snapshot assets in browse delete

### DIFF
--- a/server/src/main/java/com/github/klboke/kkrepo/server/browse/BrowseContentDeleteController.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/browse/BrowseContentDeleteController.java
@@ -22,6 +22,8 @@ import com.github.klboke.kkrepo.protocol.conda.CondaPath;
 import com.github.klboke.kkrepo.protocol.nuget.NugetPath;
 import com.github.klboke.kkrepo.protocol.nuget.NugetPathParser;
 import com.github.klboke.kkrepo.protocol.nuget.NugetPaths;
+import com.github.klboke.kkrepo.protocol.maven.path.Coordinates;
+import com.github.klboke.kkrepo.protocol.maven.path.MavenPathParser;
 import com.github.klboke.kkrepo.protocol.swift.SwiftPath;
 import com.github.klboke.kkrepo.protocol.swift.SwiftPathParser;
 import com.github.klboke.kkrepo.protocol.swift.SwiftToolsVersions;
@@ -851,11 +853,22 @@ public class BrowseContentDeleteController {
     return null;
   }
 
+  private static final MavenPathParser MAVEN_PATH_PARSER = new MavenPathParser();
+
   private MavenCoordinates mavenCoordinates(String path) {
     String normalized = isMavenHash(path)
         ? path.substring(0, path.lastIndexOf('.'))
         : path;
-    String[] segments = normalized.split("/");
+    Coordinates coordinates = MAVEN_PATH_PARSER.parsePath(normalized).coordinates();
+    if (coordinates != null) {
+      return new MavenCoordinates(
+          coordinates.groupId(), coordinates.artifactId(), coordinates.baseVersion());
+    }
+    return mavenDirectoryOrMetadataCoordinates(normalized);
+  }
+
+  private MavenCoordinates mavenDirectoryOrMetadataCoordinates(String path) {
+    String[] segments = path.split("/");
     if (segments.length < 3) {
       return null;
     }
@@ -868,37 +881,13 @@ public class BrowseContentDeleteController {
       }
       return new MavenCoordinates(String.join(".", groupSegments), artifactId, "");
     }
-
-    boolean assetPath = looksLikeMavenAssetPath(segments);
-    String version = assetPath ? segments[segments.length - 2] : segments[segments.length - 1];
-    String artifactId = assetPath ? segments[segments.length - 3] : segments[segments.length - 2];
-    List<String> groupSegments = assetPath
-        ? List.of(segments).subList(0, segments.length - 3)
-        : List.of(segments).subList(0, segments.length - 2);
+    String version = segments[segments.length - 1];
+    String artifactId = segments[segments.length - 2];
+    List<String> groupSegments = List.of(segments).subList(0, segments.length - 2);
     if (groupSegments.isEmpty()) {
       return null;
     }
     return new MavenCoordinates(String.join(".", groupSegments), artifactId, version);
-  }
-
-  private boolean looksLikeMavenAssetPath(String[] segments) {
-    if (segments.length < 4) {
-      return false;
-    }
-    String filename = segments[segments.length - 1];
-    String version = segments[segments.length - 2];
-    String artifactId = segments[segments.length - 3];
-    if (filename.startsWith(artifactId + "-" + version + ".")
-        || filename.startsWith(artifactId + "-" + version + "-")) {
-      return true;
-    }
-    // Maven timestamped snapshots use the base version without the -SNAPSHOT suffix in the
-    // file name: {artifactId}-{version}-{timestamp}-{buildNumber}.{ext}
-    if (version.endsWith("-SNAPSHOT")) {
-      String baseVersion = version.substring(0, version.length() - "-SNAPSHOT".length());
-      return filename.startsWith(artifactId + "-" + baseVersion + "-");
-    }
-    return false;
   }
 
   private static String toStoragePath(RepositoryFormat format, String publicPath) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/browse/BrowseContentDeleteController.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/browse/BrowseContentDeleteController.java
@@ -888,8 +888,17 @@ public class BrowseContentDeleteController {
     String filename = segments[segments.length - 1];
     String version = segments[segments.length - 2];
     String artifactId = segments[segments.length - 3];
-    return filename.startsWith(artifactId + "-" + version + ".")
-        || filename.startsWith(artifactId + "-" + version + "-");
+    if (filename.startsWith(artifactId + "-" + version + ".")
+        || filename.startsWith(artifactId + "-" + version + "-")) {
+      return true;
+    }
+    // Maven timestamped snapshots use the base version without the -SNAPSHOT suffix in the
+    // file name: {artifactId}-{version}-{timestamp}-{buildNumber}.{ext}
+    if (version.endsWith("-SNAPSHOT")) {
+      String baseVersion = version.substring(0, version.length() - "-SNAPSHOT".length());
+      return filename.startsWith(artifactId + "-" + baseVersion + "-");
+    }
+    return false;
   }
 
   private static String toStoragePath(RepositoryFormat format, String publicPath) {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/browse/BrowseContentDeleteControllerTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/browse/BrowseContentDeleteControllerTest.java
@@ -458,6 +458,30 @@ class BrowseContentDeleteControllerTest {
   }
 
   @Test
+  void deletesTimestampedMavenSnapshotAssetAndEnqueuesMetadataRebuilds() {
+    Fixture fixture = fixture(true, AccessDecision.allow());
+    RepositoryRecord repository =
+        repository(1L, "maven", RepositoryFormat.MAVEN2, RepositoryType.HOSTED);
+    String path = "com/acme/app/1.0-SNAPSHOT/app-1.0-20260623.055437-2.jar";
+    AssetRecord jar = asset(11L, 21L, 31L, RepositoryFormat.MAVEN2, path, "artifact", Map.of());
+    AssetRecord sha1 = asset(
+        12L, null, 32L, RepositoryFormat.MAVEN2, path + ".sha1", "checksum", Map.of());
+    when(fixture.repositoryDao.findByName("maven")).thenReturn(Optional.of(repository));
+    when(fixture.assetDao.findAssetByPath(1L, path)).thenReturn(Optional.of(jar));
+    when(fixture.assetDao.findAssetByPath(1L, path + ".sha1")).thenReturn(Optional.of(sha1));
+    when(fixture.assetDao.listAssetsByPrefix(1L, path + "/")).thenReturn(List.of());
+
+    BrowseContentDeleteController.BrowseDeleteResult result = fixture.controller.delete(
+        "maven", "/" + path, null, new MockHttpServletRequest());
+
+    assertEquals(2, result.deletedAssets());
+    verify(fixture.assetDao).deleteAssetById(11L);
+    verify(fixture.assetDao).deleteAssetById(12L);
+    verify(fixture.metadataRebuildDao).enqueue(1L, "ga:com.acme/app");
+    verify(fixture.metadataRebuildDao).enqueue(1L, "gav:com.acme/app/1.0-SNAPSHOT");
+  }
+
+  @Test
   void validatesExplicitGroupSourceMembership() {
     Fixture fixture = fixture(true, AccessDecision.allow());
     RepositoryRecord group =

--- a/server/src/test/java/com/github/klboke/kkrepo/server/browse/BrowseContentDeleteControllerTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/browse/BrowseContentDeleteControllerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -479,6 +480,63 @@ class BrowseContentDeleteControllerTest {
     verify(fixture.assetDao).deleteAssetById(12L);
     verify(fixture.metadataRebuildDao).enqueue(1L, "ga:com.acme/app");
     verify(fixture.metadataRebuildDao).enqueue(1L, "gav:com.acme/app/1.0-SNAPSHOT");
+  }
+
+  @Test
+  void deletesReleaseMavenAssetAndEnqueuesGaRebuild() {
+    Fixture fixture = fixture(true, AccessDecision.allow());
+    RepositoryRecord repository =
+        repository(1L, "maven", RepositoryFormat.MAVEN2, RepositoryType.HOSTED);
+    String path = "com/acme/app/1.0/app-1.0.jar";
+    AssetRecord jar = asset(11L, 21L, 31L, RepositoryFormat.MAVEN2, path, "artifact", Map.of());
+    when(fixture.repositoryDao.findByName("maven")).thenReturn(Optional.of(repository));
+    when(fixture.assetDao.findAssetByPath(1L, path)).thenReturn(Optional.of(jar));
+    when(fixture.assetDao.listAssetsByPrefix(1L, path + "/")).thenReturn(List.of());
+
+    BrowseContentDeleteController.BrowseDeleteResult result = fixture.controller.delete(
+        "maven", "/" + path, null, new MockHttpServletRequest());
+
+    assertEquals(1, result.deletedAssets());
+    verify(fixture.metadataRebuildDao).enqueue(1L, "ga:com.acme/app");
+    verify(fixture.metadataRebuildDao, never()).enqueue(eq(1L), startsWith("gav:"));
+  }
+
+  @Test
+  void deletesSnapshotVersionDirectoryAndEnqueuesGaGavRebuild() {
+    Fixture fixture = fixture(true, AccessDecision.allow());
+    RepositoryRecord repository =
+        repository(1L, "maven", RepositoryFormat.MAVEN2, RepositoryType.HOSTED);
+    String dir = "com/acme/app/1.0-SNAPSHOT";
+    String jarPath = dir + "/app-1.0-20260623.055437-2.jar";
+    AssetRecord jar = asset(11L, 21L, 31L, RepositoryFormat.MAVEN2, jarPath, "artifact", Map.of());
+    when(fixture.repositoryDao.findByName("maven")).thenReturn(Optional.of(repository));
+    when(fixture.assetDao.listAssetsByPrefix(1L, dir + "/")).thenReturn(List.of(jar));
+
+    BrowseContentDeleteController.BrowseDeleteResult result = fixture.controller.delete(
+        "maven", "/" + dir, null, new MockHttpServletRequest());
+
+    assertEquals(1, result.deletedAssets());
+    verify(fixture.metadataRebuildDao).enqueue(1L, "ga:com.acme/app");
+    verify(fixture.metadataRebuildDao).enqueue(1L, "gav:com.acme/app/1.0-SNAPSHOT");
+  }
+
+  @Test
+  void deletesReleaseVersionDirectoryAndEnqueuesGaRebuild() {
+    Fixture fixture = fixture(true, AccessDecision.allow());
+    RepositoryRecord repository =
+        repository(1L, "maven", RepositoryFormat.MAVEN2, RepositoryType.HOSTED);
+    String dir = "com/acme/app/1.0";
+    String jarPath = dir + "/app-1.0.jar";
+    AssetRecord jar = asset(11L, 21L, 31L, RepositoryFormat.MAVEN2, jarPath, "artifact", Map.of());
+    when(fixture.repositoryDao.findByName("maven")).thenReturn(Optional.of(repository));
+    when(fixture.assetDao.listAssetsByPrefix(1L, dir + "/")).thenReturn(List.of(jar));
+
+    BrowseContentDeleteController.BrowseDeleteResult result = fixture.controller.delete(
+        "maven", "/" + dir, null, new MockHttpServletRequest());
+
+    assertEquals(1, result.deletedAssets());
+    verify(fixture.metadataRebuildDao).enqueue(1L, "ga:com.acme/app");
+    verify(fixture.metadataRebuildDao, never()).enqueue(eq(1L), startsWith("gav:"));
   }
 
   @Test


### PR DESCRIPTION
Fixes #240

## Problem

`BrowseContentDeleteController.looksLikeMavenAssetPath` misclassified Maven **timestamped snapshot assets** as directory paths. The file-name prefix check required `artifactId-<baseVersion>-`, but Maven timestamped snapshot file names use the base version **without** the `-SNAPSHOT` suffix:

```
{artifactId}-{version}-{timestamp}-{buildNumber}.{ext}
```

Example: `com/ids/secstar/idsSecData/1.2.5-202406-SNAPSHOT/idsSecData-1.2.5-202406-20260623.055437-2.pom`

The mismatch made `mavenCoordinates` fall back to the directory branch, producing shifted GAV coordinates (groupId swallowed artifactId, artifactId became the version directory, version became the file name) and breaking `ga:`/`gav:` metadata-rebuild enqueue on snapshot deletions.

## Change

Follows the maintainer-suggested shape: reuse the shared `MavenPathParser` as the primary source of asset coordinates and keep segment-based parsing only as a fallback for directory and metadata paths.

- `mavenCoordinates` now parses asset paths with `MavenPathParser` and returns `baseVersion()` (so timestamped and non-timestamped snapshots both resolve to `gav:<group>/<artifact>/<baseVersion>`), falling back to `mavenDirectoryOrMetadataCoordinates` when the path is a directory or `maven-metadata.xml`.
- Removed `looksLikeMavenAssetPath` (the second, partial Maven filename parser in the controller).

## Tests

Coverage matrix added to `BrowseContentDeleteControllerTest`:
- non-timestamped snapshot asset (existing test, `app-1.0-SNAPSHOT.jar`)
- timestamped snapshot asset (`app-1.0-20260623.055437-2.jar`)
- release asset (`app-1.0.jar`)
- release version-directory fallback (`com/acme/app/1.0`)
- snapshot version-directory fallback (`com/acme/app/1.0-SNAPSHOT`)

## Verification

`mvn -pl server -am test -Dtest=BrowseContentDeleteControllerTest` — 32 tests pass (0 failures).
