### PR TITLE
[codex] Add GitHub Sponsors support

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [klboke]

--- a/README.cn.md
+++ b/README.cn.md
@@ -216,6 +216,18 @@ AI agent 和贡献者的开发说明见 [AGENTS.md](AGENTS.md)。
 
 加入 [kkRepo Telegram 群](https://t.me/+UbIsTKXTzxBhYjFl) 获取社区支持和使用交流。Issue 分类、支持范围和安全问题报告边界见 [SUPPORT.md](SUPPORT.md)。
 
+## 赞助者
+
+感谢所有支持 kkRepo 持续开发和维护的赞助者。你可以通过 [GitHub Sponsors](https://github.com/sponsors/klboke) 支持本项目。
+
+### 企业赞助者
+
+当前企业赞助者的 Logo 和链接将在此展示。
+
+### 项目支持者
+
+当前项目支持者的名称或 Logo 及可选链接将在此展示。
+
 ## 安全
 
 如果发现安全问题，请按 [SECURITY.md](SECURITY.md) 说明优先通过 GitHub Security Advisory 报告，避免在公开 issue 中直接披露可利用细节。普通 bug、兼容性问题和功能建议可以直接提交 issue。

--- a/README.md
+++ b/README.md
@@ -216,6 +216,18 @@ Local development and testing are documented in the [Development Guide](docs/en/
 
 Join the [kkRepo Telegram group](https://t.me/+UbIsTKXTzxBhYjFl) for community support and usage discussion. See [SUPPORT.md](SUPPORT.md) for issue routing, support scope, and security-reporting boundaries.
 
+## Sponsors
+
+Thank you to everyone supporting the ongoing development and maintenance of kkRepo. You can support the project through [GitHub Sponsors](https://github.com/sponsors/klboke).
+
+### Organization Sponsors
+
+Active organization sponsors will be featured here with their logo and link.
+
+### Project Backers
+
+Active project backers will be recognized here with their name or logo and optional link.
+
 ## Security
 
 If you find a security issue, follow [SECURITY.md](SECURITY.md) and report it through GitHub Security Advisory first. Avoid disclosing exploitable details in public issues. Regular bugs, compatibility issues, and feature requests can be submitted as public issues.


### PR DESCRIPTION
## Summary

- enable the repository Sponsor button through `.github/FUNDING.yml`
- add a GitHub Sponsors entry point to the English and Chinese READMEs
- reserve separate recognition areas for organization sponsors and project backers

## Why

The GitHub Sponsors profile is now public, but kkRepo did not expose sponsorship from the repository or provide a durable place to recognize active sponsors.

## Impact

Visitors can discover the Sponsors profile directly from kkRepo, and future sponsor acknowledgements can be maintained consistently in both README languages.

## Validation

- `git diff --check`
- parsed `.github/FUNDING.yml` and verified `github: [klboke]`
- verified `https://github.com/sponsors/klboke` returns HTTP 200
- confirmed the English and Chinese README sponsor sections have matching structure
