### PR TITLE
refactor: introduce repository protocol routing SPI

### DIFF
--- a/docs/en/architecture.md
+++ b/docs/en/architecture.md
@@ -49,9 +49,10 @@ The second shape is used on repository-level Docker connector ports, where the l
 
 The server flow is:
 
-1. `RepositoryContentController` resolves `<repo>` from shared relational repository metadata.
-2. Security filters authenticate the subject and check repository permissions.
-3. The server dispatches to the protocol implementation based on repository format and type.
+1. Security filters authenticate the subject, normalize the repository path, and check permissions.
+2. `RepositoryProtocolController` forwards the authenticated request to the protocol dispatcher.
+3. The dispatcher resolves `<repo>` from shared relational metadata and selects a
+   `RepositoryProtocolHandler` route by format, type, HTTP method, and normalized path.
 4. Hosted repositories read/write assets and metadata through relational transactions and blob storage.
 5. Proxy repositories fetch upstream content, persist cacheable assets, and use negative cache where safe.
 6. Group repositories resolve members in configured order and cache rebuildable member-hit decisions.
@@ -96,9 +97,19 @@ Admin UI and Browse UI are served by the Spring Boot service as static assets:
 | `browse-ui` | Static repository browser resources |
 | `compat-test` | Black-box and protocol compatibility tests |
 
-Protocol logic should live in services and protocol modules, not in controllers.
+Protocol logic should live in services and protocol modules, not in controllers. Exact and prefix
+routes take precedence over catch-all routes; equal-priority conflicting registrations fail closed.
+The built-in catch-all handler preserves existing behavior while runtime services are moved
+incrementally into their protocol modules or dedicated `protocol-*-runtime` modules. ArchUnit tests
+keep controllers on the routing SPI and prevent protocol modules from referencing `server`.
 
 ## Data Ownership
+
+Large JDBC facades keep their stable API contract but delegate independent responsibilities to
+focused package-private collaborators. Security-scan repository scoping, operational summaries,
+and retention/blob-reference cleanup are separate from the command facade; new independent
+security-scan persistence responsibilities should follow that boundary instead of growing the
+facade again.
 
 The selected relational database stores:
 

--- a/docs/en/dev/docker-repository-implementation-plan.md
+++ b/docs/en/dev/docker-repository-implementation-plan.md
@@ -77,7 +77,7 @@ Key conclusions:
 
 ## URL And Routing Design
 
-Add `DockerRegistryController`. Do not attach it under the existing `RepositoryContentController` `/repository/{name}` route.
+Add `DockerRegistryController`. Do not attach it under the existing `RepositoryProtocolController` `/repository/{name}` route.
 
 ## Docker Traffic Port Design
 

--- a/docs/zh/architecture.md
+++ b/docs/zh/architecture.md
@@ -49,9 +49,10 @@ Docker / OCI 客户端使用 Registry HTTP API V2 路由：
 
 服务端流程：
 
-1. `RepositoryContentController` 从共享关系数据库中的仓库元数据解析 `<repo>`。
-2. 安全过滤器完成 subject 认证并校验仓库权限。
-3. 服务端根据仓库 format 和 type 分发到协议实现。
+1. 安全过滤器完成 subject 认证、仓库路径规范化和权限校验。
+2. `RepositoryProtocolController` 将已鉴权请求交给协议分派器。
+3. 分派器从共享关系数据库元数据解析 `<repo>`，并按 format、type、HTTP method 和规范化路径选择
+   `RepositoryProtocolHandler` route。
 4. hosted 仓库通过关系数据库事务和 blob storage 读写 asset 与 metadata。
 5. proxy 仓库拉取上游内容，持久化可缓存 asset，并在安全条件下使用 negative cache。
 6. group 仓库按配置顺序解析 member，并缓存可重建的 member 命中结果。
@@ -96,9 +97,16 @@ Admin UI 和 Browse UI 由 Spring Boot 服务提供静态资源：
 | `browse-ui` | 用户侧仓库浏览器静态资源 |
 | `compat-test` | 黑盒和协议兼容性测试 |
 
-协议逻辑应位于 service 和 protocol 模块中，不应堆在 controller 里。
+协议逻辑应位于 service 和 protocol 模块中，不应堆在 controller 里。精确路径和前缀 route
+优先于兜底 route；相同优先级的冲突注册会直接失败。内置兜底 handler 在协议运行时服务逐步迁移到
+对应 protocol 模块或独立 `protocol-*-runtime` 模块期间保持现有行为。ArchUnit 测试保证 controller
+只依赖 routing SPI，并禁止 protocol 模块反向引用 `server`。
 
 ## 数据归属
+
+大型 JDBC facade 保持稳定的 API 契约，但会把独立职责委托给聚焦的 package-private collaborator。
+安全扫描的仓库范围构造、运维汇总，以及 retention/blob 引用清理已与命令 facade 分离；后续独立的
+安全扫描持久化职责应继续沿用该边界，避免 facade 再次膨胀。
 
 所选关系数据库存储：
 

--- a/docs/zh/dev/docker-repository-implementation-plan.md
+++ b/docs/zh/dev/docker-repository-implementation-plan.md
@@ -77,7 +77,7 @@ Docker Registry V1 API 和 `docker search` 不属于当前支持面。现代 Doc
 
 ## URL 与路由设计
 
-新增 `DockerRegistryController`，不要挂到现有 `RepositoryContentController` 的 `/repository/{name}` 下。
+新增 `DockerRegistryController`，不要挂到现有 `RepositoryProtocolController` 的 `/repository/{name}` 下。
 
 ## Docker 流量端口设计
 

--- a/docs/zh/dev/swift-package-registry-design.md
+++ b/docs/zh/dev/swift-package-registry-design.md
@@ -228,7 +228,7 @@ swift package-registry login \
 
 ## Hosted 发布流程
 
-`RepositoryContentController` 只读取 HTTP method/path/header 和认证上下文，再委托 `SwiftHostedService`。Multipart、ZIP、manifest、metadata 和签名解析位于 `protocol-swift` / hosted service，不进入 controller。
+`RepositoryProtocolController` 只读取 HTTP method/path/header 和认证上下文，再委托 `SwiftHostedService`。Multipart、ZIP、manifest、metadata 和签名解析位于 `protocol-swift` / hosted service，不进入 controller。
 
 同步 publish 流程：
 

--- a/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/JdbcSecurityScanDao.java
+++ b/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/JdbcSecurityScanDao.java
@@ -14,7 +14,6 @@ import com.github.klboke.kkrepo.persistence.jdbc.internal.support.EnumColumns;
 import com.github.klboke.kkrepo.persistence.jdbc.internal.support.JdbcInserts;
 import com.github.klboke.kkrepo.persistence.jdbc.internal.support.JsonColumns;
 import com.github.klboke.kkrepo.persistence.jdbc.spi.DatabaseDialect;
-import com.github.klboke.kkrepo.persistence.jdbc.spi.JsonPersistenceDialect;
 import com.github.klboke.kkrepo.security.scan.ScanEnums.BackfillStatus;
 import com.github.klboke.kkrepo.security.scan.ScanEnums.EnforcementMode;
 import com.github.klboke.kkrepo.security.scan.ScanEnums.OciPlatformPolicy;
@@ -84,7 +83,9 @@ public class JdbcSecurityScanDao implements SecurityScanDao {
 
   private final JdbcTemplate jdbc;
   private final BlobReferenceDao blobReferences;
-  private final JsonPersistenceDialect jsonDialect;
+  private final JdbcSecurityScanRepositoryScope repositoryScope;
+  private final JdbcSecurityScanRetentionDao retention;
+  private final JdbcSecurityScanSummaryDao summaries;
   // Row mappers are constructed before the constructor body and dereference this field only when
   // a query executes, after construction has completed.
   private JsonColumns json;
@@ -496,7 +497,9 @@ public class JdbcSecurityScanDao implements SecurityScanDao {
     this.jdbc = jdbc;
     this.json = json;
     this.blobReferences = new JdbcBlobReferenceDao(jdbc);
-    this.jsonDialect = databaseDialect.json();
+    this.repositoryScope = new JdbcSecurityScanRepositoryScope(json, databaseDialect.json());
+    this.retention = new JdbcSecurityScanRetentionDao(jdbc, blobReferences);
+    this.summaries = new JdbcSecurityScanSummaryDao(jdbc, repositoryScope);
   }
 
   @Override
@@ -552,10 +555,10 @@ public class JdbcSecurityScanDao implements SecurityScanDao {
 
   @Override
   public List<RepositoryScanConfig> findRepositoryConfigs(List<Long> repositoryIds) {
-    List<Long> ids = distinctLongs(repositoryIds);
+    List<Long> ids = repositoryScope.distinctLongs(repositoryIds);
     if (ids.isEmpty()) return List.of();
     return jdbc.query(
-        repositoryScopeCte() + """
+        repositoryScope.repositoryScopeCte() + """
         SELECT config.*
         FROM repository_security_scan_config config
         JOIN visible_repository visible
@@ -563,7 +566,7 @@ public class JdbcSecurityScanDao implements SecurityScanDao {
         ORDER BY config.repository_id
         """,
         configMapper,
-        repositoryScopeParameter(ids));
+        repositoryScope.parameter(ids));
   }
 
   @Override
@@ -663,7 +666,7 @@ public class JdbcSecurityScanDao implements SecurityScanDao {
   @Override
   public List<DownloadPolicySnapshot> findDownloadPolicySnapshots(
       List<Long> assetIds, Long entryRepositoryId) {
-    List<Long> ids = distinctLongs(assetIds).stream().filter(id -> id > 0).toList();
+    List<Long> ids = repositoryScope.distinctLongs(assetIds).stream().filter(id -> id > 0).toList();
     if (ids.isEmpty()) {
       return List.of();
     }
@@ -1276,7 +1279,7 @@ public class JdbcSecurityScanDao implements SecurityScanDao {
       String query,
       long afterId,
       int maxItems) {
-    List<Long> ids = distinctLongs(repositoryIds);
+    List<Long> ids = repositoryScope.distinctLongs(repositoryIds);
     if (ids.isEmpty()) return List.of();
     return listTasks(null, ids, status, query, afterId, maxItems);
   }
@@ -1291,8 +1294,8 @@ public class JdbcSecurityScanDao implements SecurityScanDao {
     List<Object> args = new ArrayList<>();
     StringBuilder sql = new StringBuilder();
     if (repositoryIds != null) {
-      sql.append(taskRepositoryScopeCte());
-      args.add(repositoryScopeParameter(repositoryIds));
+      sql.append(repositoryScope.taskRepositoryScopeCte());
+      args.add(repositoryScope.parameter(repositoryIds));
     }
     sql.append("""
         SELECT t.*
@@ -2190,7 +2193,7 @@ public class JdbcSecurityScanDao implements SecurityScanDao {
   @Override
   public List<ScanRun> listRunsByRepositories(
       List<Long> repositoryIds, String query, long afterId, int maxItems) {
-    List<Long> ids = distinctLongs(repositoryIds);
+    List<Long> ids = repositoryScope.distinctLongs(repositoryIds);
     if (ids.isEmpty()) return List.of();
     return listRuns(null, ids, query, afterId, maxItems);
   }
@@ -2204,8 +2207,8 @@ public class JdbcSecurityScanDao implements SecurityScanDao {
     StringBuilder sql = new StringBuilder();
     List<Object> args = new ArrayList<>();
     if (repositoryIds != null) {
-      sql.append(repositoryScopeCte());
-      args.add(repositoryScopeParameter(repositoryIds));
+      sql.append(repositoryScope.repositoryScopeCte());
+      args.add(repositoryScope.parameter(repositoryIds));
     }
     sql.append("""
         SELECT sr.*
@@ -2456,7 +2459,7 @@ public class JdbcSecurityScanDao implements SecurityScanDao {
       String query,
       long afterId,
       int maxItems) {
-    List<Long> ids = distinctLongs(repositoryIds);
+    List<Long> ids = repositoryScope.distinctLongs(repositoryIds);
     if (ids.isEmpty()) return List.of();
     return listFindings(null, ids, scanRunId, severity, query, afterId, maxItems);
   }
@@ -2472,8 +2475,8 @@ public class JdbcSecurityScanDao implements SecurityScanDao {
     StringBuilder sql = new StringBuilder();
     List<Object> args = new ArrayList<>();
     if (repositoryIds != null) {
-      sql.append(repositoryScopeCte());
-      args.add(repositoryScopeParameter(repositoryIds));
+      sql.append(repositoryScope.repositoryScopeCte());
+      args.add(repositoryScope.parameter(repositoryIds));
     }
     sql.append("""
         SELECT f.*
@@ -3430,8 +3433,8 @@ public class JdbcSecurityScanDao implements SecurityScanDao {
       List<String> packageSelectors,
       long afterId,
       int maxItems) {
-    List<Long> findings = distinctLongs(findingIds);
-    List<Long> runs = distinctLongs(scanRunIds);
+    List<Long> findings = repositoryScope.distinctLongs(findingIds);
+    List<Long> runs = repositoryScope.distinctLongs(scanRunIds);
     if (findings.isEmpty() || runs.isEmpty()) return List.of();
     List<String> advisories = distinctStrings(advisorySelectors, true);
     List<String> packages = distinctStrings(packageSelectors, false);
@@ -3641,287 +3644,7 @@ public class JdbcSecurityScanDao implements SecurityScanDao {
   @Transactional
   public RetentionResult cleanupRetainedData(
       Instant terminalTaskCutoff, Instant resultCutoff, int maxItems) {
-    int limit = safeLimit(maxItems);
-    int tasks = deleteTerminalTasks(terminalTaskCutoff, limit);
-    int backfills = deleteTerminalBackfills(terminalTaskCutoff, limit);
-    int subjects = deleteHistoricalRunSubjects(resultCutoff, limit);
-    int runs = deleteUnreferencedRuns(resultCutoff, limit);
-    int sboms = deleteUnreferencedSboms(resultCutoff, limit);
-    int snapshots = deleteUnreferencedSnapshots(resultCutoff, limit);
-    return new RetentionResult(tasks, backfills, subjects, runs, sboms, snapshots);
-  }
-
-  private int deleteTerminalTasks(Instant cutoff, int limit) {
-    List<Long> ids = jdbc.queryForList("""
-        SELECT id
-        FROM security_scan_task
-        WHERE status IN ('SUCCEEDED', 'FAILED', 'CANCELLED')
-          AND finished_at < ?
-        ORDER BY finished_at, id
-        LIMIT ?
-        FOR UPDATE SKIP LOCKED
-        """, Long.class, nullableTimestamp(cutoff), limit);
-    int deleted = 0;
-    for (Long id : ids) {
-      deleted += jdbc.update("""
-          DELETE FROM security_scan_task
-          WHERE id = ?
-            AND status IN ('SUCCEEDED', 'FAILED', 'CANCELLED')
-            AND finished_at < ?
-          """, id, nullableTimestamp(cutoff));
-    }
-    return deleted;
-  }
-
-  private int deleteTerminalBackfills(Instant cutoff, int limit) {
-    List<Long> ids = jdbc.queryForList("""
-        SELECT id
-        FROM security_scan_backfill_job
-        WHERE status IN ('SUCCEEDED', 'FAILED', 'CANCELLED')
-          AND completed_at < ?
-        ORDER BY completed_at, id
-        LIMIT ?
-        FOR UPDATE SKIP LOCKED
-        """, Long.class, nullableTimestamp(cutoff), limit);
-    int deleted = 0;
-    for (Long id : ids) {
-      deleted += jdbc.update("""
-          DELETE FROM security_scan_backfill_job
-          WHERE id = ?
-            AND status IN ('SUCCEEDED', 'FAILED', 'CANCELLED')
-            AND completed_at < ?
-          """, id, nullableTimestamp(cutoff));
-    }
-    return deleted;
-  }
-
-  private int deleteHistoricalRunSubjects(Instant cutoff, int limit) {
-    List<Map<String, Object>> rows = jdbc.queryForList("""
-        SELECT subject.scan_run_id, subject.repository_id, subject.asset_id,
-               subject.profile_id, subject.content_generation
-        FROM security_scan_run_subject subject
-        JOIN security_scan_run run ON run.id = subject.scan_run_id
-        WHERE subject.associated_at < ?
-          AND run.last_accessed_at < ?
-          AND NOT EXISTS (
-            SELECT 1
-            FROM asset_security_state asset_state
-            WHERE asset_state.latest_scan_run_id = subject.scan_run_id
-              AND asset_state.asset_id = subject.asset_id
-              AND asset_state.profile_id = subject.profile_id
-          )
-          AND NOT EXISTS (
-            SELECT 1
-            FROM asset_security_policy_state policy_state
-            WHERE policy_state.latest_scan_run_id = subject.scan_run_id
-              AND policy_state.asset_id = subject.asset_id
-              AND policy_state.profile_id = subject.profile_id
-              AND policy_state.repository_id = subject.repository_id
-          )
-          AND NOT EXISTS (
-            SELECT 1
-            FROM security_scan_waiver waiver
-            JOIN security_scan_finding finding ON finding.id = waiver.finding_id
-            WHERE finding.scan_run_id = subject.scan_run_id
-          )
-        ORDER BY subject.associated_at, subject.scan_run_id
-        LIMIT ?
-        FOR UPDATE SKIP LOCKED
-        """, nullableTimestamp(cutoff), nullableTimestamp(cutoff), limit);
-    int deleted = 0;
-    for (Map<String, Object> row : rows) {
-      deleted += jdbc.update("""
-          DELETE FROM security_scan_run_subject
-          WHERE scan_run_id = ? AND repository_id = ? AND asset_id = ?
-            AND profile_id = ? AND content_generation = ?
-          """,
-          number(row, "scan_run_id"),
-          number(row, "repository_id"),
-          number(row, "asset_id"),
-          number(row, "profile_id"),
-          number(row, "content_generation"));
-    }
-    return deleted;
-  }
-
-  private int deleteUnreferencedRuns(Instant cutoff, int limit) {
-    List<Map<String, Object>> rows = jdbc.queryForList("""
-        SELECT run.id, run.raw_report_blob_id
-        FROM security_scan_run run
-        WHERE run.completed_at < ?
-          AND run.last_accessed_at < ?
-          AND NOT EXISTS (
-            SELECT 1 FROM security_scan_run_subject subject
-            WHERE subject.scan_run_id = run.id
-          )
-          AND NOT EXISTS (
-            SELECT 1 FROM asset_security_state asset_state
-            WHERE asset_state.latest_scan_run_id = run.id
-          )
-          AND NOT EXISTS (
-            SELECT 1 FROM asset_security_policy_state policy_state
-            WHERE policy_state.latest_scan_run_id = run.id
-          )
-          AND NOT EXISTS (
-            SELECT 1
-            FROM security_scan_waiver waiver
-            JOIN security_scan_finding finding ON finding.id = waiver.finding_id
-            WHERE finding.scan_run_id = run.id
-          )
-        ORDER BY run.last_accessed_at, run.id
-        LIMIT ?
-        FOR UPDATE SKIP LOCKED
-        """, nullableTimestamp(cutoff), nullableTimestamp(cutoff), limit);
-    int deleted = 0;
-    for (Map<String, Object> row : rows) {
-      long runId = number(row, "id");
-      long blobId = number(row, "raw_report_blob_id");
-      blobReferences.release(SCAN_REPORT_BLOB_OWNER, runId, blobId);
-      deleted += jdbc.update("DELETE FROM security_scan_run WHERE id = ?", runId);
-    }
-    return deleted;
-  }
-
-  private int deleteUnreferencedSboms(Instant cutoff, int limit) {
-    List<Map<String, Object>> rows = jdbc.queryForList("""
-        SELECT sbom.id, sbom.document_blob_id
-        FROM security_sbom sbom
-        WHERE sbom.created_at < ?
-          AND sbom.last_accessed_at < ?
-          AND NOT EXISTS (
-            SELECT 1 FROM security_scan_run run WHERE run.sbom_id = sbom.id
-          )
-        ORDER BY sbom.last_accessed_at, sbom.id
-        LIMIT ?
-        FOR UPDATE SKIP LOCKED
-        """, nullableTimestamp(cutoff), nullableTimestamp(cutoff), limit);
-    int deleted = 0;
-    for (Map<String, Object> row : rows) {
-      long sbomId = number(row, "id");
-      long blobId = number(row, "document_blob_id");
-      blobReferences.release(SBOM_BLOB_OWNER, sbomId, blobId);
-      deleted += jdbc.update("DELETE FROM security_sbom WHERE id = ?", sbomId);
-    }
-    return deleted;
-  }
-
-  private int deleteUnreferencedSnapshots(Instant cutoff, int limit) {
-    List<Long> ids = jdbc.queryForList("""
-        SELECT snapshot.id
-        FROM security_scanner_snapshot snapshot
-        WHERE snapshot.observed_at < ?
-          AND NOT EXISTS (
-            SELECT 1 FROM security_scan_run run
-            WHERE run.scanner_snapshot_id = snapshot.id
-          )
-          AND NOT EXISTS (
-            SELECT 1 FROM security_scan_task task
-            WHERE task.requested_scanner_snapshot_id = snapshot.id
-          )
-        ORDER BY snapshot.observed_at, snapshot.id
-        LIMIT ?
-        FOR UPDATE SKIP LOCKED
-        """, Long.class, nullableTimestamp(cutoff), limit);
-    int deleted = 0;
-    for (Long id : ids) {
-      deleted += jdbc.update(
-          "DELETE FROM security_scanner_snapshot WHERE id = ?", id);
-    }
-    return deleted;
-  }
-
-  private static long number(Map<String, Object> row, String column) {
-    return ((Number) row.get(column)).longValue();
-  }
-
-  private static List<Long> distinctLongs(List<Long> values) {
-    return values == null
-        ? List.of()
-        : values.stream()
-            .filter(java.util.Objects::nonNull)
-            .distinct()
-            .toList();
-  }
-
-  /**
-   * Materializes an authorization-filtered repository scope from one JSON bind value. This avoids
-   * both one query per repository and database parameter-limit failures for large installations.
-   */
-  private String repositoryScopeCte() {
-    return """
-        WITH visible_repository AS (
-        %s
-        )
-        """.formatted(jsonDialect.selectLongsFromArray("repository_id"));
-  }
-
-  private String recursiveRepositoryScopeCte() {
-    return """
-        WITH RECURSIVE visible_repository AS (
-        %s
-        )
-        """.formatted(jsonDialect.selectLongsFromArray("repository_id"));
-  }
-
-  /**
-   * Expands visible group policy contexts to their concrete source repositories while retaining
-   * direct repository visibility as an unrestricted task scope.
-   */
-  private String taskRepositoryScopeCte() {
-    return recursiveRepositoryScopeCte() + """
-        ,
-        task_policy_source(
-          context_repository_id,
-          source_repository_id,
-          profile_id,
-          scan_hosted_content,
-          scan_proxy_content
-        ) AS (
-          SELECT
-            config.repository_id,
-            config.repository_id,
-            config.profile_id,
-            config.scan_hosted_content,
-            config.scan_proxy_content
-          FROM repository_security_scan_config config
-          JOIN visible_repository visible
-            ON visible.repository_id = config.repository_id
-          WHERE config.enabled = TRUE
-          UNION
-          SELECT
-            context.context_repository_id,
-            member.member_repository_id,
-            context.profile_id,
-            context.scan_hosted_content,
-            context.scan_proxy_content
-          FROM task_policy_source context
-          JOIN repository_member member
-            ON member.repository_id = context.source_repository_id
-        ),
-        task_repository_scope(
-          source_repository_id,
-          profile_id,
-          scan_hosted_content,
-          scan_proxy_content,
-          directly_visible
-        ) AS (
-          SELECT repository_id, NULL, FALSE, FALSE, TRUE
-          FROM visible_repository
-          UNION
-          SELECT
-            source_repository_id,
-            profile_id,
-            scan_hosted_content,
-            scan_proxy_content,
-            FALSE
-          FROM task_policy_source
-          WHERE context_repository_id <> source_repository_id
-        )
-        """;
-  }
-
-  private Object repositoryScopeParameter(List<Long> repositoryIds) {
-    return json.serializedParameter(json.writeValue(distinctLongs(repositoryIds)));
+    return retention.cleanupRetainedData(terminalTaskCutoff, resultCutoff, maxItems);
   }
 
   private static List<String> distinctStrings(List<String> values, boolean lowercase) {
@@ -3944,346 +3667,27 @@ public class JdbcSecurityScanDao implements SecurityScanDao {
 
   @Override
   public ScanSummary summary() {
-    return summary(jdbc.queryForList("SELECT id FROM repository", Long.class));
+    return summaries.summary();
   }
 
   @Override
   public ScanSummary summary(long repositoryId) {
-    return summary(List.of(repositoryId));
+    return summaries.summary(repositoryId);
   }
 
   @Override
   public ScanSummary summary(List<Long> repositoryIds) {
-    List<Long> ids = repositoryIds == null
-        ? List.of()
-        : repositoryIds.stream()
-            .filter(java.util.Objects::nonNull)
-            .distinct()
-            .toList();
-    if (ids.isEmpty()) {
-      return new ScanSummary(0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    }
-    Object repositoryScope = repositoryScopeParameter(ids);
-    long candidates = count(taskRepositoryScopeCte() + """
-        SELECT COUNT(*)
-        FROM security_scan_candidate candidate
-        JOIN asset asset ON asset.id = candidate.asset_id
-        WHERE candidate.pending = TRUE
-          AND EXISTS (
-            SELECT 1
-            FROM task_repository_scope scope
-            JOIN repository source_repository
-              ON source_repository.id = scope.source_repository_id
-            WHERE scope.source_repository_id = asset.repository_id
-              AND (
-                scope.directly_visible = TRUE
-                OR (
-                  (
-                    source_repository.type = 'hosted'
-                    AND scope.scan_hosted_content = TRUE
-                  )
-                  OR (
-                    source_repository.type = 'proxy'
-                    AND scope.scan_proxy_content = TRUE
-                  )
-                )
-              )
-          )
-        """, repositoryScope);
-    Map<String, Object> tasks = jdbc.queryForMap(taskRepositoryScopeCte() + """
-        SELECT
-          COALESCE(SUM(CASE
-            WHEN task.status IN ('PENDING', 'RETRY_WAIT') THEN 1 ELSE 0 END), 0)
-            AS pending_tasks,
-          COALESCE(SUM(CASE
-            WHEN task.status = 'RUNNING' THEN 1 ELSE 0 END), 0)
-            AS running_tasks,
-          COALESCE(SUM(CASE
-            WHEN task.status = 'FAILED' THEN 1 ELSE 0 END), 0)
-            AS failed_tasks
-        FROM security_scan_task task
-        WHERE task.status IN ('PENDING', 'RETRY_WAIT', 'RUNNING', 'FAILED')
-          AND EXISTS (
-            SELECT 1
-            FROM task_repository_scope scope
-            JOIN repository source_repository
-              ON source_repository.id = scope.source_repository_id
-            WHERE scope.source_repository_id = task.repository_id
-              AND (
-                scope.directly_visible = TRUE
-                OR (
-                  scope.profile_id = task.profile_id
-                  AND (
-                    (
-                      source_repository.type = 'hosted'
-                      AND scope.scan_hosted_content = TRUE
-                    )
-                    OR (
-                      source_repository.type = 'proxy'
-                      AND scope.scan_proxy_content = TRUE
-                    )
-                  )
-                )
-              )
-          )
-        """, repositoryScope);
-    Instant summaryAt = Instant.now();
-    Map<String, Object> states = jdbc.queryForMap(
-        recursiveRepositoryScopeCte() + """
-        ,
-        policy_context_source(context_repository_id, source_repository_id) AS (
-          SELECT config.repository_id, config.repository_id
-          FROM repository_security_scan_config config
-          JOIN visible_repository visible
-            ON visible.repository_id = config.repository_id
-          WHERE config.enabled = TRUE
-          UNION
-          SELECT context.context_repository_id, member.member_repository_id
-          FROM policy_context_source context
-          JOIN repository_member member
-            ON member.repository_id = context.source_repository_id
-        ),
-        policy_subject(context_repository_id, source_repository_id, asset_id) AS (
-          SELECT context.context_repository_id, state.repository_id, state.asset_id
-          FROM policy_context_source context
-          JOIN asset_security_state state
-            ON state.repository_id = context.source_repository_id
-          UNION
-          SELECT context.context_repository_id, asset.repository_id, candidate.asset_id
-          FROM policy_context_source context
-          JOIN asset asset
-            ON asset.repository_id = context.source_repository_id
-          JOIN security_scan_candidate candidate
-            ON candidate.asset_id = asset.id
-        ),
-        policy_snapshot AS (
-          SELECT
-            subject.asset_id,
-            state.asset_id AS state_asset_id,
-            candidate.asset_id AS candidate_asset_id,
-            candidate.content_generation AS candidate_content_generation,
-            state.content_generation AS state_content_generation,
-            state.scan_state,
-            profile.id AS profile_id,
-            profile.enabled AS profile_enabled,
-            config.pending_action,
-            config.failure_action,
-            policy_state.policy_decision,
-            CASE
-              WHEN policy_state.asset_id IS NOT NULL
-               AND candidate.asset_id IS NOT NULL
-               AND state.asset_id IS NOT NULL
-               AND state.scan_state IN ('PARTIAL', 'COMPLETE')
-               AND state.content_generation = candidate.content_generation
-               AND policy_state.content_generation = candidate.content_generation
-               AND (
-                 policy_state.latest_scan_run_id = state.latest_scan_run_id
-                 OR (
-                   policy_state.latest_scan_run_id IS NULL
-                   AND state.latest_scan_run_id IS NULL
-                 )
-               )
-               AND policy_state.config_revision = config.config_revision
-               AND policy_state.waiver_revision
-                   >= waiver_revision.global_invalidation_revision
-               AND (
-                 (
-                   config.policy_id IS NULL
-                   AND policy_state.policy_id IS NULL
-                   AND policy_state.policy_revision IS NULL
-                 )
-                 OR (
-                   config.policy_id IS NOT NULL
-                   AND current_policy.id IS NOT NULL
-                   AND policy_state.policy_id = current_policy.id
-                   AND policy_state.policy_revision = current_policy.revision
-                 )
-               )
-               AND (
-                 policy_state.stale_at IS NULL
-                 OR policy_state.stale_at > ?
-               )
-               AND (
-                 policy_state.next_waiver_expiry IS NULL
-                 OR policy_state.next_waiver_expiry > ?
-               )
-              THEN TRUE
-              ELSE FALSE
-            END AS policy_authoritative
-          FROM policy_subject subject
-          JOIN repository_security_scan_config config
-            ON config.repository_id = subject.context_repository_id
-           AND config.enabled = TRUE
-          JOIN repository source_repository
-            ON source_repository.id = subject.source_repository_id
-          JOIN security_scan_waiver_revision waiver_revision
-            ON waiver_revision.singleton_id = 1
-          LEFT JOIN security_scan_candidate candidate
-            ON candidate.asset_id = subject.asset_id
-          LEFT JOIN asset_security_state state
-            ON state.asset_id = subject.asset_id
-           AND state.profile_id = config.profile_id
-          LEFT JOIN security_scan_profile profile
-            ON profile.id = config.profile_id
-          LEFT JOIN security_scan_policy current_policy
-            ON current_policy.id = config.policy_id
-          LEFT JOIN asset_security_policy_state policy_state
-            ON policy_state.asset_id = subject.asset_id
-           AND policy_state.profile_id = config.profile_id
-           AND policy_state.repository_id = config.repository_id
-          WHERE (
-            (source_repository.type = 'hosted' AND config.scan_hosted_content = TRUE)
-            OR (source_repository.type = 'proxy' AND config.scan_proxy_content = TRUE)
-          )
-        )
-        SELECT
-          COUNT(DISTINCT CASE
-            WHEN scan_state = 'COMPLETE'
-             AND state_content_generation = candidate_content_generation
-              THEN asset_id END)
-            AS complete_assets,
-          COUNT(DISTINCT CASE
-            WHEN scan_state = 'PARTIAL'
-             AND state_content_generation = candidate_content_generation
-              THEN asset_id END)
-            AS partial_assets,
-          COUNT(DISTINCT CASE
-            WHEN scan_state = 'STALE'
-             AND state_content_generation = candidate_content_generation
-              THEN asset_id END)
-            AS stale_assets,
-          COUNT(DISTINCT CASE
-            WHEN profile_id IS NULL OR profile_enabled = FALSE
-              THEN CASE WHEN failure_action = 'BLOCK' THEN asset_id END
-            WHEN state_asset_id IS NULL
-              OR candidate_asset_id IS NULL
-              OR state_content_generation <> candidate_content_generation
-              THEN CASE WHEN pending_action = 'BLOCK' THEN asset_id END
-            WHEN scan_state = 'NOT_APPLICABLE' THEN NULL
-            WHEN scan_state IN ('PENDING', 'RUNNING', 'STALE')
-              THEN CASE WHEN pending_action = 'BLOCK' THEN asset_id END
-            WHEN scan_state IN ('FAILED', 'CANCELLED')
-              THEN CASE WHEN failure_action = 'BLOCK' THEN asset_id END
-            WHEN scan_state IN ('PARTIAL', 'COMPLETE')
-              AND policy_authoritative = TRUE
-              AND policy_decision <> 'ALLOW'
-              THEN asset_id
-            WHEN scan_state IN ('PARTIAL', 'COMPLETE')
-              AND policy_authoritative = FALSE
-              THEN CASE WHEN pending_action = 'BLOCK' THEN asset_id END
-            ELSE NULL
-          END)
-            AS blocked_assets
-        FROM policy_snapshot
-        """,
-        repositoryScope,
-        nullableTimestamp(summaryAt),
-        nullableTimestamp(summaryAt));
-    Map<String, Object> findings = jdbc.queryForMap(repositoryScopeCte() + """
-        , current_run AS (
-          SELECT DISTINCT state.latest_scan_run_id AS scan_run_id
-          FROM asset_security_state state
-          JOIN security_scan_candidate candidate
-            ON candidate.asset_id = state.asset_id
-           AND candidate.content_generation = state.content_generation
-          JOIN security_scan_run_subject subject
-            ON subject.scan_run_id = state.latest_scan_run_id
-           AND subject.asset_id = state.asset_id
-           AND subject.profile_id = state.profile_id
-           AND subject.content_generation = state.content_generation
-          JOIN visible_repository visible
-            ON visible.repository_id = subject.repository_id
-          WHERE state.latest_scan_run_id IS NOT NULL
-        )
-        SELECT
-          COALESCE(SUM(CASE WHEN finding.severity = 'CRITICAL' THEN 1 ELSE 0 END), 0)
-            AS critical_findings,
-          COALESCE(SUM(CASE WHEN finding.severity = 'HIGH' THEN 1 ELSE 0 END), 0)
-            AS high_findings
-        FROM current_run
-        JOIN security_scan_finding finding
-          ON finding.scan_run_id = current_run.scan_run_id
-        WHERE finding.severity IN ('CRITICAL', 'HIGH')
-        """, repositoryScope);
-    return new ScanSummary(
-        candidates,
-        number(tasks, "pending_tasks"),
-        number(tasks, "running_tasks"),
-        number(tasks, "failed_tasks"),
-        number(states, "complete_assets"),
-        number(states, "partial_assets"),
-        number(states, "stale_assets"),
-        number(states, "blocked_assets"),
-        number(findings, "critical_findings"),
-        number(findings, "high_findings"));
+    return summaries.summary(repositoryIds);
   }
 
   @Override
   public ScanMetricSummary metricSummary(int maxCount) {
-    int limit = Math.max(1, Math.min(1_000_000, maxCount));
-    return new ScanMetricSummary(
-        boundedCount("""
-            SELECT id FROM security_scan_task
-            WHERE status IN ('PENDING', 'RETRY_WAIT')
-            """, limit),
-        boundedCount("""
-            SELECT id FROM security_scan_task
-            WHERE status = 'RUNNING'
-            """, limit),
-        boundedCount("""
-            SELECT id FROM security_scan_task
-            WHERE status = 'FAILED'
-            """, limit),
-        boundedCount("""
-            SELECT state.asset_id
-            FROM asset_security_state state
-            JOIN security_scan_candidate candidate
-              ON candidate.asset_id = state.asset_id
-             AND candidate.content_generation = state.content_generation
-            WHERE state.scan_state = 'PARTIAL'
-            """, limit),
-        boundedCount("""
-            SELECT finding.id
-            FROM (
-              SELECT DISTINCT state.latest_scan_run_id AS scan_run_id
-              FROM asset_security_state state
-              JOIN security_scan_candidate candidate
-                ON candidate.asset_id = state.asset_id
-               AND candidate.content_generation = state.content_generation
-              WHERE state.latest_scan_run_id IS NOT NULL
-            ) current_run
-            JOIN security_scan_finding finding
-              ON finding.scan_run_id = current_run.scan_run_id
-             AND finding.severity IN ('CRITICAL', 'HIGH')
-            """, limit));
+    return summaries.metricSummary(maxCount);
   }
 
   @Override
   public Optional<Instant> oldestPendingTaskCreatedAt() {
-    List<Instant> values = jdbc.query("""
-        SELECT created_at AS oldest_created_at
-        FROM security_scan_task
-        WHERE status IN ('PENDING','RETRY_WAIT')
-        ORDER BY created_at, id
-        LIMIT 1
-        """, (rs, rowNum) -> nullableInstant(rs, "oldest_created_at"));
-    return values.isEmpty() ? Optional.empty() : Optional.ofNullable(values.getFirst());
-  }
-
-  private long count(String sql) {
-    Long value = jdbc.queryForObject(sql, Long.class);
-    return value == null ? 0 : value;
-  }
-
-  private long count(String sql, Object... args) {
-    Long value = jdbc.queryForObject(sql, Long.class, args);
-    return value == null ? 0 : value;
-  }
-
-  private long boundedCount(String selectionSql, int limit) {
-    return count(
-        "SELECT COUNT(*) FROM (" + selectionSql + " LIMIT ?) bounded_count",
-        limit);
+    return summaries.oldestPendingTaskCreatedAt();
   }
 
   private List<String> list(String value) {

--- a/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/JdbcSecurityScanRepositoryScope.java
+++ b/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/JdbcSecurityScanRepositoryScope.java
@@ -1,0 +1,106 @@
+package com.github.klboke.kkrepo.persistence.jdbc.internal;
+
+import com.github.klboke.kkrepo.persistence.jdbc.internal.support.JsonColumns;
+import com.github.klboke.kkrepo.persistence.jdbc.spi.JsonPersistenceDialect;
+import java.util.List;
+
+/** Shared SQL fragments for authorization-filtered security-scan repository scopes. */
+final class JdbcSecurityScanRepositoryScope {
+  private final JsonColumns json;
+  private final JsonPersistenceDialect jsonDialect;
+
+  JdbcSecurityScanRepositoryScope(JsonColumns json, JsonPersistenceDialect jsonDialect) {
+    this.json = json;
+    this.jsonDialect = jsonDialect;
+  }
+
+  List<Long> distinctLongs(List<Long> values) {
+    return values == null
+        ? List.of()
+        : values.stream()
+            .filter(java.util.Objects::nonNull)
+            .distinct()
+            .toList();
+  }
+
+  /**
+   * Materializes an authorization-filtered repository scope from one JSON bind value. This avoids
+   * both one query per repository and database parameter-limit failures for large installations.
+   */
+  String repositoryScopeCte() {
+    return """
+        WITH visible_repository AS (
+        %s
+        )
+        """.formatted(jsonDialect.selectLongsFromArray("repository_id"));
+  }
+
+  String recursiveRepositoryScopeCte() {
+    return """
+        WITH RECURSIVE visible_repository AS (
+        %s
+        )
+        """.formatted(jsonDialect.selectLongsFromArray("repository_id"));
+  }
+
+  /**
+   * Expands visible group policy contexts to their concrete source repositories while retaining
+   * direct repository visibility as an unrestricted task scope.
+   */
+  String taskRepositoryScopeCte() {
+    return recursiveRepositoryScopeCte() + """
+        ,
+        task_policy_source(
+          context_repository_id,
+          source_repository_id,
+          profile_id,
+          scan_hosted_content,
+          scan_proxy_content
+        ) AS (
+          SELECT
+            config.repository_id,
+            config.repository_id,
+            config.profile_id,
+            config.scan_hosted_content,
+            config.scan_proxy_content
+          FROM repository_security_scan_config config
+          JOIN visible_repository visible
+            ON visible.repository_id = config.repository_id
+          WHERE config.enabled = TRUE
+          UNION
+          SELECT
+            context.context_repository_id,
+            member.member_repository_id,
+            context.profile_id,
+            context.scan_hosted_content,
+            context.scan_proxy_content
+          FROM task_policy_source context
+          JOIN repository_member member
+            ON member.repository_id = context.source_repository_id
+        ),
+        task_repository_scope(
+          source_repository_id,
+          profile_id,
+          scan_hosted_content,
+          scan_proxy_content,
+          directly_visible
+        ) AS (
+          SELECT repository_id, NULL, FALSE, FALSE, TRUE
+          FROM visible_repository
+          UNION
+          SELECT
+            source_repository_id,
+            profile_id,
+            scan_hosted_content,
+            scan_proxy_content,
+            FALSE
+          FROM task_policy_source
+          WHERE context_repository_id <> source_repository_id
+        )
+        """;
+  }
+
+  Object parameter(List<Long> repositoryIds) {
+    return json.serializedParameter(json.writeValue(distinctLongs(repositoryIds)));
+  }
+}

--- a/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/JdbcSecurityScanRetentionDao.java
+++ b/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/JdbcSecurityScanRetentionDao.java
@@ -1,0 +1,223 @@
+package com.github.klboke.kkrepo.persistence.jdbc.internal;
+
+import static com.github.klboke.kkrepo.persistence.jdbc.internal.support.JdbcRows.nullableTimestamp;
+
+import com.github.klboke.kkrepo.persistence.jdbc.api.BlobReferenceDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.SecurityScanDao.RetentionResult;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/** Retention and blob-reference cleanup collaborator for {@link JdbcSecurityScanDao}. */
+final class JdbcSecurityScanRetentionDao {
+  private static final String SBOM_BLOB_OWNER = "security-sbom";
+  private static final String SCAN_REPORT_BLOB_OWNER = "security-scan-report";
+
+  private final JdbcTemplate jdbc;
+  private final BlobReferenceDao blobReferences;
+
+  JdbcSecurityScanRetentionDao(JdbcTemplate jdbc, BlobReferenceDao blobReferences) {
+    this.jdbc = jdbc;
+    this.blobReferences = blobReferences;
+  }
+
+  RetentionResult cleanupRetainedData(
+      Instant terminalTaskCutoff, Instant resultCutoff, int maxItems) {
+    int limit = safeLimit(maxItems);
+    int tasks = deleteTerminalTasks(terminalTaskCutoff, limit);
+    int backfills = deleteTerminalBackfills(terminalTaskCutoff, limit);
+    int subjects = deleteHistoricalRunSubjects(resultCutoff, limit);
+    int runs = deleteUnreferencedRuns(resultCutoff, limit);
+    int sboms = deleteUnreferencedSboms(resultCutoff, limit);
+    int snapshots = deleteUnreferencedSnapshots(resultCutoff, limit);
+    return new RetentionResult(tasks, backfills, subjects, runs, sboms, snapshots);
+  }
+
+  private int deleteTerminalTasks(Instant cutoff, int limit) {
+    List<Long> ids = jdbc.queryForList("""
+        SELECT id
+        FROM security_scan_task
+        WHERE status IN ('SUCCEEDED', 'FAILED', 'CANCELLED')
+          AND finished_at < ?
+        ORDER BY finished_at, id
+        LIMIT ?
+        FOR UPDATE SKIP LOCKED
+        """, Long.class, nullableTimestamp(cutoff), limit);
+    int deleted = 0;
+    for (Long id : ids) {
+      deleted += jdbc.update("""
+          DELETE FROM security_scan_task
+          WHERE id = ?
+            AND status IN ('SUCCEEDED', 'FAILED', 'CANCELLED')
+            AND finished_at < ?
+          """, id, nullableTimestamp(cutoff));
+    }
+    return deleted;
+  }
+
+  private int deleteTerminalBackfills(Instant cutoff, int limit) {
+    List<Long> ids = jdbc.queryForList("""
+        SELECT id
+        FROM security_scan_backfill_job
+        WHERE status IN ('SUCCEEDED', 'FAILED', 'CANCELLED')
+          AND completed_at < ?
+        ORDER BY completed_at, id
+        LIMIT ?
+        FOR UPDATE SKIP LOCKED
+        """, Long.class, nullableTimestamp(cutoff), limit);
+    int deleted = 0;
+    for (Long id : ids) {
+      deleted += jdbc.update("""
+          DELETE FROM security_scan_backfill_job
+          WHERE id = ?
+            AND status IN ('SUCCEEDED', 'FAILED', 'CANCELLED')
+            AND completed_at < ?
+          """, id, nullableTimestamp(cutoff));
+    }
+    return deleted;
+  }
+
+  private int deleteHistoricalRunSubjects(Instant cutoff, int limit) {
+    List<Map<String, Object>> rows = jdbc.queryForList("""
+        SELECT subject.scan_run_id, subject.repository_id, subject.asset_id,
+               subject.profile_id, subject.content_generation
+        FROM security_scan_run_subject subject
+        JOIN security_scan_run run ON run.id = subject.scan_run_id
+        WHERE subject.associated_at < ?
+          AND run.last_accessed_at < ?
+          AND NOT EXISTS (
+            SELECT 1
+            FROM asset_security_state asset_state
+            WHERE asset_state.latest_scan_run_id = subject.scan_run_id
+              AND asset_state.asset_id = subject.asset_id
+              AND asset_state.profile_id = subject.profile_id
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM asset_security_policy_state policy_state
+            WHERE policy_state.latest_scan_run_id = subject.scan_run_id
+              AND policy_state.asset_id = subject.asset_id
+              AND policy_state.profile_id = subject.profile_id
+              AND policy_state.repository_id = subject.repository_id
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM security_scan_waiver waiver
+            JOIN security_scan_finding finding ON finding.id = waiver.finding_id
+            WHERE finding.scan_run_id = subject.scan_run_id
+          )
+        ORDER BY subject.associated_at, subject.scan_run_id
+        LIMIT ?
+        FOR UPDATE SKIP LOCKED
+        """, nullableTimestamp(cutoff), nullableTimestamp(cutoff), limit);
+    int deleted = 0;
+    for (Map<String, Object> row : rows) {
+      deleted += jdbc.update("""
+          DELETE FROM security_scan_run_subject
+          WHERE scan_run_id = ? AND repository_id = ? AND asset_id = ?
+            AND profile_id = ? AND content_generation = ?
+          """,
+          number(row, "scan_run_id"),
+          number(row, "repository_id"),
+          number(row, "asset_id"),
+          number(row, "profile_id"),
+          number(row, "content_generation"));
+    }
+    return deleted;
+  }
+
+  private int deleteUnreferencedRuns(Instant cutoff, int limit) {
+    List<Map<String, Object>> rows = jdbc.queryForList("""
+        SELECT run.id, run.raw_report_blob_id
+        FROM security_scan_run run
+        WHERE run.completed_at < ?
+          AND run.last_accessed_at < ?
+          AND NOT EXISTS (
+            SELECT 1 FROM security_scan_run_subject subject
+            WHERE subject.scan_run_id = run.id
+          )
+          AND NOT EXISTS (
+            SELECT 1 FROM asset_security_state asset_state
+            WHERE asset_state.latest_scan_run_id = run.id
+          )
+          AND NOT EXISTS (
+            SELECT 1 FROM asset_security_policy_state policy_state
+            WHERE policy_state.latest_scan_run_id = run.id
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM security_scan_waiver waiver
+            JOIN security_scan_finding finding ON finding.id = waiver.finding_id
+            WHERE finding.scan_run_id = run.id
+          )
+        ORDER BY run.last_accessed_at, run.id
+        LIMIT ?
+        FOR UPDATE SKIP LOCKED
+        """, nullableTimestamp(cutoff), nullableTimestamp(cutoff), limit);
+    int deleted = 0;
+    for (Map<String, Object> row : rows) {
+      long runId = number(row, "id");
+      long blobId = number(row, "raw_report_blob_id");
+      blobReferences.release(SCAN_REPORT_BLOB_OWNER, runId, blobId);
+      deleted += jdbc.update("DELETE FROM security_scan_run WHERE id = ?", runId);
+    }
+    return deleted;
+  }
+
+  private int deleteUnreferencedSboms(Instant cutoff, int limit) {
+    List<Map<String, Object>> rows = jdbc.queryForList("""
+        SELECT sbom.id, sbom.document_blob_id
+        FROM security_sbom sbom
+        WHERE sbom.created_at < ?
+          AND sbom.last_accessed_at < ?
+          AND NOT EXISTS (
+            SELECT 1 FROM security_scan_run run WHERE run.sbom_id = sbom.id
+          )
+        ORDER BY sbom.last_accessed_at, sbom.id
+        LIMIT ?
+        FOR UPDATE SKIP LOCKED
+        """, nullableTimestamp(cutoff), nullableTimestamp(cutoff), limit);
+    int deleted = 0;
+    for (Map<String, Object> row : rows) {
+      long sbomId = number(row, "id");
+      long blobId = number(row, "document_blob_id");
+      blobReferences.release(SBOM_BLOB_OWNER, sbomId, blobId);
+      deleted += jdbc.update("DELETE FROM security_sbom WHERE id = ?", sbomId);
+    }
+    return deleted;
+  }
+
+  private int deleteUnreferencedSnapshots(Instant cutoff, int limit) {
+    List<Long> ids = jdbc.queryForList("""
+        SELECT snapshot.id
+        FROM security_scanner_snapshot snapshot
+        WHERE snapshot.observed_at < ?
+          AND NOT EXISTS (
+            SELECT 1 FROM security_scan_run run
+            WHERE run.scanner_snapshot_id = snapshot.id
+          )
+          AND NOT EXISTS (
+            SELECT 1 FROM security_scan_task task
+            WHERE task.requested_scanner_snapshot_id = snapshot.id
+          )
+        ORDER BY snapshot.observed_at, snapshot.id
+        LIMIT ?
+        FOR UPDATE SKIP LOCKED
+        """, Long.class, nullableTimestamp(cutoff), limit);
+    int deleted = 0;
+    for (Long id : ids) {
+      deleted += jdbc.update(
+          "DELETE FROM security_scanner_snapshot WHERE id = ?", id);
+    }
+    return deleted;
+  }
+
+  private static long number(Map<String, Object> row, String column) {
+    return ((Number) row.get(column)).longValue();
+  }
+
+  private static int safeLimit(int maxItems) {
+    return Math.max(1, Math.min(maxItems, 1000));
+  }
+}

--- a/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/JdbcSecurityScanSummaryDao.java
+++ b/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/JdbcSecurityScanSummaryDao.java
@@ -1,0 +1,357 @@
+package com.github.klboke.kkrepo.persistence.jdbc.internal;
+
+import static com.github.klboke.kkrepo.persistence.jdbc.internal.support.JdbcRows.nullableInstant;
+import static com.github.klboke.kkrepo.persistence.jdbc.internal.support.JdbcRows.nullableTimestamp;
+
+import com.github.klboke.kkrepo.persistence.jdbc.api.SecurityScanDao.ScanMetricSummary;
+import com.github.klboke.kkrepo.persistence.jdbc.api.SecurityScanDao.ScanSummary;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/** Read-only aggregate and metric queries for security-scan observability. */
+final class JdbcSecurityScanSummaryDao {
+  private final JdbcTemplate jdbc;
+  private final JdbcSecurityScanRepositoryScope scope;
+
+  JdbcSecurityScanSummaryDao(
+      JdbcTemplate jdbc, JdbcSecurityScanRepositoryScope scope) {
+    this.jdbc = jdbc;
+    this.scope = scope;
+  }
+
+  ScanSummary summary() {
+    return summary(jdbc.queryForList("SELECT id FROM repository", Long.class));
+  }
+
+  ScanSummary summary(long repositoryId) {
+    return summary(List.of(repositoryId));
+  }
+
+  ScanSummary summary(List<Long> repositoryIds) {
+    List<Long> ids = scope.distinctLongs(repositoryIds);
+    if (ids.isEmpty()) {
+      return new ScanSummary(0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+    }
+    Object repositoryScope = scope.parameter(ids);
+    long candidates = count(scope.taskRepositoryScopeCte() + """
+        SELECT COUNT(*)
+        FROM security_scan_candidate candidate
+        JOIN asset asset ON asset.id = candidate.asset_id
+        WHERE candidate.pending = TRUE
+          AND EXISTS (
+            SELECT 1
+            FROM task_repository_scope scope
+            JOIN repository source_repository
+              ON source_repository.id = scope.source_repository_id
+            WHERE scope.source_repository_id = asset.repository_id
+              AND (
+                scope.directly_visible = TRUE
+                OR (
+                  (
+                    source_repository.type = 'hosted'
+                    AND scope.scan_hosted_content = TRUE
+                  )
+                  OR (
+                    source_repository.type = 'proxy'
+                    AND scope.scan_proxy_content = TRUE
+                  )
+                )
+              )
+          )
+        """, repositoryScope);
+    Map<String, Object> tasks = jdbc.queryForMap(scope.taskRepositoryScopeCte() + """
+        SELECT
+          COALESCE(SUM(CASE
+            WHEN task.status IN ('PENDING', 'RETRY_WAIT') THEN 1 ELSE 0 END), 0)
+            AS pending_tasks,
+          COALESCE(SUM(CASE
+            WHEN task.status = 'RUNNING' THEN 1 ELSE 0 END), 0)
+            AS running_tasks,
+          COALESCE(SUM(CASE
+            WHEN task.status = 'FAILED' THEN 1 ELSE 0 END), 0)
+            AS failed_tasks
+        FROM security_scan_task task
+        WHERE task.status IN ('PENDING', 'RETRY_WAIT', 'RUNNING', 'FAILED')
+          AND EXISTS (
+            SELECT 1
+            FROM task_repository_scope scope
+            JOIN repository source_repository
+              ON source_repository.id = scope.source_repository_id
+            WHERE scope.source_repository_id = task.repository_id
+              AND (
+                scope.directly_visible = TRUE
+                OR (
+                  scope.profile_id = task.profile_id
+                  AND (
+                    (
+                      source_repository.type = 'hosted'
+                      AND scope.scan_hosted_content = TRUE
+                    )
+                    OR (
+                      source_repository.type = 'proxy'
+                      AND scope.scan_proxy_content = TRUE
+                    )
+                  )
+                )
+              )
+          )
+        """, repositoryScope);
+    Instant summaryAt = Instant.now();
+    Map<String, Object> states = jdbc.queryForMap(
+        scope.recursiveRepositoryScopeCte() + """
+        ,
+        policy_context_source(context_repository_id, source_repository_id) AS (
+          SELECT config.repository_id, config.repository_id
+          FROM repository_security_scan_config config
+          JOIN visible_repository visible
+            ON visible.repository_id = config.repository_id
+          WHERE config.enabled = TRUE
+          UNION
+          SELECT context.context_repository_id, member.member_repository_id
+          FROM policy_context_source context
+          JOIN repository_member member
+            ON member.repository_id = context.source_repository_id
+        ),
+        policy_subject(context_repository_id, source_repository_id, asset_id) AS (
+          SELECT context.context_repository_id, state.repository_id, state.asset_id
+          FROM policy_context_source context
+          JOIN asset_security_state state
+            ON state.repository_id = context.source_repository_id
+          UNION
+          SELECT context.context_repository_id, asset.repository_id, candidate.asset_id
+          FROM policy_context_source context
+          JOIN asset asset
+            ON asset.repository_id = context.source_repository_id
+          JOIN security_scan_candidate candidate
+            ON candidate.asset_id = asset.id
+        ),
+        policy_snapshot AS (
+          SELECT
+            subject.asset_id,
+            state.asset_id AS state_asset_id,
+            candidate.asset_id AS candidate_asset_id,
+            candidate.content_generation AS candidate_content_generation,
+            state.content_generation AS state_content_generation,
+            state.scan_state,
+            profile.id AS profile_id,
+            profile.enabled AS profile_enabled,
+            config.pending_action,
+            config.failure_action,
+            policy_state.policy_decision,
+            CASE
+              WHEN policy_state.asset_id IS NOT NULL
+               AND candidate.asset_id IS NOT NULL
+               AND state.asset_id IS NOT NULL
+               AND state.scan_state IN ('PARTIAL', 'COMPLETE')
+               AND state.content_generation = candidate.content_generation
+               AND policy_state.content_generation = candidate.content_generation
+               AND (
+                 policy_state.latest_scan_run_id = state.latest_scan_run_id
+                 OR (
+                   policy_state.latest_scan_run_id IS NULL
+                   AND state.latest_scan_run_id IS NULL
+                 )
+               )
+               AND policy_state.config_revision = config.config_revision
+               AND policy_state.waiver_revision
+                   >= waiver_revision.global_invalidation_revision
+               AND (
+                 (
+                   config.policy_id IS NULL
+                   AND policy_state.policy_id IS NULL
+                   AND policy_state.policy_revision IS NULL
+                 )
+                 OR (
+                   config.policy_id IS NOT NULL
+                   AND current_policy.id IS NOT NULL
+                   AND policy_state.policy_id = current_policy.id
+                   AND policy_state.policy_revision = current_policy.revision
+                 )
+               )
+               AND (
+                 policy_state.stale_at IS NULL
+                 OR policy_state.stale_at > ?
+               )
+               AND (
+                 policy_state.next_waiver_expiry IS NULL
+                 OR policy_state.next_waiver_expiry > ?
+               )
+              THEN TRUE
+              ELSE FALSE
+            END AS policy_authoritative
+          FROM policy_subject subject
+          JOIN repository_security_scan_config config
+            ON config.repository_id = subject.context_repository_id
+           AND config.enabled = TRUE
+          JOIN repository source_repository
+            ON source_repository.id = subject.source_repository_id
+          JOIN security_scan_waiver_revision waiver_revision
+            ON waiver_revision.singleton_id = 1
+          LEFT JOIN security_scan_candidate candidate
+            ON candidate.asset_id = subject.asset_id
+          LEFT JOIN asset_security_state state
+            ON state.asset_id = subject.asset_id
+           AND state.profile_id = config.profile_id
+          LEFT JOIN security_scan_profile profile
+            ON profile.id = config.profile_id
+          LEFT JOIN security_scan_policy current_policy
+            ON current_policy.id = config.policy_id
+          LEFT JOIN asset_security_policy_state policy_state
+            ON policy_state.asset_id = subject.asset_id
+           AND policy_state.profile_id = config.profile_id
+           AND policy_state.repository_id = config.repository_id
+          WHERE (
+            (source_repository.type = 'hosted' AND config.scan_hosted_content = TRUE)
+            OR (source_repository.type = 'proxy' AND config.scan_proxy_content = TRUE)
+          )
+        )
+        SELECT
+          COUNT(DISTINCT CASE
+            WHEN scan_state = 'COMPLETE'
+             AND state_content_generation = candidate_content_generation
+              THEN asset_id END)
+            AS complete_assets,
+          COUNT(DISTINCT CASE
+            WHEN scan_state = 'PARTIAL'
+             AND state_content_generation = candidate_content_generation
+              THEN asset_id END)
+            AS partial_assets,
+          COUNT(DISTINCT CASE
+            WHEN scan_state = 'STALE'
+             AND state_content_generation = candidate_content_generation
+              THEN asset_id END)
+            AS stale_assets,
+          COUNT(DISTINCT CASE
+            WHEN profile_id IS NULL OR profile_enabled = FALSE
+              THEN CASE WHEN failure_action = 'BLOCK' THEN asset_id END
+            WHEN state_asset_id IS NULL
+              OR candidate_asset_id IS NULL
+              OR state_content_generation <> candidate_content_generation
+              THEN CASE WHEN pending_action = 'BLOCK' THEN asset_id END
+            WHEN scan_state = 'NOT_APPLICABLE' THEN NULL
+            WHEN scan_state IN ('PENDING', 'RUNNING', 'STALE')
+              THEN CASE WHEN pending_action = 'BLOCK' THEN asset_id END
+            WHEN scan_state IN ('FAILED', 'CANCELLED')
+              THEN CASE WHEN failure_action = 'BLOCK' THEN asset_id END
+            WHEN scan_state IN ('PARTIAL', 'COMPLETE')
+              AND policy_authoritative = TRUE
+              AND policy_decision <> 'ALLOW'
+              THEN asset_id
+            WHEN scan_state IN ('PARTIAL', 'COMPLETE')
+              AND policy_authoritative = FALSE
+              THEN CASE WHEN pending_action = 'BLOCK' THEN asset_id END
+            ELSE NULL
+          END)
+            AS blocked_assets
+        FROM policy_snapshot
+        """,
+        repositoryScope,
+        nullableTimestamp(summaryAt),
+        nullableTimestamp(summaryAt));
+    Map<String, Object> findings = jdbc.queryForMap(scope.repositoryScopeCte() + """
+        , current_run AS (
+          SELECT DISTINCT state.latest_scan_run_id AS scan_run_id
+          FROM asset_security_state state
+          JOIN security_scan_candidate candidate
+            ON candidate.asset_id = state.asset_id
+           AND candidate.content_generation = state.content_generation
+          JOIN security_scan_run_subject subject
+            ON subject.scan_run_id = state.latest_scan_run_id
+           AND subject.asset_id = state.asset_id
+           AND subject.profile_id = state.profile_id
+           AND subject.content_generation = state.content_generation
+          JOIN visible_repository visible
+            ON visible.repository_id = subject.repository_id
+          WHERE state.latest_scan_run_id IS NOT NULL
+        )
+        SELECT
+          COALESCE(SUM(CASE WHEN finding.severity = 'CRITICAL' THEN 1 ELSE 0 END), 0)
+            AS critical_findings,
+          COALESCE(SUM(CASE WHEN finding.severity = 'HIGH' THEN 1 ELSE 0 END), 0)
+            AS high_findings
+        FROM current_run
+        JOIN security_scan_finding finding
+          ON finding.scan_run_id = current_run.scan_run_id
+        WHERE finding.severity IN ('CRITICAL', 'HIGH')
+        """, repositoryScope);
+    return new ScanSummary(
+        candidates,
+        number(tasks, "pending_tasks"),
+        number(tasks, "running_tasks"),
+        number(tasks, "failed_tasks"),
+        number(states, "complete_assets"),
+        number(states, "partial_assets"),
+        number(states, "stale_assets"),
+        number(states, "blocked_assets"),
+        number(findings, "critical_findings"),
+        number(findings, "high_findings"));
+  }
+
+  ScanMetricSummary metricSummary(int maxCount) {
+    int limit = Math.max(1, Math.min(1_000_000, maxCount));
+    return new ScanMetricSummary(
+        boundedCount("""
+            SELECT id FROM security_scan_task
+            WHERE status IN ('PENDING', 'RETRY_WAIT')
+            """, limit),
+        boundedCount("""
+            SELECT id FROM security_scan_task
+            WHERE status = 'RUNNING'
+            """, limit),
+        boundedCount("""
+            SELECT id FROM security_scan_task
+            WHERE status = 'FAILED'
+            """, limit),
+        boundedCount("""
+            SELECT state.asset_id
+            FROM asset_security_state state
+            JOIN security_scan_candidate candidate
+              ON candidate.asset_id = state.asset_id
+             AND candidate.content_generation = state.content_generation
+            WHERE state.scan_state = 'PARTIAL'
+            """, limit),
+        boundedCount("""
+            SELECT finding.id
+            FROM (
+              SELECT DISTINCT state.latest_scan_run_id AS scan_run_id
+              FROM asset_security_state state
+              JOIN security_scan_candidate candidate
+                ON candidate.asset_id = state.asset_id
+               AND candidate.content_generation = state.content_generation
+              WHERE state.latest_scan_run_id IS NOT NULL
+            ) current_run
+            JOIN security_scan_finding finding
+              ON finding.scan_run_id = current_run.scan_run_id
+             AND finding.severity IN ('CRITICAL', 'HIGH')
+            """, limit));
+  }
+
+  Optional<Instant> oldestPendingTaskCreatedAt() {
+    List<Instant> values = jdbc.query("""
+        SELECT created_at AS oldest_created_at
+        FROM security_scan_task
+        WHERE status IN ('PENDING','RETRY_WAIT')
+        ORDER BY created_at, id
+        LIMIT 1
+        """, (rs, rowNum) -> nullableInstant(rs, "oldest_created_at"));
+    return values.isEmpty() ? Optional.empty() : Optional.ofNullable(values.getFirst());
+  }
+
+  private long count(String sql, Object... args) {
+    Long value = jdbc.queryForObject(sql, Long.class, args);
+    return value == null ? 0 : value;
+  }
+
+  private long boundedCount(String selectionSql, int limit) {
+    return count(
+        "SELECT COUNT(*) FROM (" + selectionSql + " LIMIT ?) bounded_count",
+        limit);
+  }
+
+  private static long number(Map<String, Object> row, String column) {
+    return ((Number) row.get(column)).longValue();
+  }
+}

--- a/persistence-jdbc/src/test/java/com/github/klboke/kkrepo/persistence/jdbc/internal/JdbcSecurityScanDaoExtractionTest.java
+++ b/persistence-jdbc/src/test/java/com/github/klboke/kkrepo/persistence/jdbc/internal/JdbcSecurityScanDaoExtractionTest.java
@@ -1,0 +1,171 @@
+package com.github.klboke.kkrepo.persistence.jdbc.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.klboke.kkrepo.persistence.jdbc.api.SecurityScanDao.RetentionResult;
+import com.github.klboke.kkrepo.persistence.jdbc.api.SecurityScanDao.ScanMetricSummary;
+import com.github.klboke.kkrepo.persistence.jdbc.api.SecurityScanDao.ScanSummary;
+import com.github.klboke.kkrepo.persistence.jdbc.internal.support.JsonColumns;
+import com.github.klboke.kkrepo.persistence.jdbc.spi.DatabaseDialect;
+import com.github.klboke.kkrepo.persistence.jdbc.spi.JsonPersistenceDialect;
+import java.lang.reflect.Proxy;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+class JdbcSecurityScanDaoExtractionTest {
+  private static final Instant NOW = Instant.parse("2026-08-23T12:00:00Z");
+
+  @Test
+  void facadeKeepsSummaryAndMetricQueriesBehindDedicatedCollaborators() {
+    JdbcSecurityScanDao dao = dao(new RecordingJdbcTemplate());
+
+    ScanSummary summary = dao.summary(Arrays.asList(9L, null, 9L));
+    assertEquals(7, summary.candidateBacklog());
+    assertEquals(1, summary.pendingTasks());
+    assertEquals(2, summary.runningTasks());
+    assertEquals(3, summary.failedTasks());
+    assertEquals(4, summary.completeAssets());
+    assertEquals(5, summary.partialAssets());
+    assertEquals(6, summary.staleAssets());
+    assertEquals(7, summary.blockedAssets());
+    assertEquals(8, summary.criticalFindings());
+    assertEquals(9, summary.highFindings());
+    assertEquals(summary, dao.summary(9));
+    assertEquals(summary, dao.summary());
+    assertEquals(new ScanSummary(0, 0, 0, 0, 0, 0, 0, 0, 0, 0), dao.summary(List.of()));
+    assertEquals(
+        new ScanSummary(0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+        dao.summary((List<Long>) null));
+
+    ScanMetricSummary metrics = dao.metricSummary(0);
+    assertEquals(new ScanMetricSummary(7, 7, 7, 7, 7), metrics);
+    assertEquals(Optional.of(NOW), dao.oldestPendingTaskCreatedAt());
+  }
+
+  @Test
+  void facadeKeepsAllRetentionStagesInsideTheExistingTransactionEntryPoint() {
+    RecordingJdbcTemplate jdbc = new RecordingJdbcTemplate();
+    JdbcSecurityScanDao dao = dao(jdbc);
+
+    RetentionResult result = dao.cleanupRetainedData(
+        NOW.minusSeconds(3_600), NOW.minusSeconds(7_200), 5_000);
+
+    assertEquals(new RetentionResult(1, 1, 1, 1, 1, 1), result);
+    assertEquals(2, jdbc.blobReferenceDeletes);
+    assertTrue(jdbc.limits.stream().allMatch(limit -> limit == 1_000));
+  }
+
+  private static JdbcSecurityScanDao dao(JdbcTemplate jdbc) {
+    JsonPersistenceDialect jsonDialect = (JsonPersistenceDialect) Proxy.newProxyInstance(
+        JsonPersistenceDialect.class.getClassLoader(),
+        new Class<?>[] {JsonPersistenceDialect.class},
+        (proxy, method, arguments) -> switch (method.getName()) {
+          case "jdbcValue" -> arguments[0];
+          case "selectLongsFromArray" -> "SELECT 1 AS " + arguments[0];
+          default -> null;
+        });
+    DatabaseDialect databaseDialect = (DatabaseDialect) Proxy.newProxyInstance(
+        DatabaseDialect.class.getClassLoader(),
+        new Class<?>[] {DatabaseDialect.class},
+        (proxy, method, arguments) -> "json".equals(method.getName()) ? jsonDialect : null);
+    return new JdbcSecurityScanDao(
+        jdbc, new JsonColumns(new ObjectMapper(), jsonDialect), databaseDialect);
+  }
+
+  private static final class RecordingJdbcTemplate extends JdbcTemplate {
+    private final List<Integer> limits = new java.util.ArrayList<>();
+    private int blobReferenceDeletes;
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> List<T> queryForList(String sql, Class<T> elementType, Object... args) {
+      if (args.length > 0 && args[args.length - 1] instanceof Integer limit) {
+        limits.add(limit);
+      }
+      if (sql.contains("FROM security_scan_task")
+          && sql.contains("finished_at <")) return (List<T>) List.of(101L);
+      if (sql.contains("FROM security_scan_backfill_job")) return (List<T>) List.of(102L);
+      if (sql.contains("FROM security_scanner_snapshot")) return (List<T>) List.of(103L);
+      if (sql.contains("FROM asset_blob")) return (List<T>) List.of(501L);
+      return List.of();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> List<T> queryForList(String sql, Class<T> elementType) {
+      if (sql.equals("SELECT id FROM repository")) return (List<T>) List.of(9L);
+      return List.of();
+    }
+
+    @Override
+    public List<Map<String, Object>> queryForList(String sql, Object... args) {
+      if (args.length > 0 && args[args.length - 1] instanceof Integer limit) {
+        limits.add(limit);
+      }
+      String normalized = sql.stripLeading();
+      if (normalized.startsWith("SELECT subject.scan_run_id")) {
+        return List.of(Map.of(
+            "scan_run_id", 201L,
+            "repository_id", 9L,
+            "asset_id", 301L,
+            "profile_id", 401L,
+            "content_generation", 1L));
+      }
+      if (normalized.startsWith("SELECT run.id")) {
+        return List.of(Map.of("id", 201L, "raw_report_blob_id", 501L));
+      }
+      if (normalized.startsWith("SELECT sbom.id")) {
+        return List.of(Map.of("id", 202L, "document_blob_id", 502L));
+      }
+      return List.of();
+    }
+
+    @Override
+    public Map<String, Object> queryForMap(String sql, Object... args) {
+      if (sql.contains("pending_tasks")) {
+        return Map.of("pending_tasks", 1L, "running_tasks", 2L, "failed_tasks", 3L);
+      }
+      if (sql.contains("blocked_assets")) {
+        return Map.of(
+            "complete_assets", 4L,
+            "partial_assets", 5L,
+            "stale_assets", 6L,
+            "blocked_assets", 7L);
+      }
+      return Map.of("critical_findings", 8L, "high_findings", 9L);
+    }
+
+    @Override
+    public <T> T queryForObject(String sql, Class<T> requiredType, Object... args) {
+      return requiredType.cast(7L);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> List<T> query(String sql, RowMapper<T> rowMapper, Object... args) {
+      if (sql.contains("oldest_created_at")) return (List<T>) List.of(NOW);
+      return List.of();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> List<T> query(String sql, RowMapper<T> rowMapper) {
+      if (sql.contains("oldest_created_at")) return (List<T>) List.of(NOW);
+      return List.of();
+    }
+
+    @Override
+    public int update(String sql, Object... args) {
+      if (sql.contains("DELETE FROM blob_reference")) blobReferenceDeletes++;
+      return 1;
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
     <commons.lang3.version>3.20.0</commons.lang3.version>
     <bouncycastle.version>1.85</bouncycastle.version>
     <jacoco.version>0.8.15</jacoco.version>
+    <archunit.version>1.5.0</archunit.version>
     <flatten.maven.plugin.version>1.8.0</flatten.maven.plugin.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <kkrepo.dist.version>${project.version}</kkrepo.dist.version>
@@ -98,6 +99,11 @@
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-artifact</artifactId>
         <version>${maven.artifact.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.tngtech.archunit</groupId>
+        <artifactId>archunit-junit5</artifactId>
+        <version>${archunit.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -237,6 +237,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
       <scope>test</scope>

--- a/server/src/main/java/com/github/klboke/kkrepo/server/RepositoryProtocolController.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/RepositoryProtocolController.java
@@ -1,0 +1,91 @@
+package com.github.klboke.kkrepo.server;
+
+import com.github.klboke.kkrepo.server.routing.RepositoryProtocolDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+/**
+ * HTTP entry point for Nexus-compatible repository URLs.
+ *
+ * <p>Authentication and path normalization are applied by the repository security filter. This
+ * controller deliberately owns no protocol service and delegates every request through the route
+ * SPI so format runtimes can evolve independently of the web entry point.
+ */
+@RestController
+@RequestMapping("/repository/{name}")
+public class RepositoryProtocolController {
+  private final RepositoryProtocolDispatcher protocols;
+
+  public RepositoryProtocolController(RepositoryProtocolDispatcher protocols) {
+    this.protocols = protocols;
+  }
+
+  @GetMapping("/**")
+  public ResponseEntity<StreamingResponseBody> get(
+      @PathVariable("name") String name, HttpServletRequest request) {
+    return cast(protocols.dispatchRead(name, request, HttpMethod.GET));
+  }
+
+  @RequestMapping(value = "/**", method = RequestMethod.HEAD)
+  public ResponseEntity<Void> head(
+      @PathVariable("name") String name, HttpServletRequest request) {
+    return cast(protocols.dispatchRead(name, request, HttpMethod.HEAD));
+  }
+
+  @PutMapping("/**")
+  public ResponseEntity<?> put(
+      @PathVariable("name") String name,
+      HttpServletRequest request) throws IOException, ServletException {
+    return protocols.dispatch(name, request, HttpMethod.PUT, null);
+  }
+
+  ResponseEntity<?> put(
+      String name, HttpServletRequest request, String contentType)
+      throws IOException, ServletException {
+    return protocols.dispatch(name, request, HttpMethod.PUT, contentType, null);
+  }
+
+  @DeleteMapping("/**")
+  public ResponseEntity<?> delete(
+      @PathVariable("name") String name,
+      HttpServletRequest request) throws IOException, ServletException {
+    return protocols.dispatch(name, request, HttpMethod.DELETE, null);
+  }
+
+  @PostMapping("/**")
+  public ResponseEntity<?> post(
+      @PathVariable("name") String name, HttpServletRequest request) {
+    try {
+      return protocols.dispatch(name, request, HttpMethod.POST, null);
+    } catch (IOException | ServletException error) {
+      throw new IllegalStateException("Repository POST handler failed", error);
+    }
+  }
+
+  @PostMapping(value = "/api/charts", consumes = "multipart/form-data")
+  public ResponseEntity<?> pushHelmChart(
+      @PathVariable("name") String name,
+      @RequestPart("chart") MultipartFile chart,
+      HttpServletRequest request) throws IOException, ServletException {
+    return protocols.dispatch(name, request, HttpMethod.POST, chart);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> ResponseEntity<T> cast(ResponseEntity<?> response) {
+    return (ResponseEntity<T>) response;
+  }
+}

--- a/server/src/main/java/com/github/klboke/kkrepo/server/ansible/AnsibleGalaxyErrorAdvice.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/ansible/AnsibleGalaxyErrorAdvice.java
@@ -1,6 +1,6 @@
 package com.github.klboke.kkrepo.server.ansible;
 
-import com.github.klboke.kkrepo.server.RepositoryContentController;
+import com.github.klboke.kkrepo.server.RepositoryProtocolController;
 import java.util.List;
 import java.util.Map;
 import org.springframework.http.MediaType;
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 /** Prevents Spring HTML errors from leaking into Galaxy v3 client responses. */
-@RestControllerAdvice(assignableTypes = RepositoryContentController.class)
+@RestControllerAdvice(assignableTypes = RepositoryProtocolController.class)
 public class AnsibleGalaxyErrorAdvice {
   @ExceptionHandler(AnsibleGalaxyExceptions.GalaxyException.class)
   public ResponseEntity<Map<String, Object>> handle(

--- a/server/src/main/java/com/github/klboke/kkrepo/server/conan/ConanErrorAdvice.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/conan/ConanErrorAdvice.java
@@ -1,6 +1,6 @@
 package com.github.klboke.kkrepo.server.conan;
 
-import com.github.klboke.kkrepo.server.RepositoryContentController;
+import com.github.klboke.kkrepo.server.RepositoryProtocolController;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 /** Prevents HTML framework error pages from reaching the Conan CLI. */
-@RestControllerAdvice(assignableTypes = RepositoryContentController.class)
+@RestControllerAdvice(assignableTypes = RepositoryProtocolController.class)
 public class ConanErrorAdvice {
   @ExceptionHandler(ConanExceptions.ConanException.class)
   public ResponseEntity<String> handle(ConanExceptions.ConanException failure) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/maven/MavenErrorAdvice.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/maven/MavenErrorAdvice.java
@@ -1,6 +1,6 @@
 package com.github.klboke.kkrepo.server.maven;
 
-import com.github.klboke.kkrepo.server.RepositoryContentController;
+import com.github.klboke.kkrepo.server.RepositoryProtocolController;
 import com.github.klboke.kkrepo.server.cargo.CargoExceptions;
 import com.github.klboke.kkrepo.server.cargo.CargoResponses;
 import com.github.klboke.kkrepo.server.composer.ComposerExceptions;
@@ -16,7 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@RestControllerAdvice(assignableTypes = RepositoryContentController.class)
+@RestControllerAdvice(assignableTypes = RepositoryProtocolController.class)
 public class MavenErrorAdvice {
 
   @ExceptionHandler(MavenExceptions.MavenNotFoundException.class)

--- a/server/src/main/java/com/github/klboke/kkrepo/server/routing/RepositoryProtocolDispatcher.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/routing/RepositoryProtocolDispatcher.java
@@ -1,0 +1,168 @@
+package com.github.klboke.kkrepo.server.routing;
+
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.jdbc.api.model.RepositoryRecord;
+import com.github.klboke.kkrepo.server.maven.MavenExceptions;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
+import com.github.klboke.kkrepo.server.security.RepositorySecurityFilter;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+/** Resolves one repository runtime and dispatches the request to the most specific route. */
+@Component
+public class RepositoryProtocolDispatcher {
+  private static final Comparator<RegisteredRoute> ROUTE_ORDER =
+      Comparator.comparingInt((RegisteredRoute route) -> route.route().pathSpecificity())
+          .reversed()
+          .thenComparingInt(route -> route.route().order())
+          .thenComparing(route -> route.handler().getClass().getName());
+
+  private final RepositoryRuntimeRegistry runtimes;
+  private final Map<RouteKey, List<RegisteredRoute>> routes;
+
+  public RepositoryProtocolDispatcher(
+      RepositoryRuntimeRegistry runtimes, List<RepositoryProtocolHandler> handlers) {
+    this.runtimes = Objects.requireNonNull(runtimes, "runtimes");
+    Objects.requireNonNull(handlers, "handlers");
+    Map<RouteKey, List<RegisteredRoute>> registered = new HashMap<>();
+    for (RepositoryProtocolHandler handler : handlers) {
+      if (handler == null) {
+        throw new IllegalStateException("Repository protocol handler list contains null");
+      }
+      List<RepositoryProtocolRoute> handlerRoutes = CollectionValidator.requireRoutes(handler);
+      for (RepositoryProtocolRoute route : handlerRoutes) {
+        registered.computeIfAbsent(RouteKey.from(route), ignored -> new ArrayList<>())
+            .add(new RegisteredRoute(route, handler));
+      }
+    }
+    if (registered.isEmpty()) {
+      throw new IllegalStateException("No repository protocol routes are registered");
+    }
+    Map<RouteKey, List<RegisteredRoute>> indexed = new HashMap<>();
+    registered.forEach((key, value) -> {
+      List<RegisteredRoute> ordered = value.stream().sorted(ROUTE_ORDER).toList();
+      requireUnambiguousRegistrations(key, ordered);
+      indexed.put(key, ordered);
+    });
+    this.routes = Map.copyOf(indexed);
+  }
+
+  public ResponseEntity<?> dispatchRead(
+      String repositoryName, HttpServletRequest request, HttpMethod method) {
+    try {
+      return dispatch(repositoryName, request, method, null);
+    } catch (IOException | ServletException error) {
+      throw new IllegalStateException("Repository read handler failed", error);
+    }
+  }
+
+  public ResponseEntity<?> dispatch(
+      String repositoryName,
+      HttpServletRequest request,
+      HttpMethod method,
+      MultipartFile multipartFile) throws IOException, ServletException {
+    return dispatch(
+        repositoryName, request, method, request.getContentType(), multipartFile);
+  }
+
+  public ResponseEntity<?> dispatch(
+      String repositoryName,
+      HttpServletRequest request,
+      HttpMethod method,
+      String contentType,
+      MultipartFile multipartFile) throws IOException, ServletException {
+    RepositoryRuntime runtime = resolveRuntime(repositoryName, request);
+    String path = routePath(repositoryName, request);
+    RouteKey key = new RouteKey(runtime.format(), runtime.type(), method);
+    for (RegisteredRoute candidate : routes.getOrDefault(key, List.of())) {
+      if (!candidate.route().matches(runtime, method, path)) continue;
+      return candidate.handler().handle(new RepositoryProtocolRequest(
+          runtime, repositoryName, path, method, request, contentType, multipartFile));
+    }
+    throw new MavenExceptions.MethodNotAllowed(
+        "No repository protocol handler for " + runtime.format() + "/" + runtime.type()
+            + " " + method + " " + path);
+  }
+
+  private RepositoryRuntime resolveRuntime(String name, HttpServletRequest request) {
+    Object record = request.getAttribute(RepositorySecurityFilter.REPOSITORY_RECORD_ATTRIBUTE);
+    if (record instanceof RepositoryRecord repository) {
+      if (!name.equals(repository.name())) {
+        throw new MavenExceptions.MavenNotFoundException("Repository not found: " + name);
+      }
+      return runtimes.resolve(repository)
+          .orElseThrow(() -> new MavenExceptions.MavenNotFoundException(
+              "Repository not found: " + name));
+    }
+    return runtimes.resolve(name)
+        .orElseThrow(() -> new MavenExceptions.MavenNotFoundException(
+            "Repository not found: " + name));
+  }
+
+  private static String routePath(String name, HttpServletRequest request) {
+    Object normalized = request.getAttribute(
+        RepositorySecurityFilter.NORMALIZED_REPOSITORY_PATH_ATTRIBUTE);
+    if (normalized instanceof String path) return path;
+    String uri = request.getRequestURI();
+    String root = request.getContextPath() + "/repository/" + name;
+    if (uri.equals(root)) return "";
+    String prefix = root + "/";
+    return uri.startsWith(prefix) ? uri.substring(prefix.length()) : "";
+  }
+
+  private record RegisteredRoute(
+      RepositoryProtocolRoute route, RepositoryProtocolHandler handler) {}
+
+  private record RouteKey(
+      RepositoryFormat format, RepositoryType type, HttpMethod method) {
+    static RouteKey from(RepositoryProtocolRoute route) {
+      return new RouteKey(route.format(), route.type(), route.method());
+    }
+  }
+
+  private static void requireUnambiguousRegistrations(
+      RouteKey key, List<RegisteredRoute> registrations) {
+    Map<RegistrationKey, RegisteredRoute> registered = new HashMap<>();
+    for (RegisteredRoute current : registrations) {
+      RegistrationKey registration = new RegistrationKey(
+          current.route().pathPattern(), current.route().order());
+      RegisteredRoute previous = registered.putIfAbsent(registration, current);
+      if (previous != null) {
+        throw new IllegalStateException(
+            "Ambiguous repository protocol route registration for " + key.format() + "/"
+                + key.type() + " " + key.method() + " " + current.route().pathPattern()
+                + ": " + previous.handler().getClass().getName() + " and "
+                + current.handler().getClass().getName());
+      }
+    }
+  }
+
+  private record RegistrationKey(String pathPattern, int order) {}
+
+  private static final class CollectionValidator {
+    private CollectionValidator() {}
+
+    static List<RepositoryProtocolRoute> requireRoutes(RepositoryProtocolHandler handler) {
+      var routes = handler.routes();
+      if (routes == null || routes.isEmpty() || routes.stream().anyMatch(Objects::isNull)) {
+        throw new IllegalStateException(
+            "Repository protocol handler must register at least one non-null route: "
+                + handler.getClass().getName());
+      }
+      return List.copyOf(routes);
+    }
+  }
+}

--- a/server/src/main/java/com/github/klboke/kkrepo/server/routing/RepositoryProtocolHandler.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/routing/RepositoryProtocolHandler.java
@@ -1,0 +1,19 @@
+package com.github.klboke.kkrepo.server.routing;
+
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.util.Collection;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Runtime extension point for Nexus-compatible repository routes.
+ *
+ * <p>Implementations register every route they own. Protocol services remain behind handlers;
+ * controllers and security filters depend only on this routing boundary.
+ */
+public interface RepositoryProtocolHandler {
+  Collection<RepositoryProtocolRoute> routes();
+
+  ResponseEntity<?> handle(RepositoryProtocolRequest request)
+      throws IOException, ServletException;
+}

--- a/server/src/main/java/com/github/klboke/kkrepo/server/routing/RepositoryProtocolRequest.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/routing/RepositoryProtocolRequest.java
@@ -1,0 +1,26 @@
+package com.github.klboke.kkrepo.server.routing;
+
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Objects;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.multipart.MultipartFile;
+
+/** Immutable request context passed from the HTTP entry point to a protocol handler. */
+public record RepositoryProtocolRequest(
+    RepositoryRuntime runtime,
+    String repositoryName,
+    String path,
+    HttpMethod method,
+    HttpServletRequest servletRequest,
+    String contentType,
+    MultipartFile multipartFile) {
+
+  public RepositoryProtocolRequest {
+    Objects.requireNonNull(runtime, "runtime");
+    Objects.requireNonNull(repositoryName, "repositoryName");
+    path = RepositoryProtocolRoute.normalizePath(path);
+    Objects.requireNonNull(method, "method");
+    Objects.requireNonNull(servletRequest, "servletRequest");
+  }
+}

--- a/server/src/main/java/com/github/klboke/kkrepo/server/routing/RepositoryProtocolRoute.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/routing/RepositoryProtocolRoute.java
@@ -1,0 +1,86 @@
+package com.github.klboke.kkrepo.server.routing;
+
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import java.util.Objects;
+import org.springframework.http.HttpMethod;
+
+/**
+ * Declarative route registration for one repository protocol handler.
+ *
+ * <p>Routes are matched by repository format, repository type, HTTP method, and normalized
+ * repository-relative path. The path pattern is either {@value #ANY_PATH}, an exact path, or a
+ * prefix ending in {@code /**}. Lower order values win after path specificity is considered.
+ */
+public record RepositoryProtocolRoute(
+    RepositoryFormat format,
+    RepositoryType type,
+    HttpMethod method,
+    String pathPattern,
+    int order) {
+  public static final String ANY_PATH = "**";
+
+  public RepositoryProtocolRoute {
+    Objects.requireNonNull(format, "format");
+    Objects.requireNonNull(type, "type");
+    Objects.requireNonNull(method, "method");
+    Objects.requireNonNull(pathPattern, "pathPattern");
+    pathPattern = normalizePattern(pathPattern);
+  }
+
+  public static RepositoryProtocolRoute anyPath(
+      RepositoryFormat format, RepositoryType type, HttpMethod method, int order) {
+    return new RepositoryProtocolRoute(format, type, method, ANY_PATH, order);
+  }
+
+  public static RepositoryProtocolRoute exactPath(
+      RepositoryFormat format,
+      RepositoryType type,
+      HttpMethod method,
+      String path,
+      int order) {
+    return new RepositoryProtocolRoute(format, type, method, path, order);
+  }
+
+  boolean matches(RepositoryRuntime runtime, HttpMethod requestMethod, String path) {
+    return format == runtime.format()
+        && type == runtime.type()
+        && method == requestMethod
+        && matchesPath(normalizePath(path));
+  }
+
+  int pathSpecificity() {
+    if (ANY_PATH.equals(pathPattern)) return 0;
+    if (pathPattern.endsWith("/**")) return 1_000 + pathPattern.length();
+    return 1_000_000 + pathPattern.length();
+  }
+
+  private boolean matchesPath(String path) {
+    if (ANY_PATH.equals(pathPattern)) return true;
+    if (pathPattern.endsWith("/**")) {
+      String prefix = pathPattern.substring(0, pathPattern.length() - 3);
+      return path.equals(prefix) || path.startsWith(prefix + "/");
+    }
+    return pathPattern.equals(path);
+  }
+
+  private static String normalizePattern(String pattern) {
+    String normalized = normalizePath(pattern);
+    int wildcard = normalized.indexOf('*');
+    boolean trailingPrefix = normalized.endsWith("/**")
+        && wildcard == normalized.length() - 2;
+    if (wildcard >= 0 && !ANY_PATH.equals(normalized) && !trailingPrefix) {
+      throw new IllegalArgumentException(
+          "Repository route wildcard is only supported as ** or a trailing /**");
+    }
+    return normalized;
+  }
+
+  static String normalizePath(String path) {
+    if (path == null) return "";
+    String normalized = path.trim();
+    while (normalized.startsWith("/")) normalized = normalized.substring(1);
+    return normalized;
+  }
+}

--- a/server/src/main/java/com/github/klboke/kkrepo/server/routing/builtin/BuiltinRepositoryProtocolHandler.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/routing/builtin/BuiltinRepositoryProtocolHandler.java
@@ -1,9 +1,9 @@
-package com.github.klboke.kkrepo.server;
+package com.github.klboke.kkrepo.server.routing.builtin;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.klboke.kkrepo.auth.PermissionSubject;
 import com.github.klboke.kkrepo.core.RepositoryFormat;
-import com.github.klboke.kkrepo.persistence.jdbc.api.model.RepositoryRecord;
+import com.github.klboke.kkrepo.core.RepositoryType;
 import com.github.klboke.kkrepo.protocol.maven.path.MavenPath;
 import com.github.klboke.kkrepo.protocol.maven.path.MavenPathParser;
 import com.github.klboke.kkrepo.protocol.cargo.CargoPath;
@@ -48,7 +48,6 @@ import com.github.klboke.kkrepo.server.maven.MavenPartialFetchSupport;
 import com.github.klboke.kkrepo.server.maven.MavenProxyService;
 import com.github.klboke.kkrepo.server.maven.MavenResponse;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
-import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
 import com.github.klboke.kkrepo.server.npm.NpmExceptions;
 import com.github.klboke.kkrepo.server.npm.NpmGroupService;
 import com.github.klboke.kkrepo.server.npm.NpmHostedService;
@@ -72,6 +71,9 @@ import com.github.klboke.kkrepo.server.raw.RawGroupService;
 import com.github.klboke.kkrepo.server.raw.RawHostedService;
 import com.github.klboke.kkrepo.server.raw.RawProxyService;
 import com.github.klboke.kkrepo.server.r.RService;
+import com.github.klboke.kkrepo.server.routing.RepositoryProtocolHandler;
+import com.github.klboke.kkrepo.server.routing.RepositoryProtocolRequest;
+import com.github.klboke.kkrepo.server.routing.RepositoryProtocolRoute;
 import com.github.klboke.kkrepo.server.rubygems.RubygemsService;
 import com.github.klboke.kkrepo.server.security.AuthenticatedSubject;
 import com.github.klboke.kkrepo.server.security.ForwardedHeaderPolicy;
@@ -91,37 +93,43 @@ import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 /**
- * Unified content entry point for Nexus-compatible repository URLs. URL shape
- * {@code /repository/{name}/{path:.*}} mirrors Nexus and dispatches by repository format to the
- * protocol-specific hosted/proxy/group service.
+ * Compatibility catch-all for protocol paths not yet owned by a focused route handler.
+ *
+ * <p>The dispatcher supplies one immutable repository runtime snapshot. New routes should be
+ * implemented as focused handlers so this class can shrink as protocol runtimes move to their
+ * owning modules.
  */
-@RestController
-@RequestMapping("/repository/{name}")
-public class RepositoryContentController {
-  private final RepositoryRuntimeRegistry registry;
+@Component
+public class BuiltinRepositoryProtocolHandler implements RepositoryProtocolHandler {
+  private static final List<RepositoryProtocolRoute> ROUTES =
+      Arrays.stream(RepositoryFormat.values())
+          .flatMap(format -> Arrays.stream(RepositoryType.values())
+              .flatMap(type -> List.of(
+                      HttpMethod.GET,
+                      HttpMethod.HEAD,
+                      HttpMethod.PUT,
+                      HttpMethod.DELETE,
+                      HttpMethod.POST)
+                  .stream()
+                  .map(method -> RepositoryProtocolRoute.anyPath(
+                      format, type, method, 1_000))))
+          .toList();
   private final MavenHostedService hosted;
   private final MavenProxyService proxy;
   private final MavenGroupService group;
@@ -175,52 +183,52 @@ public class RepositoryContentController {
   private final PypiPartialFetchSupport pypiPartialFetch = new PypiPartialFetchSupport();
 
   @Autowired(required = false)
-  void setSwiftService(SwiftService swift) {
+  public void setSwiftService(SwiftService swift) {
     this.swift = swift;
   }
 
   @Autowired(required = false)
-  void setAnsibleGalaxyService(AnsibleGalaxyService ansible) {
+  public void setAnsibleGalaxyService(AnsibleGalaxyService ansible) {
     this.ansible = ansible;
   }
 
   @Autowired(required = false)
-  void setAnsibleGalaxyMultipartReader(AnsibleGalaxyMultipartReader ansibleMultipart) {
+  public void setAnsibleGalaxyMultipartReader(AnsibleGalaxyMultipartReader ansibleMultipart) {
     this.ansibleMultipart = ansibleMultipart;
   }
 
   @Autowired(required = false)
-  void setCondaService(CondaService conda) {
+  public void setCondaService(CondaService conda) {
     this.conda = conda;
   }
 
   @Autowired(required = false)
-  void setConanService(ConanService conan) {
+  public void setConanService(ConanService conan) {
     this.conan = conan;
   }
 
   @Autowired(required = false)
-  void setAptService(AptService apt) {
+  public void setAptService(AptService apt) {
     this.apt = apt;
   }
 
   @Autowired(required = false)
-  void setAlpineService(AlpineService alpine) {
+  public void setAlpineService(AlpineService alpine) {
     this.alpine = alpine;
   }
 
   @Autowired(required = false)
-  void setRService(RService r) {
+  public void setRService(RService r) {
     this.r = r;
   }
 
   @Autowired(required = false)
-  void setHuggingFaceService(HuggingFaceService huggingFace) {
+  public void setHuggingFaceService(HuggingFaceService huggingFace) {
     this.huggingFace = huggingFace;
   }
 
   @Autowired
-  public RepositoryContentController(RepositoryRuntimeRegistry registry,
+  public BuiltinRepositoryProtocolHandler(
       MavenHostedService hosted, MavenProxyService proxy, MavenGroupService group,
       GoProxyService goProxy, GoGroupService goGroup,
       HelmHostedService helmHosted, HelmProxyService helmProxy,
@@ -239,7 +247,6 @@ public class RepositoryContentController {
       ObjectMapper objectMapper,
       ForwardedHeaderPolicy forwardedHeaderPolicy,
       TerraformService terraform) {
-    this.registry = registry;
     this.hosted = hosted;
     this.proxy = proxy;
     this.group = group;
@@ -277,7 +284,7 @@ public class RepositoryContentController {
   }
 
   /** Backward-compatible full constructor retained for focused unit tests. */
-  public RepositoryContentController(RepositoryRuntimeRegistry registry,
+  public BuiltinRepositoryProtocolHandler(
       MavenHostedService hosted, MavenProxyService proxy, MavenGroupService group,
       GoProxyService goProxy, GoGroupService goGroup,
       HelmHostedService helmHosted, HelmProxyService helmProxy,
@@ -292,7 +299,7 @@ public class RepositoryContentController {
       NugetService nuget, RubygemsService rubygems, YumService yum,
       RawHostedService rawHosted, RawProxyService rawProxy, RawGroupService rawGroup,
       ObjectMapper objectMapper, ForwardedHeaderPolicy forwardedHeaderPolicy) {
-    this(registry, hosted, proxy, group, goProxy, goGroup, helmHosted, helmProxy, htmlListing,
+    this(hosted, proxy, group, goProxy, goGroup, helmHosted, helmProxy, htmlListing,
         npmHosted, npmProxy, npmGroup, npmSearch, npmToken, pypiHosted, pypiProxy, pypiGroup,
         cargoHosted, cargoProxy, cargoGroup, pubHosted, pubProxy, pubGroup,
         composerHosted, composerProxy, composerGroup, nuget, rubygems, yum,
@@ -300,7 +307,7 @@ public class RepositoryContentController {
   }
 
   /** Backward-compatible constructor used by focused controller unit tests. */
-  public RepositoryContentController(RepositoryRuntimeRegistry registry,
+  public BuiltinRepositoryProtocolHandler(
       MavenHostedService hosted, MavenProxyService proxy, MavenGroupService group,
       GoProxyService goProxy, GoGroupService goGroup,
       HelmHostedService helmHosted, HelmProxyService helmProxy,
@@ -316,7 +323,7 @@ public class RepositoryContentController {
       RawHostedService rawHosted, RawProxyService rawProxy, RawGroupService rawGroup,
       ObjectMapper objectMapper,
       ForwardedHeaderPolicy forwardedHeaderPolicy) {
-    this(registry, hosted, proxy, group, goProxy, goGroup, helmHosted, helmProxy, htmlListing,
+    this(hosted, proxy, group, goProxy, goGroup, helmHosted, helmProxy, htmlListing,
         npmHosted, npmProxy, npmGroup, npmSearch, npmToken,
         pypiHosted, pypiProxy, pypiGroup,
         cargoHosted, cargoProxy, cargoGroup,
@@ -325,15 +332,35 @@ public class RepositoryContentController {
         nuget, rubygems, yum, rawHosted, rawProxy, rawGroup, objectMapper, forwardedHeaderPolicy, null);
   }
 
-  @GetMapping("/**")
-  public ResponseEntity<StreamingResponseBody> get(
-      @PathVariable("name") String name, HttpServletRequest request) {
-    return serveBody(name, request, false);
+  @Override
+  public Collection<RepositoryProtocolRoute> routes() {
+    return ROUTES;
   }
 
-  @RequestMapping(value = "/**", method = RequestMethod.HEAD)
-  public ResponseEntity<Void> head(@PathVariable("name") String name, HttpServletRequest request) {
-    RepositoryRuntime runtime = resolveRuntime(name, request);
+  @Override
+  public ResponseEntity<?> handle(RepositoryProtocolRequest request)
+      throws IOException, ServletException {
+    return switch (request.method().name()) {
+      case "GET" -> get(request.runtime(), request.repositoryName(), request.servletRequest());
+      case "HEAD" -> head(request.runtime(), request.repositoryName(), request.servletRequest());
+      case "PUT" -> put(
+          request.runtime(), request.repositoryName(), request.servletRequest(), request.contentType());
+      case "DELETE" -> delete(
+          request.runtime(), request.repositoryName(), request.servletRequest());
+      case "POST" -> post(
+          request.runtime(), request.repositoryName(), request.servletRequest());
+      default -> throw new MavenExceptions.MethodNotAllowed(
+          "Unsupported repository HTTP method: " + request.method());
+    };
+  }
+
+  private ResponseEntity<StreamingResponseBody> get(
+      RepositoryRuntime runtime, String name, HttpServletRequest request) {
+    return serveBody(runtime, name, request, false);
+  }
+
+  private ResponseEntity<Void> head(
+      RepositoryRuntime runtime, String name, HttpServletRequest request) {
     if (runtime.format() == RepositoryFormat.NPM) {
       NpmPath path = npmParser.parse(extractRepositoryPath(name, request));
       return toHeadResponse(dispatchNpmGet(runtime, path, request, true), request);
@@ -456,13 +483,12 @@ public class RepositoryContentController {
     return toHeadResponse(resp, request);
   }
 
-  @PutMapping("/**")
-  public ResponseEntity<?> put(
-      @PathVariable("name") String name,
+  private ResponseEntity<?> put(
+      RepositoryRuntime runtime,
+      String name,
       HttpServletRequest request,
-      @RequestHeader(value = HttpHeaders.CONTENT_TYPE, required = false) String contentType)
+      String contentType)
       throws IOException, ServletException {
-    RepositoryRuntime runtime = resolveRuntime(name, request);
     String userId = requestUserId(request);
     if (runtime.format() == RepositoryFormat.NPM) {
       String rawPath = extractRepositoryPath(name, request);
@@ -664,9 +690,8 @@ public class RepositoryContentController {
     return ResponseEntity.status(resp.status()).build();
   }
 
-  @DeleteMapping("/**")
-  public ResponseEntity<?> delete(@PathVariable("name") String name, HttpServletRequest request) throws IOException {
-    RepositoryRuntime runtime = resolveRuntime(name, request);
+  private ResponseEntity<?> delete(
+      RepositoryRuntime runtime, String name, HttpServletRequest request) throws IOException {
     if (runtime.format() == RepositoryFormat.NPM) {
       String rawPath = extractRepositoryPath(name, request);
       if (NpmTokenService.isLogoutPath(rawPath)) {
@@ -760,9 +785,8 @@ public class RepositoryContentController {
     return ResponseEntity.status(resp.status()).build();
   }
 
-  @PostMapping("/**")
-  public ResponseEntity<?> post(@PathVariable("name") String name, HttpServletRequest request) {
-    RepositoryRuntime runtime = resolveRuntime(name, request);
+  private ResponseEntity<?> post(
+      RepositoryRuntime runtime, String name, HttpServletRequest request) {
     if (runtime.format() == RepositoryFormat.HUGGINGFACE) {
       String raw = extractRepositoryPath(name, request, true);
       try (InputStream body = request.getInputStream()) {
@@ -1000,22 +1024,8 @@ public class RepositoryContentController {
             "totalDependencies", 0));
   }
 
-  @PostMapping(value = "/api/charts", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-  public ResponseEntity<?> pushHelmChart(
-      @PathVariable("name") String name,
-      @RequestPart("chart") MultipartFile chart,
-      HttpServletRequest request) throws IOException {
-    RepositoryRuntime runtime = resolveRuntime(name, request);
-    if (runtime.format() != RepositoryFormat.HELM) {
-      throw new MavenExceptions.MethodNotAllowed("POST is not supported for " + runtime.format() + " repositories");
-    }
-    MavenResponse resp = helmHosted.push(runtime, chart, "anonymous", request.getRemoteAddr());
-    return ResponseEntity.status(resp.status()).build();
-  }
-
   private ResponseEntity<StreamingResponseBody> serveBody(
-      String name, HttpServletRequest request, boolean headOnly) {
-    RepositoryRuntime runtime = resolveRuntime(name, request);
+      RepositoryRuntime runtime, String name, HttpServletRequest request, boolean headOnly) {
     if (runtime.format() == RepositoryFormat.NPM) {
       NpmPath path = npmParser.parse(extractRepositoryPath(name, request));
       MavenResponse resp = dispatchNpmGet(runtime, path, request, headOnly);
@@ -1419,10 +1429,6 @@ public class RepositoryContentController {
     return converted.withStatus(response.status());
   }
 
-  private RuntimeAndPath resolve(String name, HttpServletRequest request) {
-    return resolve(resolveRuntime(name, request), name, request);
-  }
-
   private RuntimeAndPath resolve(RepositoryRuntime runtime, String name, HttpServletRequest request) {
     if (runtime.format() != RepositoryFormat.MAVEN2) {
       throw new MavenExceptions.MavenNotFoundException("Repository is not Maven format: " + name);
@@ -1430,22 +1436,6 @@ public class RepositoryContentController {
     String raw = extractMavenPath(name, request);
     MavenPath path = parser.parsePath(raw);
     return new RuntimeAndPath(runtime, path);
-  }
-
-  private RepositoryRuntime resolveRuntime(String name) {
-    return registry.resolve(name)
-        .orElseThrow(() -> new MavenExceptions.MavenNotFoundException("Repository not found: " + name));
-  }
-
-  private RepositoryRuntime resolveRuntime(String name, HttpServletRequest request) {
-    Object record = request == null
-        ? null : request.getAttribute(RepositorySecurityFilter.REPOSITORY_RECORD_ATTRIBUTE);
-    if (record instanceof RepositoryRecord repository && name.equals(repository.name())) {
-      return registry.resolve(repository)
-          .orElseThrow(() -> new MavenExceptions.MavenNotFoundException(
-              "Repository not found: " + name));
-    }
-    return resolveRuntime(name);
   }
 
   private SwiftService swift() {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/routing/helm/HelmChartUploadProtocolHandler.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/routing/helm/HelmChartUploadProtocolHandler.java
@@ -1,0 +1,53 @@
+package com.github.klboke.kkrepo.server.routing.helm;
+
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.server.helm.HelmHostedService;
+import com.github.klboke.kkrepo.server.maven.MavenExceptions;
+import com.github.klboke.kkrepo.server.maven.MavenResponse;
+import com.github.klboke.kkrepo.server.routing.RepositoryProtocolHandler;
+import com.github.klboke.kkrepo.server.routing.RepositoryProtocolRequest;
+import com.github.klboke.kkrepo.server.routing.RepositoryProtocolRoute;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+/** Exact multipart upload route, kept separate from the catch-all built-in protocol handler. */
+@Component
+public class HelmChartUploadProtocolHandler implements RepositoryProtocolHandler {
+  private static final List<RepositoryProtocolRoute> ROUTES = List.of(
+      RepositoryProtocolRoute.exactPath(
+          RepositoryFormat.HELM,
+          RepositoryType.HOSTED,
+          HttpMethod.POST,
+          "api/charts",
+          0));
+
+  private final HelmHostedService helm;
+
+  public HelmChartUploadProtocolHandler(HelmHostedService helm) {
+    this.helm = helm;
+  }
+
+  @Override
+  public Collection<RepositoryProtocolRoute> routes() {
+    return ROUTES;
+  }
+
+  @Override
+  public ResponseEntity<?> handle(RepositoryProtocolRequest request) throws IOException {
+    if (request.multipartFile() == null) {
+      throw new MavenExceptions.BadRequestException(
+          "Helm chart upload requires multipart field 'chart'");
+    }
+    MavenResponse response = helm.push(
+        request.runtime(),
+        request.multipartFile(),
+        "anonymous",
+        request.servletRequest().getRemoteAddr());
+    return ResponseEntity.status(response.status()).build();
+  }
+}

--- a/server/src/main/java/com/github/klboke/kkrepo/server/swift/SwiftErrorAdvice.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/swift/SwiftErrorAdvice.java
@@ -1,6 +1,6 @@
 package com.github.klboke.kkrepo.server.swift;
 
-import com.github.klboke.kkrepo.server.RepositoryContentController;
+import com.github.klboke.kkrepo.server.RepositoryProtocolController;
 import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 /** Keeps Spring's HTML/default error document out of Swift Package Registry responses. */
-@RestControllerAdvice(assignableTypes = RepositoryContentController.class)
+@RestControllerAdvice(assignableTypes = RepositoryProtocolController.class)
 public class SwiftErrorAdvice {
   @ExceptionHandler(SwiftExceptions.SwiftException.class)
   public ResponseEntity<Map<String, Object>> handle(

--- a/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerAlpineTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerAlpineTest.java
@@ -51,7 +51,7 @@ class RepositoryContentControllerAlpineTest {
       throws Exception {
     RepositoryRuntime runtime = runtime(type);
     AlpineService alpine = mock(AlpineService.class);
-    RepositoryContentController controller = controller(runtimes(runtime), alpine);
+    RepositoryProtocolController controller = controller(runtimes(runtime), alpine);
 
     ResponseEntity<StreamingResponseBody> get = controller.get(
         "alpine", request("GET", "/repository/alpine/"));
@@ -81,7 +81,7 @@ class RepositoryContentControllerAlpineTest {
   void bareRootGetAndHeadReturnNexusStyleBadRequest(RepositoryType type) throws Exception {
     RepositoryRuntime runtime = runtime(type);
     AlpineService alpine = mock(AlpineService.class);
-    RepositoryContentController controller = controller(runtimes(runtime), alpine);
+    RepositoryProtocolController controller = controller(runtimes(runtime), alpine);
 
     ResponseEntity<StreamingResponseBody> get = controller.get(
         "alpine", request("GET", "/repository/alpine"));
@@ -116,7 +116,7 @@ class RepositoryContentControllerAlpineTest {
             HttpHeaders.LOCATION, "v3.23/main/x86_64/demo-1-r0.apk"));
     when(alpine.delete(runtime, "v3.23/main/x86_64/demo-1-r0.apk",
         "repository-content-delete", true)).thenReturn(MavenResponse.noBody(204));
-    RepositoryContentController controller = controller(runtimes(runtime), alpine);
+    RepositoryProtocolController controller = controller(runtimes(runtime), alpine);
 
     MockHttpServletRequest get = request(
         "GET", "/repository/alpine/v3.23/main/x86_64/demo-1-r0.apk");
@@ -151,7 +151,7 @@ class RepositoryContentControllerAlpineTest {
     AlpineService alpine = mock(AlpineService.class);
     when(alpine.publish(eq(runtime), any(), any(), any(), any(), any(),
         eq("anonymous"), eq("127.0.0.1"))).thenReturn(published());
-    RepositoryContentController controller = controller(runtimes(runtime), alpine);
+    RepositoryProtocolController controller = controller(runtimes(runtime), alpine);
 
     MockHttpServletRequest named = multipartRequest();
     named.addPart(new MockPart("empty", new byte[0]));
@@ -187,7 +187,7 @@ class RepositoryContentControllerAlpineTest {
   @Test
   void rejectsInvalidPostRequestsAndUnavailableService() throws Exception {
     AlpineService alpine = mock(AlpineService.class);
-    RepositoryContentController hosted = controller(
+    RepositoryProtocolController hosted = controller(
         runtimes(runtime(RepositoryType.HOSTED)), alpine);
     MockHttpServletRequest path = request("POST", "/repository/alpine/not-root");
     path.setContentType("multipart/form-data; boundary=x");
@@ -201,12 +201,12 @@ class RepositoryContentControllerAlpineTest {
     assertThrows(MavenExceptions.BadRequestException.class,
         () -> hosted.post("alpine", multipartRequest()));
 
-    RepositoryContentController proxy = controller(
+    RepositoryProtocolController proxy = controller(
         runtimes(runtime(RepositoryType.PROXY)), alpine);
     assertThrows(MavenExceptions.MethodNotAllowed.class,
         () -> proxy.post("alpine", multipartRequest()));
 
-    RepositoryContentController unavailable = controller(
+    RepositoryProtocolController unavailable = controller(
         runtimes(runtime(RepositoryType.HOSTED)), null);
     assertThrows(IllegalStateException.class, () -> unavailable.head(
         "alpine", request("HEAD", "/repository/alpine/v3.23/main/x86_64/APKINDEX.tar.gz")));
@@ -216,7 +216,7 @@ class RepositoryContentControllerAlpineTest {
   @Test
   void mapsMultipartPartAndBodyFailuresToBadRequest() throws Exception {
     AlpineService alpine = mock(AlpineService.class);
-    RepositoryContentController controller = controller(
+    RepositoryProtocolController controller = controller(
         runtimes(runtime(RepositoryType.HOSTED)), alpine);
     MockHttpServletRequest invalidParts = new MockHttpServletRequest(
         "POST", "/repository/alpine/") {
@@ -273,9 +273,10 @@ class RepositoryContentControllerAlpineTest {
         60, 30, true, null, List.of());
   }
 
-  private static RepositoryContentController controller(
+  private static RepositoryProtocolController controller(
       RepositoryRuntimeRegistry runtimes, AlpineService alpine) {
-    RepositoryContentController controller = new RepositoryContentController(
+    RepositoryProtocolControllerTestSupport controller =
+        RepositoryProtocolControllerTestSupport.controller(
         runtimes,
         null, null, null,
         null, null,

--- a/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerAnsibleTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerAnsibleTest.java
@@ -55,7 +55,7 @@ class RepositoryContentControllerAnsibleTest {
         .thenReturn(MavenResponse.ok(
             new ByteArrayInputStream(archive), archive.length,
             "application/octet-stream", SHA256, Instant.EPOCH));
-    RepositoryContentController controller = controller(
+    RepositoryProtocolController controller = controller(
         runtimes, ansible, new AnsibleGalaxyMultipartReader(1024, 1024));
 
     MockHttpServletRequest head = request(
@@ -85,7 +85,7 @@ class RepositoryContentControllerAnsibleTest {
     String path = "api/v3/plugin/ansible/content/published/collections/artifacts/" + FILENAME;
     when(ansible.putArtifact(eq(runtime), eq(path), any(), eq("anonymous"), eq("192.0.2.10")))
         .thenReturn(MavenResponse.created());
-    RepositoryContentController controller = controller(
+    RepositoryProtocolController controller = controller(
         runtimes, ansible, new AnsibleGalaxyMultipartReader(1024, 1024));
     MockHttpServletRequest put = request("PUT", "/repository/ansible/" + path);
     put.setRemoteAddr("192.0.2.10");
@@ -116,7 +116,7 @@ class RepositoryContentControllerAnsibleTest {
         .thenReturn(MavenResponse.ok(
             new ByteArrayInputStream(responseBody), responseBody.length,
             "application/json", null, null).withStatus(202));
-    RepositoryContentController controller = controller(
+    RepositoryProtocolController controller = controller(
         runtimes, ansible, new AnsibleGalaxyMultipartReader(1024, 1024));
     MockHttpServletRequest request = request(
         "POST", "/repository/ansible/api/v3/artifacts/collections/");
@@ -145,7 +145,7 @@ class RepositoryContentControllerAnsibleTest {
         RepositoryRuntime runtime = nonHosted(type);
         AnsibleGalaxyService ansible = mock(AnsibleGalaxyService.class);
         AnsibleGalaxyMultipartReader reader = mock(AnsibleGalaxyMultipartReader.class);
-        RepositoryContentController controller = controller(runtimes(runtime), ansible, reader);
+        RepositoryProtocolController controller = controller(runtimes(runtime), ansible, reader);
         MockHttpServletRequest request = request(
             "POST", "/repository/ansible/api/v3/artifacts/collections/");
         request.setContentType(contentType);
@@ -168,7 +168,7 @@ class RepositoryContentControllerAnsibleTest {
     AnsibleGalaxyMultipartReader reader = mock(AnsibleGalaxyMultipartReader.class);
     doThrow(new AnsibleGalaxyExceptions.MethodNotAllowed("unsupported"))
         .when(ansible).validatePublishRequest(runtime, "api/v3/collections/acme/tools/", null);
-    RepositoryContentController controller = controller(runtimes(runtime), ansible, reader);
+    RepositoryProtocolController controller = controller(runtimes(runtime), ansible, reader);
     MockHttpServletRequest request = request(
         "POST", "/repository/ansible/api/v3/collections/acme/tools/");
     request.setContentType("multipart/form-data; boundary=x");
@@ -186,7 +186,7 @@ class RepositoryContentControllerAnsibleTest {
     RepositoryRuntime runtime = hosted();
     RepositoryRuntimeRegistry runtimes = runtimes(runtime);
     AnsibleGalaxyService ansible = mock(AnsibleGalaxyService.class);
-    RepositoryContentController controller = controller(runtimes, ansible, null);
+    RepositoryProtocolController controller = controller(runtimes, ansible, null);
     MockHttpServletRequest plain = request(
         "POST", "/repository/ansible/api/v3/artifacts/collections/");
     plain.setContentType("application/gzip");
@@ -200,7 +200,7 @@ class RepositoryContentControllerAnsibleTest {
     multipart.setContentType("multipart/form-data; boundary=x");
     assertThrows(IllegalStateException.class, () -> controller.post("ansible", multipart));
 
-    RepositoryContentController unavailable = controller(runtimes, null, null);
+    RepositoryProtocolController unavailable = controller(runtimes, null, null);
     assertThrows(IllegalStateException.class, () -> unavailable.head(
         "ansible", request("HEAD", "/repository/ansible/api/")));
   }
@@ -213,7 +213,7 @@ class RepositoryContentControllerAnsibleTest {
     AnsibleGalaxyMultipartReader.Upload upload = mock(AnsibleGalaxyMultipartReader.Upload.class);
     when(reader.read(any())).thenReturn(upload);
     when(upload.openStream()).thenThrow(new IOException("spool closed"));
-    RepositoryContentController controller = controller(runtimes(runtime), ansible, reader);
+    RepositoryProtocolController controller = controller(runtimes(runtime), ansible, reader);
     MockHttpServletRequest request = request(
         "POST", "/repository/ansible/api/v3/artifacts/collections/");
     request.setContentType("multipart/form-data; boundary=x");
@@ -223,11 +223,12 @@ class RepositoryContentControllerAnsibleTest {
     assertTrue(failure.getMessage().contains("Unable to read"));
   }
 
-  private static RepositoryContentController controller(
+  private static RepositoryProtocolController controller(
       RepositoryRuntimeRegistry runtimes,
       AnsibleGalaxyService ansible,
       AnsibleGalaxyMultipartReader multipart) {
-    RepositoryContentController controller = new RepositoryContentController(
+    RepositoryProtocolControllerTestSupport controller =
+        RepositoryProtocolControllerTestSupport.controller(
         runtimes,
         null, null, null,
         null, null,

--- a/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerAptTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerAptTest.java
@@ -68,7 +68,7 @@ class RepositoryContentControllerAptTest {
             HttpHeaders.LOCATION, "pool/d/demo/demo_1_amd64.deb"));
     when(apt.delete(runtime, "pool/d/demo/demo_1_amd64.deb",
         "repository-content-delete", true)).thenReturn(MavenResponse.noBody(204));
-    RepositoryContentController controller = controller(runtimes, apt, null);
+    RepositoryProtocolController controller = controller(runtimes, apt, null);
 
     MockHttpServletRequest get = request(
         "GET", "/repository/apt/pool/d/demo/demo_1_amd64.deb");
@@ -102,7 +102,7 @@ class RepositoryContentControllerAptTest {
     AptService apt = mock(AptService.class);
     when(apt.publish(eq(runtime), eq(null), any(), eq(null), eq(null),
         eq("anonymous"), eq("192.0.2.20"))).thenReturn(published());
-    RepositoryContentController controller = controller(runtimes(runtime), apt, null);
+    RepositoryProtocolController controller = controller(runtimes(runtime), apt, null);
     MockHttpServletRequest request = request("POST", "/repository/apt/");
     request.setRemoteAddr("192.0.2.20");
     request.setContentType("multipart/form-data");
@@ -122,7 +122,7 @@ class RepositoryContentControllerAptTest {
     AptService apt = mock(AptService.class);
     when(apt.publish(eq(runtime), anyString(), any(), any(), any(),
         eq("anonymous"), eq("127.0.0.1"))).thenReturn(published());
-    RepositoryContentController controller = controller(runtimes(runtime), apt, null);
+    RepositoryProtocolController controller = controller(runtimes(runtime), apt, null);
 
     MockHttpServletRequest named = multipartRequest();
     named.addPart(new MockPart("empty", new byte[0]));
@@ -146,7 +146,7 @@ class RepositoryContentControllerAptTest {
   @Test
   void rejectsInvalidAptPostRequestsAndUnavailableService() throws Exception {
     AptService apt = mock(AptService.class);
-    RepositoryContentController hosted = controller(
+    RepositoryProtocolController hosted = controller(
         runtimes(aptRuntime(RepositoryType.HOSTED)), apt, null);
     MockHttpServletRequest path = request("POST", "/repository/apt/not-root");
     path.setContentType("multipart/form-data; boundary=x");
@@ -159,12 +159,12 @@ class RepositoryContentControllerAptTest {
     MockHttpServletRequest missing = multipartRequest();
     assertThrows(MavenExceptions.BadRequestException.class, () -> hosted.post("apt", missing));
 
-    RepositoryContentController proxy = controller(
+    RepositoryProtocolController proxy = controller(
         runtimes(aptRuntime(RepositoryType.PROXY)), apt, null);
     assertThrows(MavenExceptions.MethodNotAllowed.class,
         () -> proxy.post("apt", multipartRequest()));
 
-    RepositoryContentController unavailable = controller(
+    RepositoryProtocolController unavailable = controller(
         runtimes(aptRuntime(RepositoryType.HOSTED)), null, null);
     assertThrows(IllegalStateException.class, () -> unavailable.head(
         "apt", request("HEAD", "/repository/apt/dists/stable/Release")));
@@ -175,7 +175,7 @@ class RepositoryContentControllerAptTest {
   void mapsMultipartPartAndBodyFailuresToBadRequest() throws Exception {
     RepositoryRuntime runtime = aptRuntime(RepositoryType.HOSTED);
     AptService apt = mock(AptService.class);
-    RepositoryContentController controller = controller(runtimes(runtime), apt, null);
+    RepositoryProtocolController controller = controller(runtimes(runtime), apt, null);
     MockHttpServletRequest invalidParts = new MockHttpServletRequest(
         "POST", "/repository/apt/") {
       @Override
@@ -222,7 +222,7 @@ class RepositoryContentControllerAptTest {
           assertTrue(signature.isEmpty());
           return PypiResponse.noBody(200);
         });
-    RepositoryContentController controller = controller(runtimes(runtime), null, pypi);
+    RepositoryProtocolController controller = controller(runtimes(runtime), null, pypi);
     MockHttpServletRequest request = new MockHttpServletRequest("POST", "/repository/pypi/");
     request.setRemoteAddr("192.0.2.30");
     request.setContentType("multipart/form-data; boundary=x");
@@ -241,7 +241,7 @@ class RepositoryContentControllerAptTest {
   @Test
   void validatesPypiRootMultipartBeforeUpload() throws Exception {
     PypiHostedService pypi = mock(PypiHostedService.class);
-    RepositoryContentController hosted = controller(
+    RepositoryProtocolController hosted = controller(
         runtimes(pypiRuntime(RepositoryType.HOSTED)), null, pypi);
     MockHttpServletRequest path = new MockHttpServletRequest(
         "POST", "/repository/pypi/project");
@@ -259,7 +259,7 @@ class RepositoryContentControllerAptTest {
     missing.setContentType("multipart/form-data; boundary=x");
     assertThrows(PypiExceptions.BadRequestException.class, () -> hosted.post("pypi", missing));
 
-    RepositoryContentController proxy = controller(
+    RepositoryProtocolController proxy = controller(
         runtimes(pypiRuntime(RepositoryType.PROXY)), null, pypi);
     assertThrows(PypiExceptions.MethodNotAllowed.class,
         () -> proxy.post("pypi", missing));
@@ -316,9 +316,10 @@ class RepositoryContentControllerAptTest {
         60, 30, true, null, List.of());
   }
 
-  private static RepositoryContentController controller(
+  private static RepositoryProtocolController controller(
       RepositoryRuntimeRegistry runtimes, AptService apt, PypiHostedService pypi) {
-    RepositoryContentController controller = new RepositoryContentController(
+    RepositoryProtocolControllerTestSupport controller =
+        RepositoryProtocolControllerTestSupport.controller(
         runtimes,
         null, null, null,
         null, null,

--- a/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerConanTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerConanTest.java
@@ -48,7 +48,7 @@ class RepositoryContentControllerConanTest {
         eq("a".repeat(40)), eq(false), eq(subject), eq("192.0.2.1")))
         .thenReturn(MavenResponse.noBody(200));
     when(conan.delete(eq(runtime), any())).thenReturn(MavenResponse.noBody(200));
-    RepositoryContentController controller = controller(runtimes, conan);
+    RepositoryProtocolController controller = controller(runtimes, conan);
 
     MockHttpServletRequest get = request(
         "GET", "/repository/conan-hosted/v2/conans/search");
@@ -86,7 +86,7 @@ class RepositoryContentControllerConanTest {
   void failsExplicitlyWhenOptionalConanServiceWasNotWired() {
     RepositoryRuntimeRegistry runtimes = mock(RepositoryRuntimeRegistry.class);
     when(runtimes.resolve("conan-hosted")).thenReturn(Optional.of(runtime()));
-    RepositoryContentController controller = controller(runtimes, null);
+    RepositoryProtocolController controller = controller(runtimes, null);
 
     assertThrows(IllegalStateException.class, () -> controller.get(
         "conan-hosted", request("GET", "/repository/conan-hosted/v1/ping")));
@@ -107,9 +107,10 @@ class RepositoryContentControllerConanTest {
         null, null, null, List.of());
   }
 
-  private static RepositoryContentController controller(
+  private static RepositoryProtocolController controller(
       RepositoryRuntimeRegistry runtimes, ConanService conan) {
-    RepositoryContentController controller = new RepositoryContentController(
+    RepositoryProtocolControllerTestSupport controller =
+        RepositoryProtocolControllerTestSupport.controller(
         runtimes,
         null, null, null,
         null, null,

--- a/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerCondaTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerCondaTest.java
@@ -50,7 +50,7 @@ class RepositoryContentControllerCondaTest {
         .thenReturn(MavenResponse.created());
     when(conda.delete(runtime, "main/linux-64/demo-1.0-0.conda"))
         .thenReturn(MavenResponse.noBody(204));
-    RepositoryContentController controller = controller(runtimes, conda);
+    RepositoryProtocolController controller = controller(runtimes, conda);
 
     MockHttpServletRequest get = new MockHttpServletRequest(
         "GET", "/repository/conda/main/linux-64/repodata.json");
@@ -91,7 +91,7 @@ class RepositoryContentControllerCondaTest {
     when(runtimes.resolve("conda")).thenReturn(Optional.of(runtime));
     when(conda.get(runtime, "main/linux-64/repodata.json", false)).thenReturn(
         MavenResponse.ok(body, 42, "application/json", "metadata-etag", Instant.EPOCH));
-    RepositoryContentController controller = controller(runtimes, conda);
+    RepositoryProtocolController controller = controller(runtimes, conda);
     MockHttpServletRequest request = new MockHttpServletRequest(
         "GET", "/repository/conda/main/linux-64/repodata.json");
     request.addHeader(HttpHeaders.IF_NONE_MATCH, "\"metadata-etag\"");
@@ -108,9 +108,10 @@ class RepositoryContentControllerCondaTest {
         true, 1L, "ALLOW_ONCE", null, null, true, null, null, null, null, null, List.of());
   }
 
-  private static RepositoryContentController controller(
+  private static RepositoryProtocolController controller(
       RepositoryRuntimeRegistry runtimes, CondaService conda) {
-    RepositoryContentController controller = new RepositoryContentController(
+    RepositoryProtocolControllerTestSupport controller =
+        RepositoryProtocolControllerTestSupport.controller(
         runtimes,
         null, null, null,
         null, null,

--- a/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerConditionalTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerConditionalTest.java
@@ -36,7 +36,7 @@ class RepositoryContentControllerConditionalTest {
   @Test
   void mavenRangeWithMatchingIfNoneMatchReturnsNotModifiedBeforeOpeningBody() {
     CountingHostedService hosted = new CountingHostedService();
-    RepositoryContentController controller = controller(hosted);
+    RepositoryProtocolController controller = controller(hosted);
     MockHttpServletRequest request = new MockHttpServletRequest(
         "GET", "/repository/maven/com/acme/app/1.0/app-1.0.jar");
     request.addHeader(HttpHeaders.RANGE, "bytes=1-3");
@@ -52,7 +52,7 @@ class RepositoryContentControllerConditionalTest {
   @Test
   void mavenRangeStillReturnsPartialBodyAfterConditionalMiss() throws Exception {
     CountingHostedService hosted = new CountingHostedService();
-    RepositoryContentController controller = controller(hosted);
+    RepositoryProtocolController controller = controller(hosted);
     MockHttpServletRequest request = new MockHttpServletRequest(
         "GET", "/repository/maven/com/acme/app/1.0/app-1.0.jar");
     request.addHeader(HttpHeaders.RANGE, "bytes=1-3");
@@ -70,7 +70,7 @@ class RepositoryContentControllerConditionalTest {
   @Test
   void cargoConfigWithMatchingIfNoneMatchReturnsNotModified() {
     CountingCargoHostedService cargoHosted = new CountingCargoHostedService();
-    RepositoryContentController controller = cargoController(cargoHosted);
+    RepositoryProtocolController controller = cargoController(cargoHosted);
     MockHttpServletRequest request = new MockHttpServletRequest(
         "GET", "/repository/cargo/config.json");
     request.addHeader(HttpHeaders.IF_NONE_MATCH, "\"cargo-config\"");
@@ -85,7 +85,7 @@ class RepositoryContentControllerConditionalTest {
   @Test
   void cargoHeadWithMatchingIfModifiedSinceReturnsNotModified() {
     CountingCargoHostedService cargoHosted = new CountingCargoHostedService();
-    RepositoryContentController controller = cargoController(cargoHosted);
+    RepositoryProtocolController controller = cargoController(cargoHosted);
     MockHttpServletRequest request = new MockHttpServletRequest(
         "HEAD", "/repository/cargo/config.json");
     request.addHeader(HttpHeaders.IF_MODIFIED_SINCE, "Mon, 08 Jun 2026 00:00:00 GMT");
@@ -99,7 +99,7 @@ class RepositoryContentControllerConditionalTest {
   @Test
   void cargoPublishReturnsJsonBytesInsteadOfSerializingStreamingResponseBody() throws Exception {
     CountingCargoHostedService cargoHosted = new CountingCargoHostedService();
-    RepositoryContentController controller = cargoController(cargoHosted);
+    RepositoryProtocolController controller = cargoController(cargoHosted);
     MockHttpServletRequest request = new MockHttpServletRequest(
         "PUT", "/repository/cargo/api/v1/crates/new");
     request.setContent("publish-body".getBytes(StandardCharsets.UTF_8));
@@ -114,23 +114,23 @@ class RepositoryContentControllerConditionalTest {
     assertEquals(body.length, response.getHeaders().getContentLength());
   }
 
-  private static RepositoryContentController controller(MavenHostedService hosted) {
+  private static RepositoryProtocolController controller(MavenHostedService hosted) {
     FakeRepositoryDao repositories = new FakeRepositoryDao();
     repositories.repository(repository("maven", RepositoryFormat.MAVEN2, RepositoryType.HOSTED));
     return controller(repositories, hosted, null);
   }
 
-  private static RepositoryContentController cargoController(CargoHostedService cargoHosted) {
+  private static RepositoryProtocolController cargoController(CargoHostedService cargoHosted) {
     FakeRepositoryDao repositories = new FakeRepositoryDao();
     repositories.repository(repository("cargo", RepositoryFormat.CARGO, RepositoryType.HOSTED));
     return controller(repositories, null, cargoHosted);
   }
 
-  private static RepositoryContentController controller(
+  private static RepositoryProtocolController controller(
       FakeRepositoryDao repositories,
       MavenHostedService hosted,
       CargoHostedService cargoHosted) {
-    return new RepositoryContentController(
+    return RepositoryProtocolControllerTestSupport.controller(
         new RepositoryRuntimeRegistry(repositories, 0),
         hosted, null, null,
         null, null,

--- a/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerHuggingFaceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerHuggingFaceTest.java
@@ -39,7 +39,7 @@ class RepositoryContentControllerHuggingFaceTest {
   void trailingSlashRootGetAndHeadServeNexusStyleRepositoryHtml() throws Exception {
     RepositoryRuntime runtime = proxy();
     HuggingFaceService huggingFace = mock(HuggingFaceService.class);
-    RepositoryContentController controller = controller(runtimes(runtime), huggingFace);
+    RepositoryProtocolController controller = controller(runtimes(runtime), huggingFace);
 
     ResponseEntity<StreamingResponseBody> get = controller.get(
         "hf", request("GET", "/repository/hf/"));
@@ -68,7 +68,7 @@ class RepositoryContentControllerHuggingFaceTest {
   void bareRootGetAndHeadReturnNexusStyleBadRequest() throws Exception {
     RepositoryRuntime runtime = proxy();
     HuggingFaceService huggingFace = mock(HuggingFaceService.class);
-    RepositoryContentController controller = controller(runtimes(runtime), huggingFace);
+    RepositoryProtocolController controller = controller(runtimes(runtime), huggingFace);
 
     ResponseEntity<StreamingResponseBody> get = controller.get(
         "hf", request("GET", "/repository/hf"));
@@ -108,7 +108,7 @@ class RepositoryContentControllerHuggingFaceTest {
         .thenReturn(MavenResponse.ok(
             new ByteArrayInputStream(responseBody), responseBody.length,
             MediaType.APPLICATION_JSON_VALUE, "paths-etag", null));
-    RepositoryContentController controller = controller(runtimes, huggingFace);
+    RepositoryProtocolController controller = controller(runtimes, huggingFace);
     MockHttpServletRequest request = new MockHttpServletRequest(
         "POST",
         "/repository/hf/api/models/org/model/paths-info/"
@@ -142,7 +142,7 @@ class RepositoryContentControllerHuggingFaceTest {
         .thenReturn(MavenResponse.ok(
             new ByteArrayInputStream(new byte[0]), 123L,
             MediaType.APPLICATION_OCTET_STREAM_VALUE, "config-etag", null));
-    RepositoryContentController controller = controller(runtimes, huggingFace);
+    RepositoryProtocolController controller = controller(runtimes, huggingFace);
     MockHttpServletRequest request = request(
         "HEAD", "/repository/hf/org/model/resolve/main/config.json");
     request.setQueryString("download=true");
@@ -174,7 +174,7 @@ class RepositoryContentControllerHuggingFaceTest {
         .thenReturn(MavenResponse.ok(
             new ByteArrayInputStream(artifact), artifact.length,
             MediaType.APPLICATION_OCTET_STREAM_VALUE, "file-etag", null));
-    RepositoryContentController controller = controller(runtimes, huggingFace);
+    RepositoryProtocolController controller = controller(runtimes, huggingFace);
 
     ResponseEntity<?> metadataResponse = controller.get(
         "hf", request("GET", "/repository/hf/api/models/org/model"));
@@ -196,7 +196,7 @@ class RepositoryContentControllerHuggingFaceTest {
   void rejectsUnreadablePathsInfoBody() {
     RepositoryRuntimeRegistry runtimes = mock(RepositoryRuntimeRegistry.class);
     when(runtimes.resolve("hf")).thenReturn(Optional.of(proxy()));
-    RepositoryContentController controller = controller(runtimes, mock(HuggingFaceService.class));
+    RepositoryProtocolController controller = controller(runtimes, mock(HuggingFaceService.class));
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRequestURI())
         .thenReturn("/repository/hf/api/models/org/model/paths-info/main");
@@ -216,7 +216,7 @@ class RepositoryContentControllerHuggingFaceTest {
   void failsClosedWhenHuggingFaceServiceIsUnavailable() {
     RepositoryRuntimeRegistry runtimes = mock(RepositoryRuntimeRegistry.class);
     when(runtimes.resolve("hf")).thenReturn(Optional.of(proxy()));
-    RepositoryContentController controller = controller(runtimes, null);
+    RepositoryProtocolController controller = controller(runtimes, null);
 
     assertThrows(
         IllegalStateException.class,
@@ -259,9 +259,10 @@ class RepositoryContentControllerHuggingFaceTest {
     return request;
   }
 
-  private static RepositoryContentController controller(
+  private static RepositoryProtocolController controller(
       RepositoryRuntimeRegistry runtimes, HuggingFaceService huggingFace) {
-    RepositoryContentController controller = new RepositoryContentController(
+    RepositoryProtocolControllerTestSupport controller =
+        RepositoryProtocolControllerTestSupport.controller(
         runtimes,
         null, null, null,
         null, null,

--- a/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerNpmAuditTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerNpmAuditTest.java
@@ -22,7 +22,7 @@ class RepositoryContentControllerNpmAuditTest {
   void npmAdvisoriesBulkReturnsEmptyCompatibilityResponse() {
     FakeRepositoryDao repositories = new FakeRepositoryDao();
     repositories.repository(repository("npm-example", RepositoryFormat.NPM, RepositoryType.GROUP));
-    RepositoryContentController controller = controller(repositories);
+    RepositoryProtocolController controller = controller(repositories);
     MockHttpServletRequest request = new MockHttpServletRequest(
         "POST", "/repository/npm-example/-/npm/v1/security/advisories/bulk");
 
@@ -37,7 +37,7 @@ class RepositoryContentControllerNpmAuditTest {
   void npmAuditQuickReturnsEmptyAuditReport() {
     FakeRepositoryDao repositories = new FakeRepositoryDao();
     repositories.repository(repository("npm-example", RepositoryFormat.NPM, RepositoryType.GROUP));
-    RepositoryContentController controller = controller(repositories);
+    RepositoryProtocolController controller = controller(repositories);
     MockHttpServletRequest request = new MockHttpServletRequest(
         "POST", "/repository/npm-example/-/npm/v1/security/audits/quick");
 
@@ -51,8 +51,8 @@ class RepositoryContentControllerNpmAuditTest {
     assertEquals(0, ((Map<String, Object>) body.get("metadata")).get("totalDependencies"));
   }
 
-  private static RepositoryContentController controller(FakeRepositoryDao repositories) {
-    return new RepositoryContentController(
+  private static RepositoryProtocolController controller(FakeRepositoryDao repositories) {
+    return RepositoryProtocolControllerTestSupport.controller(
         new RepositoryRuntimeRegistry(repositories, 0),
         null, null, null,
         null, null,

--- a/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerNugetTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerNugetTest.java
@@ -33,7 +33,7 @@ class RepositoryContentControllerNugetTest {
     repositories.repository(repository("nuget-hosted", RepositoryFormat.NUGET, RepositoryType.HOSTED));
     ObjectMapper objectMapper = new ObjectMapper();
     NugetService nuget = new NugetService(null, null, null, objectMapper);
-    RepositoryContentController controller = controller(repositories, nuget);
+    RepositoryProtocolController controller = controller(repositories, nuget);
     MockHttpServletRequest request = new MockHttpServletRequest(
         "GET", "/repository/nuget-hosted/");
     request.setScheme("http");
@@ -56,7 +56,7 @@ class RepositoryContentControllerNugetTest {
     FakeRepositoryDao repositories = new FakeRepositoryDao();
     repositories.repository(repository("nuget-hosted", RepositoryFormat.NUGET, RepositoryType.HOSTED));
     CapturingNugetService nuget = new CapturingNugetService();
-    RepositoryContentController controller = controller(repositories, nuget);
+    RepositoryProtocolController controller = controller(repositories, nuget);
     MockHttpServletRequest request = new MockHttpServletRequest(
         "PUT", "/repository/nuget-hosted/");
     request.setContentType("multipart/form-data; boundary=test");
@@ -75,7 +75,7 @@ class RepositoryContentControllerNugetTest {
     FakeRepositoryDao repositories = new FakeRepositoryDao();
     repositories.repository(repository("nuget-hosted", RepositoryFormat.NUGET, RepositoryType.HOSTED));
     CapturingNugetService nuget = new CapturingNugetService();
-    RepositoryContentController controller = controller(repositories, nuget);
+    RepositoryProtocolController controller = controller(repositories, nuget);
     MockHttpServletRequest request = new MockHttpServletRequest(
         "PUT", "/repository/nuget-hosted/api/v2/package/");
     request.setContentType("application/octet-stream");
@@ -93,7 +93,7 @@ class RepositoryContentControllerNugetTest {
     FakeRepositoryDao repositories = new FakeRepositoryDao();
     repositories.repository(repository("nuget-hosted", RepositoryFormat.NUGET, RepositoryType.HOSTED));
     CapturingNugetService nuget = new CapturingNugetService();
-    RepositoryContentController controller = controller(repositories, nuget);
+    RepositoryProtocolController controller = controller(repositories, nuget);
     MockHttpServletRequest request = new MockHttpServletRequest(
         "PUT", "/repository/nuget-hosted/api/v2/package/");
     request.setContentType("multipart/form-data; boundary=test");
@@ -107,8 +107,8 @@ class RepositoryContentControllerNugetTest {
     assertEquals("fake nupkg", nuget.body);
   }
 
-  private static RepositoryContentController controller(FakeRepositoryDao repositories, NugetService nuget) {
-    return new RepositoryContentController(
+  private static RepositoryProtocolController controller(FakeRepositoryDao repositories, NugetService nuget) {
+    return RepositoryProtocolControllerTestSupport.controller(
         new com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry(repositories, 0),
         null, null, null,
         null, null,

--- a/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerPubRoutingTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerPubRoutingTest.java
@@ -39,7 +39,8 @@ class RepositoryContentControllerPubRoutingTest {
     repositories.repository(repository("pub-group", RepositoryFormat.PUB, RepositoryType.GROUP));
     RepositoryRuntimeRegistry registry = new RepositoryRuntimeRegistry(repositories, 0);
     CapturingPubGroupService pubGroup = new CapturingPubGroupService();
-    RepositoryContentController contentController = new RepositoryContentController(
+    RepositoryProtocolController contentController =
+        RepositoryProtocolControllerTestSupport.controller(
         registry,
         null, null, null,
         null, null,

--- a/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerRTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerRTest.java
@@ -42,7 +42,7 @@ class RepositoryContentControllerRTest {
       throws Exception {
     RepositoryRuntime runtime = runtime(type);
     RService r = mock(RService.class);
-    RepositoryContentController controller = controller(runtimes(runtime), r);
+    RepositoryProtocolController controller = controller(runtimes(runtime), r);
 
     ResponseEntity<StreamingResponseBody> get = controller.get(
         "cran", request("GET", "/repository/cran/"));
@@ -87,7 +87,7 @@ class RepositoryContentControllerRTest {
             MavenResponse.noBody(200).withHeader(HttpHeaders.LOCATION, path));
     when(r.delete(runtime, path, "repository-content-delete", true))
         .thenReturn(MavenResponse.noBody(204));
-    RepositoryContentController controller = controller(runtimes(runtime), r);
+    RepositoryProtocolController controller = controller(runtimes(runtime), r);
 
     ResponseEntity<StreamingResponseBody> get = controller.get(
         "cran", request("GET", "/repository/cran/" + path));
@@ -113,7 +113,7 @@ class RepositoryContentControllerRTest {
 
   @Test
   void reportsUnavailableRServiceAtContentBoundary() {
-    RepositoryContentController controller = controller(
+    RepositoryProtocolController controller = controller(
         runtimes(runtime(RepositoryType.HOSTED)), null);
     assertThrows(IllegalStateException.class, () -> controller.get(
         "cran", request("GET", "/repository/cran/src/contrib/PACKAGES.gz")));
@@ -139,9 +139,10 @@ class RepositoryContentControllerRTest {
         60, 30, true, null, List.of());
   }
 
-  private static RepositoryContentController controller(
+  private static RepositoryProtocolController controller(
       RepositoryRuntimeRegistry runtimes, RService r) {
-    RepositoryContentController controller = new RepositoryContentController(
+    RepositoryProtocolControllerTestSupport controller =
+        RepositoryProtocolControllerTestSupport.controller(
         runtimes,
         null, null, null,
         null, null,

--- a/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerRubygemsTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerRubygemsTest.java
@@ -146,9 +146,9 @@ class RepositoryContentControllerRubygemsTest {
     return out.toString(StandardCharsets.UTF_8);
   }
 
-  private static RepositoryContentController controller(
+  private static RepositoryProtocolController controller(
       FakeRepositoryDao repositories, RubygemsService rubygems) {
-    return new RepositoryContentController(
+    return RepositoryProtocolControllerTestSupport.controller(
         new RepositoryRuntimeRegistry(repositories, 0),
         null, null, null,
         null, null,
@@ -186,7 +186,7 @@ class RepositoryContentControllerRubygemsTest {
 
   private record TestContext(
       String repositoryName,
-      RepositoryContentController controller,
+      RepositoryProtocolController controller,
       CapturingRubygemsService rubygems) {}
 
   private static final class FakeRepositoryDao extends RepositoryDaoAdapter {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerSwiftTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerSwiftTest.java
@@ -62,7 +62,7 @@ class RepositoryContentControllerSwiftTest {
             SwiftMediaTypes.ARCHIVE,
             "archive-etag",
             Instant.EPOCH));
-    RepositoryContentController controller = controller(runtimes, swift);
+    RepositoryProtocolController controller = controller(runtimes, swift);
     MockHttpServletRequest request = request(
         "GET", "/repository/swift/Acme/Demo/1.2.3.zip");
     request.setQueryString("download=1");
@@ -104,7 +104,7 @@ class RepositoryContentControllerSwiftTest {
             SwiftMediaTypes.JSON,
             "metadata-etag",
             Instant.EPOCH));
-    RepositoryContentController controller = controller(runtimes, swift);
+    RepositoryProtocolController controller = controller(runtimes, swift);
     MockHttpServletRequest request = request(
         "GET", "/repository/swift/Acme/Demo/1.2.3+linux.zip");
     request.addHeader(HttpHeaders.ACCEPT, SwiftMediaTypes.VENDOR_JSON);
@@ -140,7 +140,7 @@ class RepositoryContentControllerSwiftTest {
             eq(permissionSubject)))
         .thenReturn(MavenResponse.noBody(
             200, 42, SwiftMediaTypes.MANIFEST, "manifest-etag", Instant.EPOCH));
-    RepositoryContentController controller = controller(runtimes, swift);
+    RepositoryProtocolController controller = controller(runtimes, swift);
     MockHttpServletRequest request = request(
         "HEAD", "/repository/swift/Acme/Demo/1.2.3/Package.swift");
     request.setQueryString("swift-version=5.9");
@@ -182,7 +182,7 @@ class RepositoryContentControllerSwiftTest {
             .withStatus(201)
             .withHeader("Content-Version", "1")
             .withHeader("Location", "https://repo.example/repository/swift/Acme/Demo/1.2.3"));
-    RepositoryContentController controller = controller(runtimes, swift);
+    RepositoryProtocolController controller = controller(runtimes, swift);
     MockHttpServletRequest request = request(
         "PUT", "/repository/swift/Acme/Demo/1.2.3");
     request.setQueryString("source=swiftpm");
@@ -220,7 +220,7 @@ class RepositoryContentControllerSwiftTest {
     RepositoryRuntimeRegistry runtimes = mock(RepositoryRuntimeRegistry.class);
     SwiftService swift = mock(SwiftService.class);
     when(runtimes.resolve("swift")).thenReturn(Optional.of(hosted()));
-    RepositoryContentController controller = controller(runtimes, swift);
+    RepositoryProtocolController controller = controller(runtimes, swift);
     MockHttpServletRequest request = request(
         "PUT", "/repository/swift/Acme/Demo/1.2.3");
 
@@ -239,7 +239,7 @@ class RepositoryContentControllerSwiftTest {
     when(swift.validatePublishRequest(
         eq(runtime), eq("Acme/Demo/1.2.3"), eq(null), eq(null)))
         .thenThrow(new SwiftExceptions.MethodNotAllowed("read-only"));
-    RepositoryContentController controller = controller(runtimes, swift);
+    RepositoryProtocolController controller = controller(runtimes, swift);
     MockHttpServletRequest request = new MockHttpServletRequest(
         "PUT", "/repository/swift/Acme/Demo/1.2.3") {
       @Override
@@ -264,7 +264,7 @@ class RepositoryContentControllerSwiftTest {
     when(swift.validatePublishRequest(
         eq(runtime), eq("Acme/Demo/1.2.3"), eq(null), eq(null)))
         .thenThrow(new SwiftExceptions.Conflict("Swift release already exists"));
-    RepositoryContentController controller = controller(runtimes, swift);
+    RepositoryProtocolController controller = controller(runtimes, swift);
     MockHttpServletRequest request = new MockHttpServletRequest(
         "PUT", "/repository/swift/Acme/Demo/1.2.3") {
       @Override
@@ -287,7 +287,7 @@ class RepositoryContentControllerSwiftTest {
     SwiftService swift = mock(SwiftService.class);
     when(runtimes.resolve("swift")).thenReturn(Optional.of(runtime));
     when(swift.login(runtime)).thenReturn(MavenResponse.noBody(200));
-    RepositoryContentController controller = controller(runtimes, swift);
+    RepositoryProtocolController controller = controller(runtimes, swift);
 
     ResponseEntity<?> response = controller.post(
         "swift", request("POST", "/repository/swift/login"));
@@ -328,9 +328,10 @@ class RepositoryContentControllerSwiftTest {
         List.of());
   }
 
-  private static RepositoryContentController controller(
+  private static RepositoryProtocolController controller(
       RepositoryRuntimeRegistry runtimes, SwiftService swift) {
-    RepositoryContentController controller = new RepositoryContentController(
+    RepositoryProtocolControllerTestSupport controller =
+        RepositoryProtocolControllerTestSupport.controller(
         runtimes,
         null, null, null,
         null, null,

--- a/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerTerraformTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerTerraformTest.java
@@ -56,7 +56,7 @@ class RepositoryContentControllerTerraformTest {
             any(),
             eq("127.0.0.1")))
         .thenReturn(MavenResponse.created());
-    RepositoryContentController controller = controller(runtimes, terraform);
+    RepositoryProtocolController controller = controller(runtimes, terraform);
     MockHttpServletRequest request = new MockHttpServletRequest(
         "PUT", "/repository/terraform/v1/providers/acme/cloud/1.2.3/download/linux/amd64");
     request.setContent(new byte[] {1});
@@ -80,9 +80,9 @@ class RepositoryContentControllerTerraformTest {
         eq("127.0.0.1"));
   }
 
-  private static RepositoryContentController controller(
+  private static RepositoryProtocolController controller(
       RepositoryRuntimeRegistry runtimes, TerraformService terraform) {
-    return new RepositoryContentController(
+    return RepositoryProtocolControllerTestSupport.controller(
         runtimes,
         null, null, null,
         null, null,

--- a/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryProtocolControllerTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryProtocolControllerTest.java
@@ -1,0 +1,70 @@
+package com.github.klboke.kkrepo.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.github.klboke.kkrepo.server.routing.RepositoryProtocolDispatcher;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.multipart.MultipartFile;
+
+class RepositoryProtocolControllerTest {
+  @Test
+  void delegatesEveryHttpEntryPointWithoutOwningProtocolLogic() throws Exception {
+    RepositoryProtocolDispatcher dispatcher = mock(RepositoryProtocolDispatcher.class);
+    RepositoryProtocolController controller = new RepositoryProtocolController(dispatcher);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MultipartFile chart = mock(MultipartFile.class);
+    ResponseEntity<?> get = ResponseEntity.status(200).build();
+    ResponseEntity<?> head = ResponseEntity.status(204).build();
+    ResponseEntity<?> put = ResponseEntity.status(201).build();
+    ResponseEntity<?> typedPut = ResponseEntity.status(202).build();
+    ResponseEntity<?> delete = ResponseEntity.status(203).build();
+    ResponseEntity<?> post = ResponseEntity.status(205).build();
+    ResponseEntity<?> helm = ResponseEntity.status(206).build();
+    doReturn(get).when(dispatcher).dispatchRead("repo", request, HttpMethod.GET);
+    doReturn(head).when(dispatcher).dispatchRead("repo", request, HttpMethod.HEAD);
+    doReturn(put).when(dispatcher)
+        .dispatch("repo", request, HttpMethod.PUT, (MultipartFile) null);
+    doReturn(typedPut).when(dispatcher)
+        .dispatch("repo", request, HttpMethod.PUT, "application/octet-stream", null);
+    doReturn(delete).when(dispatcher)
+        .dispatch("repo", request, HttpMethod.DELETE, (MultipartFile) null);
+    doReturn(post).when(dispatcher)
+        .dispatch("repo", request, HttpMethod.POST, (MultipartFile) null);
+    doReturn(helm).when(dispatcher).dispatch("repo", request, HttpMethod.POST, chart);
+
+    assertSame(get, controller.get("repo", request));
+    assertSame(head, controller.head("repo", request));
+    assertSame(put, controller.put("repo", request));
+    assertSame(typedPut, controller.put("repo", request, "application/octet-stream"));
+    assertSame(delete, controller.delete("repo", request));
+    assertSame(post, controller.post("repo", request));
+    assertSame(helm, controller.pushHelmChart("repo", chart, request));
+    assertEquals(206, helm.getStatusCode().value());
+
+    verify(dispatcher).dispatch("repo", request, HttpMethod.POST, chart);
+  }
+
+  @Test
+  void translatesCheckedPostFailureAtTheHttpBoundary() throws Exception {
+    RepositoryProtocolDispatcher dispatcher = mock(RepositoryProtocolDispatcher.class);
+    RepositoryProtocolController controller = new RepositoryProtocolController(dispatcher);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    doThrow(new java.io.IOException("failed")).when(dispatcher)
+        .dispatch("repo", request, HttpMethod.POST, (MultipartFile) null);
+
+    IllegalStateException error = assertThrows(
+        IllegalStateException.class, () -> controller.post("repo", request));
+
+    assertEquals("Repository POST handler failed", error.getMessage());
+    assertEquals("failed", error.getCause().getMessage());
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryProtocolControllerTestSupport.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryProtocolControllerTestSupport.java
@@ -1,0 +1,100 @@
+package com.github.klboke.kkrepo.server;
+
+import com.github.klboke.kkrepo.server.alpine.AlpineService;
+import com.github.klboke.kkrepo.server.ansible.AnsibleGalaxyMultipartReader;
+import com.github.klboke.kkrepo.server.ansible.AnsibleGalaxyService;
+import com.github.klboke.kkrepo.server.apt.AptService;
+import com.github.klboke.kkrepo.server.conda.CondaService;
+import com.github.klboke.kkrepo.server.conan.ConanService;
+import com.github.klboke.kkrepo.server.huggingface.HuggingFaceService;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
+import com.github.klboke.kkrepo.server.r.RService;
+import com.github.klboke.kkrepo.server.routing.RepositoryProtocolDispatcher;
+import com.github.klboke.kkrepo.server.routing.builtin.BuiltinRepositoryProtocolHandler;
+import com.github.klboke.kkrepo.server.swift.SwiftService;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.List;
+
+/** Keeps focused legacy routing tests readable while production controllers stay protocol-free. */
+public final class RepositoryProtocolControllerTestSupport extends RepositoryProtocolController {
+  private final BuiltinRepositoryProtocolHandler handler;
+
+  private RepositoryProtocolControllerTestSupport(
+      RepositoryProtocolDispatcher dispatcher, BuiltinRepositoryProtocolHandler handler) {
+    super(dispatcher);
+    this.handler = handler;
+  }
+
+  public static RepositoryProtocolControllerTestSupport controller(
+      RepositoryRuntimeRegistry runtimes, Object... dependencies) {
+    BuiltinRepositoryProtocolHandler handler = instantiate(dependencies);
+    return new RepositoryProtocolControllerTestSupport(
+        new RepositoryProtocolDispatcher(runtimes, List.of(handler)), handler);
+  }
+
+  private static BuiltinRepositoryProtocolHandler instantiate(Object[] arguments) {
+    Constructor<?> constructor = Arrays.stream(BuiltinRepositoryProtocolHandler.class
+            .getConstructors())
+        .filter(candidate -> candidate.getParameterCount() == arguments.length)
+        .filter(candidate -> compatible(candidate.getParameterTypes(), arguments))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException(
+            "No built-in protocol handler constructor accepts " + arguments.length
+                + " test arguments"));
+    try {
+      return (BuiltinRepositoryProtocolHandler) constructor.newInstance(arguments);
+    } catch (InstantiationException | IllegalAccessException error) {
+      throw new IllegalStateException("Cannot create built-in protocol test handler", error);
+    } catch (InvocationTargetException error) {
+      throw new IllegalStateException(
+          "Built-in protocol test handler construction failed", error.getCause());
+    }
+  }
+
+  private static boolean compatible(Class<?>[] parameterTypes, Object[] arguments) {
+    for (int index = 0; index < parameterTypes.length; index++) {
+      if (arguments[index] != null && !parameterTypes[index].isInstance(arguments[index])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  void setSwiftService(SwiftService service) {
+    handler.setSwiftService(service);
+  }
+
+  void setAnsibleGalaxyService(AnsibleGalaxyService service) {
+    handler.setAnsibleGalaxyService(service);
+  }
+
+  void setAnsibleGalaxyMultipartReader(AnsibleGalaxyMultipartReader reader) {
+    handler.setAnsibleGalaxyMultipartReader(reader);
+  }
+
+  void setCondaService(CondaService service) {
+    handler.setCondaService(service);
+  }
+
+  void setConanService(ConanService service) {
+    handler.setConanService(service);
+  }
+
+  void setAptService(AptService service) {
+    handler.setAptService(service);
+  }
+
+  void setAlpineService(AlpineService service) {
+    handler.setAlpineService(service);
+  }
+
+  void setHuggingFaceService(HuggingFaceService service) {
+    handler.setHuggingFaceService(service);
+  }
+
+  void setRService(RService service) {
+    handler.setRService(service);
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/architecture/RepositoryRoutingArchitectureTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/architecture/RepositoryRoutingArchitectureTest.java
@@ -1,0 +1,90 @@
+package com.github.klboke.kkrepo.server.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.github.klboke.kkrepo.server.RepositoryProtocolController;
+import com.github.klboke.kkrepo.server.routing.RepositoryProtocolHandler;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.Test;
+
+class RepositoryRoutingArchitectureTest {
+  private static final String ROOT = "com.github.klboke.kkrepo";
+
+  @Test
+  void repositoryProtocolControllerDependsOnlyOnTheRoutingBoundary() {
+    ArchRule rule = classes()
+        .that().haveFullyQualifiedName(RepositoryProtocolController.class.getName())
+        .should().onlyDependOnClassesThat().resideInAnyPackage(
+            "java..",
+            "jakarta.servlet..",
+            "org.springframework..",
+            "com.github.klboke.kkrepo.server",
+            "com.github.klboke.kkrepo.server.routing");
+
+    rule.check(serverClasses());
+  }
+
+  @Test
+  void protocolRuntimeServicesDoNotReferenceTheRoutingLayer() {
+    ArchRule rule = noClasses()
+        .that().resideInAnyPackage(
+            "..server.alpine..",
+            "..server.ansible..",
+            "..server.apt..",
+            "..server.cargo..",
+            "..server.composer..",
+            "..server.conda..",
+            "..server.conan..",
+            "..server.docker..",
+            "..server.goartifact..",
+            "..server.helm..",
+            "..server.huggingface..",
+            "..server.maven..",
+            "..server.npm..",
+            "..server.nuget..",
+            "..server.pub..",
+            "..server.pypi..",
+            "..server.r..",
+            "..server.raw..",
+            "..server.rubygems..",
+            "..server.swift..",
+            "..server.terraform..",
+            "..server.yum..")
+        .should().dependOnClassesThat().resideInAnyPackage("..server.routing..");
+
+    rule.check(serverClasses());
+  }
+
+  @Test
+  void protocolModulesDoNotReferenceTheServerModule() {
+    ArchRule rule = noClasses()
+        .that().resideInAnyPackage("..protocol..")
+        .should().dependOnClassesThat().resideInAnyPackage("..server..");
+
+    rule.check(allProjectClasses());
+  }
+
+  @Test
+  void routeHandlersStayInsideTheRoutingLayer() {
+    ArchRule rule = classes()
+        .that().implement(RepositoryProtocolHandler.class)
+        .should().resideInAPackage("..server.routing..");
+
+    rule.check(serverClasses());
+  }
+
+  private static com.tngtech.archunit.core.domain.JavaClasses serverClasses() {
+    return new ClassFileImporter()
+        .withImportOption(new ImportOption.DoNotIncludeTests())
+        .importPackages(ROOT + ".server");
+  }
+
+  private static com.tngtech.archunit.core.domain.JavaClasses allProjectClasses() {
+    return new ClassFileImporter()
+        .withImportOption(new ImportOption.DoNotIncludeTests())
+        .importPackages(ROOT);
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/composer/ComposerRepositoryControllerPathTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/composer/ComposerRepositoryControllerPathTest.java
@@ -7,7 +7,8 @@ import com.github.klboke.kkrepo.core.RepositoryFormat;
 import com.github.klboke.kkrepo.core.RepositoryType;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.RepositoryRecord;
 import com.github.klboke.kkrepo.protocol.composer.ComposerPath;
-import com.github.klboke.kkrepo.server.RepositoryContentController;
+import com.github.klboke.kkrepo.server.RepositoryProtocolController;
+import com.github.klboke.kkrepo.server.RepositoryProtocolControllerTestSupport;
 import com.github.klboke.kkrepo.server.maven.MavenResponse;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
@@ -24,7 +25,7 @@ class ComposerRepositoryControllerPathTest {
   @Test
   void getUsesFilterCanonicalPathWithoutDecodingItAgain() {
     RecordingHostedService hosted = new RecordingHostedService();
-    RepositoryContentController controller = controller(hosted);
+    RepositoryProtocolController controller = controller(hosted);
     MockHttpServletRequest request = request(
         "/repository/composer/company/example/1.0.0/"
             + "company-example-1.0.0%252Bbuild.zip");
@@ -42,7 +43,7 @@ class ComposerRepositoryControllerPathTest {
   @Test
   void headCanonicalizesDirectRequestOnceWhenFilterIsAbsent() {
     RecordingHostedService hosted = new RecordingHostedService();
-    RepositoryContentController controller = controller(hosted);
+    RepositoryProtocolController controller = controller(hosted);
 
     controller.head("composer", request(
         "/repository/composer/company/example/1.0.0/"
@@ -53,8 +54,8 @@ class ComposerRepositoryControllerPathTest {
         hosted.requestedPath.distPath());
   }
 
-  private static RepositoryContentController controller(ComposerHostedService hosted) {
-    return new RepositoryContentController(
+  private static RepositoryProtocolController controller(ComposerHostedService hosted) {
+    return RepositoryProtocolControllerTestSupport.controller(
         new RepositoryRuntimeRegistry(new SingleRepositoryDao(), 0),
         null, null, null,
         null, null,

--- a/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiRepositoryControllerRangeTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiRepositoryControllerRangeTest.java
@@ -8,7 +8,8 @@ import com.github.klboke.kkrepo.core.RepositoryFormat;
 import com.github.klboke.kkrepo.core.RepositoryType;
 import com.github.klboke.kkrepo.persistence.jdbc.api.RepositoryDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.RepositoryRecord;
-import com.github.klboke.kkrepo.server.RepositoryContentController;
+import com.github.klboke.kkrepo.server.RepositoryProtocolController;
+import com.github.klboke.kkrepo.server.RepositoryProtocolControllerTestSupport;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
 import com.github.klboke.kkrepo.server.security.ForwardedHeaderPolicy;
@@ -31,7 +32,7 @@ class PypiRepositoryControllerRangeTest {
   @Test
   void packageDownloadHonorsSingleRangeRequest() throws Exception {
     RangeHostedService hosted = new RangeHostedService();
-    RepositoryContentController controller = controller(hosted);
+    RepositoryProtocolController controller = controller(hosted);
     MockHttpServletRequest request = request(
         "/repository/pypi/packages/demo/1.0.0/demo-1.0.0.whl");
     request.addHeader(HttpHeaders.RANGE, "bytes=2-4");
@@ -49,7 +50,7 @@ class PypiRepositoryControllerRangeTest {
   @Test
   void packageDownloadDecodesPercentEncodedPlusWithoutChangingLiteralPlus() {
     RangeHostedService hosted = new RangeHostedService();
-    RepositoryContentController controller = controller(hosted);
+    RepositoryProtocolController controller = controller(hosted);
 
     controller.get("pypi", request(
         "/repository/pypi/packages/demo/0.0.0%2Bbuild/demo-0.0.0%2Bbuild.whl"));
@@ -67,7 +68,7 @@ class PypiRepositoryControllerRangeTest {
   @Test
   void packageHeadDecodesPercentEncodedPlusOnce() {
     RangeHostedService hosted = new RangeHostedService();
-    RepositoryContentController controller = controller(hosted);
+    RepositoryProtocolController controller = controller(hosted);
 
     controller.head("pypi", request(
         "/repository/pypi/packages/demo/0.0.0%2Bbuild/demo-0.0.0%2Bbuild.whl"));
@@ -80,7 +81,7 @@ class PypiRepositoryControllerRangeTest {
   @Test
   void proxyReceivesFilterCanonicalPathWithoutDecodingItAgain() {
     RangeProxyService proxy = new RangeProxyService();
-    RepositoryContentController controller = controller(proxy);
+    RepositoryProtocolController controller = controller(proxy);
     MockHttpServletRequest request = request(
         "/repository/pypi/packages/demo/0.0.0%252Bbuild/demo-0.0.0%252Bbuild.whl");
     String canonicalPath =
@@ -96,26 +97,26 @@ class PypiRepositoryControllerRangeTest {
 
   @Test
   void packageDownloadRejectsEncodedPathSeparators() {
-    RepositoryContentController controller = controller(new RangeHostedService());
+    RepositoryProtocolController controller = controller(new RangeHostedService());
 
     assertThrows(PypiExceptions.BadRequestException.class, () -> controller.get(
         "pypi",
         request("/repository/pypi/packages/demo/1.0.0/demo%2Fevil.whl")));
   }
 
-  private static RepositoryContentController controller(PypiHostedService hosted) {
+  private static RepositoryProtocolController controller(PypiHostedService hosted) {
     return controller(RepositoryType.HOSTED, hosted, null);
   }
 
-  private static RepositoryContentController controller(PypiProxyService proxy) {
+  private static RepositoryProtocolController controller(PypiProxyService proxy) {
     return controller(RepositoryType.PROXY, null, proxy);
   }
 
-  private static RepositoryContentController controller(
+  private static RepositoryProtocolController controller(
       RepositoryType type,
       PypiHostedService hosted,
       PypiProxyService proxy) {
-    return new RepositoryContentController(
+    return RepositoryProtocolControllerTestSupport.controller(
         new RepositoryRuntimeRegistry(new SingleRepositoryDao(type), 0),
         null, null, null,
         null, null,

--- a/server/src/test/java/com/github/klboke/kkrepo/server/routing/RepositoryProtocolDispatcherTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/routing/RepositoryProtocolDispatcherTest.java
@@ -1,0 +1,308 @@
+package com.github.klboke.kkrepo.server.routing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.jdbc.api.model.RepositoryRecord;
+import com.github.klboke.kkrepo.server.maven.MavenExceptions;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
+import com.github.klboke.kkrepo.server.security.RepositorySecurityFilter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class RepositoryProtocolDispatcherTest {
+  @Test
+  void exactPathWinsOverCatchAllForTheSameProtocol() throws Exception {
+    RepositoryRuntime runtime = runtime(RepositoryFormat.HELM, RepositoryType.HOSTED);
+    RecordingHandler fallback = handler(
+        RepositoryProtocolRoute.anyPath(
+            RepositoryFormat.HELM, RepositoryType.HOSTED, HttpMethod.POST, 1_000),
+        ResponseEntity.status(202).build());
+    RecordingHandler exact = handler(
+        RepositoryProtocolRoute.exactPath(
+            RepositoryFormat.HELM,
+            RepositoryType.HOSTED,
+            HttpMethod.POST,
+            "api/charts",
+            0),
+        ResponseEntity.status(201).build());
+
+    ResponseEntity<?> response = dispatcher(runtime, fallback, exact).dispatch(
+        runtime.name(), request("POST", "/repository/repo/api/charts"),
+        HttpMethod.POST, null);
+
+    assertEquals(201, response.getStatusCode().value());
+    assertEquals(0, fallback.invocations);
+    assertEquals(1, exact.invocations);
+    assertEquals("api/charts", exact.lastRequest.path());
+    assertSame(runtime, exact.lastRequest.runtime());
+  }
+
+  @Test
+  void formatTypeAndMethodArePartOfRouteIdentity() {
+    RepositoryRuntime runtime = runtime(RepositoryFormat.NPM, RepositoryType.PROXY);
+    RecordingHandler wrongType = handler(
+        RepositoryProtocolRoute.anyPath(
+            RepositoryFormat.NPM, RepositoryType.HOSTED, HttpMethod.GET, 0),
+        ResponseEntity.ok().build());
+    RecordingHandler wrongMethod = handler(
+        RepositoryProtocolRoute.anyPath(
+            RepositoryFormat.NPM, RepositoryType.PROXY, HttpMethod.PUT, 0),
+        ResponseEntity.ok().build());
+
+    assertThrows(MavenExceptions.MethodNotAllowed.class, () -> dispatcher(
+        runtime, wrongType, wrongMethod).dispatchRead(
+            runtime.name(), request("GET", "/repository/repo/pkg"), HttpMethod.GET));
+  }
+
+  @Test
+  void emptyExactPathCanOwnTheRepositoryRoot() throws Exception {
+    RepositoryRuntime runtime = runtime(RepositoryFormat.PYPI, RepositoryType.HOSTED);
+    RecordingHandler root = handler(
+        RepositoryProtocolRoute.exactPath(
+            RepositoryFormat.PYPI, RepositoryType.HOSTED, HttpMethod.POST, "", 0),
+        ResponseEntity.status(204).build());
+
+    ResponseEntity<?> response = dispatcher(runtime, root).dispatch(
+        runtime.name(), request("POST", "/repository/repo"), HttpMethod.POST, null);
+
+    assertEquals(204, response.getStatusCode().value());
+    assertEquals("", root.lastRequest.path());
+  }
+
+  @Test
+  void duplicateRegistrationsAcrossHandlersAreRejectedAtStartup() {
+    RepositoryRuntime runtime = runtime(RepositoryFormat.RAW, RepositoryType.HOSTED);
+    RecordingHandler first = handler(
+        RepositoryProtocolRoute.exactPath(
+            RepositoryFormat.RAW, RepositoryType.HOSTED, HttpMethod.GET, "asset", 10),
+        ResponseEntity.ok().build());
+    RecordingHandler second = handler(
+        RepositoryProtocolRoute.exactPath(
+            RepositoryFormat.RAW, RepositoryType.HOSTED, HttpMethod.GET, "asset", 10),
+        ResponseEntity.ok().build());
+
+    IllegalStateException error = assertThrows(
+        IllegalStateException.class, () -> dispatcher(runtime, first, second));
+
+    assertTrue(error.getMessage().startsWith(
+        "Ambiguous repository protocol route registration"));
+  }
+
+  @Test
+  void duplicateRegistrationInsideOneHandlerIsRejectedAtStartup() {
+    RepositoryRuntime runtime = runtime(RepositoryFormat.RAW, RepositoryType.HOSTED);
+    RepositoryProtocolRoute route = RepositoryProtocolRoute.exactPath(
+        RepositoryFormat.RAW, RepositoryType.HOSTED, HttpMethod.GET, "asset", 10);
+    RecordingHandler duplicate = new RecordingHandler(
+        List.of(route, route), ResponseEntity.ok().build());
+
+    assertThrows(IllegalStateException.class, () -> dispatcher(runtime, duplicate));
+  }
+
+  @Test
+  void longerPrefixWinsBeforeRouteOrder() throws Exception {
+    RepositoryRuntime runtime = runtime(RepositoryFormat.RAW, RepositoryType.HOSTED);
+    RecordingHandler broad = handler(
+        new RepositoryProtocolRoute(
+            RepositoryFormat.RAW, RepositoryType.HOSTED, HttpMethod.GET, "api/**", 0),
+        ResponseEntity.status(202).build());
+    RecordingHandler narrow = handler(
+        new RepositoryProtocolRoute(
+            RepositoryFormat.RAW,
+            RepositoryType.HOSTED,
+            HttpMethod.GET,
+            "api/packages/**",
+            100),
+        ResponseEntity.status(203).build());
+
+    ResponseEntity<?> response = dispatcher(runtime, broad, narrow).dispatchRead(
+        runtime.name(), request("GET", "/repository/repo/api/packages/demo"), HttpMethod.GET);
+
+    assertEquals(203, response.getStatusCode().value());
+    assertEquals(0, broad.invocations);
+    assertEquals(1, narrow.invocations);
+  }
+
+  @Test
+  void handlerMustRegisterAtLeastOneRoute() {
+    RepositoryRuntimeRegistry runtimes = mock(RepositoryRuntimeRegistry.class);
+    RepositoryProtocolHandler empty = new RecordingHandler(List.of(), ResponseEntity.ok().build());
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> new RepositoryProtocolDispatcher(runtimes, List.of(empty)));
+  }
+
+  @Test
+  void dispatcherMustHaveAtLeastOneHandler() {
+    RepositoryRuntimeRegistry runtimes = mock(RepositoryRuntimeRegistry.class);
+
+    IllegalStateException error = assertThrows(
+        IllegalStateException.class,
+        () -> new RepositoryProtocolDispatcher(runtimes, List.of()));
+
+    assertEquals("No repository protocol routes are registered", error.getMessage());
+  }
+
+  @Test
+  void nullHandlerRegistrationIsRejectedInsteadOfSilentlySkipped() {
+    RepositoryRuntimeRegistry runtimes = mock(RepositoryRuntimeRegistry.class);
+    List<RepositoryProtocolHandler> handlers = new ArrayList<>();
+    handlers.add(handler(
+        RepositoryProtocolRoute.anyPath(
+            RepositoryFormat.RAW, RepositoryType.HOSTED, HttpMethod.GET, 0),
+        ResponseEntity.ok().build()));
+    handlers.add(null);
+
+    IllegalStateException error = assertThrows(
+        IllegalStateException.class,
+        () -> new RepositoryProtocolDispatcher(runtimes, handlers));
+
+    assertEquals("Repository protocol handler list contains null", error.getMessage());
+  }
+
+  @Test
+  void mismatchedSecuritySnapshotFailsClosedWithoutResolvingAnotherRepository() {
+    RepositoryRuntimeRegistry runtimes = mock(RepositoryRuntimeRegistry.class);
+    RepositoryRecord record = mock(RepositoryRecord.class);
+    when(record.name()).thenReturn("authorized-repository");
+    MockHttpServletRequest request = request("GET", "/repository/repo/asset");
+    request.setAttribute(RepositorySecurityFilter.REPOSITORY_RECORD_ATTRIBUTE, record);
+    RepositoryProtocolDispatcher dispatcher = new RepositoryProtocolDispatcher(
+        runtimes,
+        List.of(handler(
+            RepositoryProtocolRoute.anyPath(
+                RepositoryFormat.RAW, RepositoryType.HOSTED, HttpMethod.GET, 0),
+            ResponseEntity.ok().build())));
+
+    assertThrows(
+        MavenExceptions.MavenNotFoundException.class,
+        () -> dispatcher.dispatchRead("repo", request, HttpMethod.GET));
+    verifyNoInteractions(runtimes);
+  }
+
+  @Test
+  void readDispatchWrapsCheckedHandlerFailures() {
+    RepositoryRuntime runtime = runtime(RepositoryFormat.RAW, RepositoryType.HOSTED);
+    RepositoryProtocolHandler failing = new RepositoryProtocolHandler() {
+      @Override
+      public Collection<RepositoryProtocolRoute> routes() {
+        return List.of(RepositoryProtocolRoute.anyPath(
+            RepositoryFormat.RAW, RepositoryType.HOSTED, HttpMethod.GET, 0));
+      }
+
+      @Override
+      public ResponseEntity<?> handle(RepositoryProtocolRequest request) throws java.io.IOException {
+        throw new java.io.IOException("read failed");
+      }
+    };
+
+    IllegalStateException error = assertThrows(
+        IllegalStateException.class,
+        () -> dispatcher(runtime, failing).dispatchRead(
+            runtime.name(), request("GET", "/repository/repo/asset"), HttpMethod.GET));
+
+    assertEquals("Repository read handler failed", error.getMessage());
+    assertTrue(error.getCause() instanceof java.io.IOException);
+  }
+
+  @Test
+  void wildcardIsOnlyAllowedAsCatchAllOrTrailingPrefix() {
+    assertThrows(IllegalArgumentException.class, () -> new RepositoryProtocolRoute(
+        RepositoryFormat.RAW,
+        RepositoryType.HOSTED,
+        HttpMethod.GET,
+        "api/**/assets",
+        0));
+    assertThrows(IllegalArgumentException.class, () -> new RepositoryProtocolRoute(
+        RepositoryFormat.RAW,
+        RepositoryType.HOSTED,
+        HttpMethod.GET,
+        "api/*",
+        0));
+    assertThrows(IllegalArgumentException.class, () -> new RepositoryProtocolRoute(
+        RepositoryFormat.RAW,
+        RepositoryType.HOSTED,
+        HttpMethod.GET,
+        "api/**/**",
+        0));
+  }
+
+  private static RepositoryProtocolDispatcher dispatcher(
+      RepositoryRuntime runtime, RepositoryProtocolHandler... handlers) {
+    RepositoryRuntimeRegistry runtimes = mock(RepositoryRuntimeRegistry.class);
+    when(runtimes.resolve(runtime.name())).thenReturn(Optional.of(runtime));
+    return new RepositoryProtocolDispatcher(runtimes, List.of(handlers));
+  }
+
+  private static RecordingHandler handler(
+      RepositoryProtocolRoute route, ResponseEntity<?> response) {
+    return new RecordingHandler(List.of(route), response);
+  }
+
+  private static MockHttpServletRequest request(String method, String uri) {
+    return new MockHttpServletRequest(method, uri);
+  }
+
+  private static RepositoryRuntime runtime(
+      RepositoryFormat format, RepositoryType type) {
+    return new RepositoryRuntime(
+        1L,
+        "repo",
+        format,
+        type,
+        format.name().toLowerCase() + "-" + type.name().toLowerCase(),
+        true,
+        1L,
+        null,
+        null,
+        null,
+        true,
+        null,
+        null,
+        null,
+        null,
+        null,
+        List.of());
+  }
+
+  private static final class RecordingHandler implements RepositoryProtocolHandler {
+    private final Collection<RepositoryProtocolRoute> routes;
+    private final ResponseEntity<?> response;
+    private int invocations;
+    private RepositoryProtocolRequest lastRequest;
+
+    private RecordingHandler(
+        Collection<RepositoryProtocolRoute> routes, ResponseEntity<?> response) {
+      this.routes = routes;
+      this.response = response;
+    }
+
+    @Override
+    public Collection<RepositoryProtocolRoute> routes() {
+      return routes;
+    }
+
+    @Override
+    public ResponseEntity<?> handle(RepositoryProtocolRequest request) {
+      invocations++;
+      lastRequest = request;
+      return response;
+    }
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/routing/helm/HelmChartUploadProtocolHandlerTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/routing/helm/HelmChartUploadProtocolHandlerTest.java
@@ -1,0 +1,87 @@
+package com.github.klboke.kkrepo.server.routing.helm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.server.helm.HelmHostedService;
+import com.github.klboke.kkrepo.server.maven.MavenExceptions;
+import com.github.klboke.kkrepo.server.maven.MavenResponse;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import com.github.klboke.kkrepo.server.routing.RepositoryProtocolRequest;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.multipart.MultipartFile;
+
+class HelmChartUploadProtocolHandlerTest {
+  @Test
+  void registersAndHandlesHostedChartUpload() throws Exception {
+    RepositoryRuntime runtime = runtime();
+    HelmHostedService helm = mock(HelmHostedService.class);
+    MultipartFile chart = mock(MultipartFile.class);
+    MockHttpServletRequest servletRequest = new MockHttpServletRequest();
+    servletRequest.setRemoteAddr("192.0.2.10");
+    when(helm.push(runtime, chart, "anonymous", "192.0.2.10"))
+        .thenReturn(MavenResponse.created());
+    HelmChartUploadProtocolHandler handler = new HelmChartUploadProtocolHandler(helm);
+
+    ResponseEntity<?> response = handler.handle(new RepositoryProtocolRequest(
+        runtime,
+        runtime.name(),
+        "api/charts",
+        HttpMethod.POST,
+        servletRequest,
+        "multipart/form-data",
+        chart));
+
+    assertEquals(201, response.getStatusCode().value());
+    assertEquals(1, handler.routes().size());
+    verify(helm).push(runtime, chart, "anonymous", "192.0.2.10");
+  }
+
+  @Test
+  void rejectsUploadWithoutChartPartBeforeCallingService() {
+    HelmHostedService helm = mock(HelmHostedService.class);
+    HelmChartUploadProtocolHandler handler = new HelmChartUploadProtocolHandler(helm);
+
+    assertThrows(MavenExceptions.BadRequestException.class, () -> handler.handle(
+        new RepositoryProtocolRequest(
+            runtime(),
+            "repo",
+            "api/charts",
+            HttpMethod.POST,
+            new MockHttpServletRequest(),
+            "multipart/form-data",
+            null)));
+    verifyNoInteractions(helm);
+  }
+
+  private static RepositoryRuntime runtime() {
+    return new RepositoryRuntime(
+        1L,
+        "repo",
+        RepositoryFormat.HELM,
+        RepositoryType.HOSTED,
+        "helm-hosted",
+        true,
+        1L,
+        null,
+        null,
+        null,
+        true,
+        null,
+        null,
+        null,
+        null,
+        null,
+        List.of());
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/security/RepositorySecurityFilterTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/security/RepositorySecurityFilterTest.java
@@ -17,7 +17,8 @@ import com.github.klboke.kkrepo.persistence.jdbc.api.SecurityDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.TerraformRegistryDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.AssetRecord;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.RepositoryRecord;
-import com.github.klboke.kkrepo.server.RepositoryContentController;
+import com.github.klboke.kkrepo.server.RepositoryProtocolController;
+import com.github.klboke.kkrepo.server.RepositoryProtocolControllerTestSupport;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
 import com.github.klboke.kkrepo.server.pypi.PypiHostedService;
@@ -600,7 +601,7 @@ class RepositorySecurityFilterTest {
         repositoryDao,
         false);
     RecordingPypiHostedService hosted = new RecordingPypiHostedService();
-    RepositoryContentController controller = pypiController(repositoryDao, hosted);
+    RepositoryProtocolController controller = pypiController(repositoryDao, hosted);
     HttpServletRequest request = request(
         "GET",
         "/repository/pypi-private/packages/pr%69vate/0.0.0%2Bbuild/"
@@ -1447,10 +1448,10 @@ class RepositorySecurityFilterTest {
         new NexusLegacyUiCompatibility(legacyUiEnabled));
   }
 
-  private static RepositoryContentController pypiController(
+  private static RepositoryProtocolController pypiController(
       RepositoryDao repositoryDao,
       PypiHostedService hosted) {
-    return new RepositoryContentController(
+    return RepositoryProtocolControllerTestSupport.controller(
         new RepositoryRuntimeRegistry(repositoryDao, 0),
         null, null, null,
         null, null,


### PR DESCRIPTION
## Summary

- introduce an indexed `RepositoryProtocolHandler` route SPI keyed by repository format, type, HTTP method, and normalized path, leaving the repository HTTP controller responsible only for request mapping and dispatch
- preserve existing protocol behavior behind a built-in catch-all handler and extract Helm multipart chart upload as the first focused exact-path handler
- split repository-scope SQL, operational summaries, and retention/blob-reference cleanup out of the 4,380-line `JdbcSecurityScanDao` while preserving its public facade
- add ArchUnit dependency boundaries and bilingual architecture documentation for the controller, routing, protocol-runtime, and persistence migration direction

## Routing behavior

- the dispatcher reuses the repository snapshot resolved by the security filter and fails closed if that snapshot does not match the path repository
- exact routes beat prefixes, the longest prefix wins, prefixes beat catch-all routes, and lower handler order is the final tie-breaker
- duplicate, null, and empty registrations fail during startup instead of producing order-dependent runtime behavior
- the SPI adds no shared mutable runtime state; existing database and blob-store coordination semantics remain unchanged for multi-replica deployments

## Migration shape

- existing protocol handling remains available through `BuiltinRepositoryProtocolHandler`, so this PR does not require a flag day
- focused routes can now move incrementally into their owning protocol module or a future `protocol-*-runtime` module
- `JdbcSecurityScanDao` is reduced from 4,380 to 3,784 lines and delegates the extracted responsibilities to independently testable collaborators

## Verification

- `mvn -B -ntp -pl server,scanner-adapter -am -Dsurefire.failIfNoSpecifiedTests=false verify`
  - all 35 reactor modules passed
  - server: 2,731 tests, 0 failures, 0 errors
  - scanner-adapter: 126 tests, 0 failures, 0 errors, 1 skipped
  - MySQL: 112 tests; PostgreSQL: 72 tests; both passed against Testcontainers databases
- focused routing/controller/Helm/ArchUnit/R/JDBC extraction suites passed
- changed executable lines: 314/316 covered (99.37%) from the generated JaCoCo aggregate report
- `git diff --check origin/main`
