### PR TITLE
fix: parse Maven snapshot metadata in browse delete

### DIFF
--- a/server/src/main/java/com/github/klboke/kkrepo/server/browse/BrowseContentDeleteController.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/browse/BrowseContentDeleteController.java
@@ -804,7 +804,7 @@ public class BrowseContentDeleteController {
     if (target.type() != RepositoryType.HOSTED || target.format() != RepositoryFormat.MAVEN2) {
       return;
     }
-    MavenCoordinates coordinates = mavenCoordinates(storagePath);
+    MavenCoordinates coordinates = mavenCoordinates(target.id(), storagePath);
     if (coordinates == null) {
       return;
     }
@@ -855,7 +855,7 @@ public class BrowseContentDeleteController {
 
   private static final MavenPathParser MAVEN_PATH_PARSER = new MavenPathParser();
 
-  private MavenCoordinates mavenCoordinates(String path) {
+  private MavenCoordinates mavenCoordinates(long repositoryId, String path) {
     String normalized = isMavenHash(path)
         ? path.substring(0, path.lastIndexOf('.'))
         : path;
@@ -864,10 +864,10 @@ public class BrowseContentDeleteController {
       return new MavenCoordinates(
           coordinates.groupId(), coordinates.artifactId(), coordinates.baseVersion());
     }
-    return mavenDirectoryOrMetadataCoordinates(normalized);
+    return mavenDirectoryOrMetadataCoordinates(repositoryId, normalized);
   }
 
-  private MavenCoordinates mavenDirectoryOrMetadataCoordinates(String path) {
+  private MavenCoordinates mavenDirectoryOrMetadataCoordinates(long repositoryId, String path) {
     String[] segments = path.split("/");
     if (segments.length < 3) {
       return null;
@@ -879,7 +879,22 @@ public class BrowseContentDeleteController {
       if (groupSegments.isEmpty()) {
         return null;
       }
-      return new MavenCoordinates(String.join(".", groupSegments), artifactId, "");
+      MavenCoordinates gaCoordinates =
+          new MavenCoordinates(String.join(".", groupSegments), artifactId, "");
+      // A V-level metadata path can also look like A-level metadata when the artifactId itself
+      // ends with SNAPSHOT. Preserve an existing GA; otherwise follow Maven's snapshot directory
+      // layout and treat the parent segment as the base version.
+      if (segments.length >= 4
+          && artifactId.endsWith("SNAPSHOT")
+          && componentDao.listByGa(
+                  repositoryId, gaCoordinates.groupId(), gaCoordinates.artifactId())
+              .isEmpty()) {
+        String version = artifactId;
+        artifactId = segments[segments.length - 3];
+        groupSegments = List.of(segments).subList(0, segments.length - 3);
+        return new MavenCoordinates(String.join(".", groupSegments), artifactId, version);
+      }
+      return gaCoordinates;
     }
     String version = segments[segments.length - 1];
     String artifactId = segments[segments.length - 2];

--- a/server/src/test/java/com/github/klboke/kkrepo/server/browse/BrowseContentDeleteControllerTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/browse/BrowseContentDeleteControllerTest.java
@@ -483,6 +483,91 @@ class BrowseContentDeleteControllerTest {
   }
 
   @Test
+  void deletesMavenSnapshotMetadataAndEnqueuesGaGavRebuilds() {
+    Fixture fixture = fixture(true, AccessDecision.allow());
+    RepositoryRecord repository =
+        repository(1L, "maven", RepositoryFormat.MAVEN2, RepositoryType.HOSTED);
+    String path = "com/acme/app/1.0-SNAPSHOT/maven-metadata.xml";
+    AssetRecord metadata =
+        asset(11L, null, 31L, RepositoryFormat.MAVEN2, path, "metadata", Map.of());
+    AssetRecord sha1 = asset(
+        12L, null, 32L, RepositoryFormat.MAVEN2, path + ".sha1", "checksum", Map.of());
+    when(fixture.repositoryDao.findByName("maven")).thenReturn(Optional.of(repository));
+    when(fixture.assetDao.findAssetByPath(1L, path)).thenReturn(Optional.of(metadata));
+    when(fixture.assetDao.findAssetByPath(1L, path + ".sha1")).thenReturn(Optional.of(sha1));
+    when(fixture.assetDao.listAssetsByPrefix(1L, path + "/")).thenReturn(List.of());
+    when(fixture.componentDao.listByGa(1L, "com.acme.app", "1.0-SNAPSHOT"))
+        .thenReturn(List.of());
+
+    BrowseContentDeleteController.BrowseDeleteResult result = fixture.controller.delete(
+        "maven", "/" + path, null, new MockHttpServletRequest());
+
+    assertEquals(2, result.deletedAssets());
+    verify(fixture.assetDao).deleteAssetById(11L);
+    verify(fixture.assetDao).deleteAssetById(12L);
+    verify(fixture.metadataRebuildDao).enqueue(1L, "ga:com.acme/app");
+    verify(fixture.metadataRebuildDao).enqueue(1L, "gav:com.acme/app/1.0-SNAPSHOT");
+    verify(fixture.metadataRebuildDao, never())
+        .enqueue(1L, "ga:com.acme.app/1.0-SNAPSHOT");
+  }
+
+  @Test
+  void keepsArtifactLevelMavenMetadataWhenArtifactIdEndsWithSnapshot() {
+    Fixture fixture = fixture(true, AccessDecision.allow());
+    RepositoryRecord repository =
+        repository(1L, "maven", RepositoryFormat.MAVEN2, RepositoryType.HOSTED);
+    String path = "com/acme/app-SNAPSHOT/maven-metadata.xml";
+    AssetRecord metadata =
+        asset(11L, null, 31L, RepositoryFormat.MAVEN2, path, "metadata", Map.of());
+    ComponentRecord component = new ComponentRecord(
+        21L, repository.id(), RepositoryFormat.MAVEN2, "com.acme", "app-SNAPSHOT", "1.0",
+        "maven", new byte[] {1}, Map.of(), Instant.EPOCH);
+    when(fixture.repositoryDao.findByName("maven")).thenReturn(Optional.of(repository));
+    when(fixture.assetDao.findAssetByPath(1L, path)).thenReturn(Optional.of(metadata));
+    when(fixture.assetDao.listAssetsByPrefix(1L, path + "/")).thenReturn(List.of());
+    when(fixture.componentDao.listByGa(1L, "com.acme", "app-SNAPSHOT"))
+        .thenReturn(List.of(component));
+
+    BrowseContentDeleteController.BrowseDeleteResult result = fixture.controller.delete(
+        "maven", "/" + path, null, new MockHttpServletRequest());
+
+    assertEquals(1, result.deletedAssets());
+    verify(fixture.metadataRebuildDao).enqueue(1L, "ga:com.acme/app-SNAPSHOT");
+    verify(fixture.metadataRebuildDao, never()).enqueue(eq(1L), startsWith("gav:"));
+  }
+
+  @Test
+  void keepsArtifactLevelMavenMetadataAtDifferentGroupDepths() {
+    Fixture fixture = fixture(true, AccessDecision.allow());
+    RepositoryRecord repository =
+        repository(1L, "maven", RepositoryFormat.MAVEN2, RepositoryType.HOSTED);
+    String nestedGroupPath = "com/acme/app/maven-metadata.xml";
+    String singleGroupPath = "com/app/maven-metadata.xml";
+    AssetRecord nestedGroupMetadata = asset(
+        11L, null, 31L, RepositoryFormat.MAVEN2, nestedGroupPath, "metadata", Map.of());
+    AssetRecord singleGroupMetadata = asset(
+        12L, null, 32L, RepositoryFormat.MAVEN2, singleGroupPath, "metadata", Map.of());
+    when(fixture.repositoryDao.findByName("maven")).thenReturn(Optional.of(repository));
+    when(fixture.assetDao.findAssetByPath(1L, nestedGroupPath))
+        .thenReturn(Optional.of(nestedGroupMetadata));
+    when(fixture.assetDao.findAssetByPath(1L, singleGroupPath))
+        .thenReturn(Optional.of(singleGroupMetadata));
+    when(fixture.assetDao.listAssetsByPrefix(1L, nestedGroupPath + "/"))
+        .thenReturn(List.of());
+    when(fixture.assetDao.listAssetsByPrefix(1L, singleGroupPath + "/"))
+        .thenReturn(List.of());
+
+    assertEquals(1, fixture.controller.delete(
+        "maven", "/" + nestedGroupPath, null, new MockHttpServletRequest()).deletedAssets());
+    assertEquals(1, fixture.controller.delete(
+        "maven", "/" + singleGroupPath, null, new MockHttpServletRequest()).deletedAssets());
+
+    verify(fixture.metadataRebuildDao).enqueue(1L, "ga:com.acme/app");
+    verify(fixture.metadataRebuildDao).enqueue(1L, "ga:com/app");
+    verify(fixture.metadataRebuildDao, never()).enqueue(eq(1L), startsWith("gav:"));
+  }
+
+  @Test
   void deletesReleaseMavenAssetAndEnqueuesGaRebuild() {
     Fixture fixture = fixture(true, AccessDecision.allow());
     RepositoryRecord repository =


### PR DESCRIPTION
## Problem

As a follow-up to #241, browse deletion still parsed every `maven-metadata.xml` path as artifact-level (GA) metadata. A version-level snapshot path such as:

```text
com/acme/app/1.0-SNAPSHOT/maven-metadata.xml
```

was therefore shifted to `ga:com.acme.app/1.0-SNAPSHOT` instead of enqueueing rebuilds for `com.acme:app:1.0-SNAPSHOT`.

Maven defines version-level metadata under the snapshot base-version directory: https://maven.apache.org/repositories/metadata.html

## Change

- Parse snapshot version-level metadata as `groupId/artifactId/baseVersion`.
- Enqueue both `ga:com.acme/app` and `gav:com.acme/app/1.0-SNAPSHOT` after browse deletion.
- Preserve artifact-level metadata when an existing artifactId itself ends with `SNAPSHOT`, because Maven repository paths can be structurally ambiguous.
- Pass the repository id into the fallback coordinate resolver so it can perform that disambiguation.

## Tests

Added regression coverage for:

- snapshot version-level metadata and its checksum sibling;
- artifact-level metadata whose artifactId ends with `SNAPSHOT`;
- artifact-level metadata with single- and multi-segment groupIds.

```text
mvn -pl server -am -Dtest=BrowseContentDeleteControllerTest -Dsurefire.failIfNoSpecifiedTests=false test
```

35 tests pass with 0 failures. A local JaCoCo report shows all branches added to the metadata coordinate condition are covered.
