### PR TITLE
fix(pypi): support Twine uploads with many metadata fields

### DIFF
--- a/compat-test/src/test/java/com/github/klboke/kkrepo/compat/PypiRepositoryBlackBoxCompatibilityTest.java
+++ b/compat-test/src/test/java/com/github/klboke/kkrepo/compat/PypiRepositoryBlackBoxCompatibilityTest.java
@@ -27,6 +27,7 @@ import java.util.zip.ZipOutputStream;
 import org.junit.jupiter.api.Test;
 
 class PypiRepositoryBlackBoxCompatibilityTest {
+  private static final int TWINE_REPEATED_METADATA_FIELDS = 50;
   private static final Pattern LINK = Pattern.compile(
       "<a\\b([^>]*)>(.*?)</a>", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
   private static final Pattern HREF = Pattern.compile(
@@ -131,7 +132,34 @@ class PypiRepositoryBlackBoxCompatibilityTest {
         fixture.bytes());
   }
 
+  @Test
+  void hostedUploadAcceptsTwineMetadataBeyondTomcatDefaultWhenConfigured() throws Exception {
+    CompatConfig config = CompatConfig.load();
+    assumeTrue(config.configured(),
+        "Set NEXUS_COMPAT_BASE_URL and KKREPO_COMPAT_BASE_URL to run PyPI black-box compatibility");
+
+    if (config.setupEnabled()) {
+      ensureNexusRepositories(config);
+      ensureKkRepoRepositories(config);
+    }
+
+    WheelFixture fixture = WheelFixture.create();
+    Exchange reference = upload(config.nexusHosted(), fixture, TWINE_REPEATED_METADATA_FIELDS);
+    Exchange candidate = upload(config.nexusPlusHosted(), fixture, TWINE_REPEATED_METADATA_FIELDS);
+
+    assertSameStatus("hosted Twine upload with more than 50 multipart parts", reference, candidate);
+    assert2xx("Nexus hosted Twine upload with more than 50 multipart parts", reference);
+    assert2xx("kkrepo hosted Twine upload with more than 50 multipart parts", candidate);
+  }
+
   private static Exchange upload(Endpoint endpoint, WheelFixture fixture) throws Exception {
+    return upload(endpoint, fixture, 0);
+  }
+
+  private static Exchange upload(
+      Endpoint endpoint,
+      WheelFixture fixture,
+      int repeatedMetadataFields) throws Exception {
     String boundary = "kkrepo-pypi-compat-" + System.nanoTime();
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     formField(out, boundary, ":action", "file_upload");
@@ -142,6 +170,9 @@ class PypiRepositoryBlackBoxCompatibilityTest {
     formField(out, boundary, "summary", "kkrepo PyPI compatibility fixture");
     formField(out, boundary, "requires_python", ">=3.8");
     formField(out, boundary, "md5_digest", hex(MessageDigest.getInstance("MD5").digest(fixture.bytes())));
+    for (int i = 0; i < repeatedMetadataFields; i++) {
+      formField(out, boundary, "requires_dist", "kkrepo-compat-dependency-" + i + ">=1");
+    }
     fileField(out, boundary, "content", fixture.filename(), "application/octet-stream", fixture.bytes());
     out.write(("--" + boundary + "--\r\n").getBytes(StandardCharsets.UTF_8));
 

--- a/docker-compose.quickstart-postgresql.yml
+++ b/docker-compose.quickstart-postgresql.yml
@@ -55,6 +55,7 @@ services:
       KKREPO_CREDENTIAL_SECRET: ${KKREPO_CREDENTIAL_SECRET:-quickstart-credential-secret-change-me-0123456789}
       KKREPO_API_KEY_PAYLOAD_SECRET: ${KKREPO_API_KEY_PAYLOAD_SECRET:-quickstart-api-key-payload-secret-change-me-0123456789}
       KKREPO_FILE_BASE_DIR: ${KKREPO_FILE_BASE_DIR:-/var/lib/kkrepo/blobs}
+      SERVER_TOMCAT_MAX_PART_COUNT: ${KKREPO_TOMCAT_MAX_PART_COUNT:-200}
       # Deployment capability only: starts kkRepo scan coordination and policy integration.
       # The scanner container also requires --profile security-scanning, and repository
       # administrators still activate scanning per repository in the Admin UI.

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -56,6 +56,7 @@ services:
       KKREPO_CREDENTIAL_SECRET: ${KKREPO_CREDENTIAL_SECRET:-quickstart-credential-secret-change-me-0123456789}
       KKREPO_API_KEY_PAYLOAD_SECRET: ${KKREPO_API_KEY_PAYLOAD_SECRET:-quickstart-api-key-payload-secret-change-me-0123456789}
       KKREPO_FILE_BASE_DIR: ${KKREPO_FILE_BASE_DIR:-/var/lib/kkrepo/blobs}
+      SERVER_TOMCAT_MAX_PART_COUNT: ${KKREPO_TOMCAT_MAX_PART_COUNT:-200}
       # Deployment capability only: starts kkRepo scan coordination and policy integration.
       # The scanner container also requires --profile security-scanning, and repository
       # administrators still activate scanning per repository in the Admin UI.

--- a/docs/en/production-hardening.md
+++ b/docs/en/production-hardening.md
@@ -171,10 +171,14 @@ Defaults allow large uploads, but reverse proxies often need separate tuning:
 ```bash
 KKREPO_MULTIPART_MAX_FILE_SIZE=1024MB
 KKREPO_MULTIPART_MAX_REQUEST_SIZE=1024MB
+KKREPO_TOMCAT_MAX_PART_COUNT=200
 KKREPO_UPLOAD_MAX_REQUEST_BYTES=1073741824
 ```
 
 Make sure proxy limits, application limits, and object-storage multipart settings are aligned.
+PyPI clients such as Twine encode repeated package metadata as separate multipart parts. Increase
+`KKREPO_TOMCAT_MAX_PART_COUNT` for packages with unusually large metadata sets, but keep the value
+bounded because each accepted part consumes request-processing memory.
 
 Ansible collection uploads also apply archive-specific compressed/expanded size, entry size/count, compression-ratio, inspection-time, and multipart-overhead limits. At minimum review `KKREPO_ANSIBLE_ARCHIVE_MAX_COMPRESSED_BYTES`, `KKREPO_ANSIBLE_ARCHIVE_MAX_EXPANDED_BYTES`, `KKREPO_ANSIBLE_ARCHIVE_MAX_ENTRIES`, and `KKREPO_ANSIBLE_MULTIPART_MAX_OVERHEAD_BYTES`. Raising an HTTP body limit does not bypass archive safety checks. Complete `MANIFEST.json`/`FILES.json` and oversized upstream JSON belong in blob storage; do not enlarge relational JSON columns to accommodate them.
 

--- a/docs/zh/production-hardening.md
+++ b/docs/zh/production-hardening.md
@@ -171,10 +171,13 @@ KKREPO_TOMCAT_CONNECTION_TIMEOUT=30s
 ```bash
 KKREPO_MULTIPART_MAX_FILE_SIZE=1024MB
 KKREPO_MULTIPART_MAX_REQUEST_SIZE=1024MB
+KKREPO_TOMCAT_MAX_PART_COUNT=200
 KKREPO_UPLOAD_MAX_REQUEST_BYTES=1073741824
 ```
 
 确保代理限制、应用限制和对象存储 multipart 参数一致。
+PyPI 客户端（例如 Twine）会把重复的包元数据编码为独立的 multipart part。如果包含有异常多的元数据，
+可以调高 `KKREPO_TOMCAT_MAX_PART_COUNT`；但应保持有界，因为每个被接受的 part 都会占用请求处理内存。
 
 Ansible collection 上传还会应用 archive compressed/expanded size、entry size/count、compression ratio、inspection time 和 multipart overhead 限制。至少应检查 `KKREPO_ANSIBLE_ARCHIVE_MAX_COMPRESSED_BYTES`、`KKREPO_ANSIBLE_ARCHIVE_MAX_EXPANDED_BYTES`、`KKREPO_ANSIBLE_ARCHIVE_MAX_ENTRIES` 和 `KKREPO_ANSIBLE_MULTIPART_MAX_OVERHEAD_BYTES`。提高 HTTP body limit 不会绕过 archive 安全校验。完整 `MANIFEST.json`/`FILES.json` 与超大上游 JSON 应放在 blob storage，不能通过扩大关系数据库 JSON 列来容纳。
 

--- a/server/src/dist/conf/application.properties
+++ b/server/src/dist/conf/application.properties
@@ -29,6 +29,7 @@ server.tomcat.threads.min-spare=10
 server.tomcat.max-connections=2000
 server.tomcat.accept-count=200
 server.tomcat.connection-timeout=30s
+server.tomcat.max-part-count=200
 spring.mvc.async.request-timeout=10m
 
 server.servlet.session.timeout=24h

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -42,6 +42,7 @@ spring.session.jdbc.flush-mode=on_save
 spring.servlet.multipart.max-file-size=${KKREPO_MULTIPART_MAX_FILE_SIZE:1024MB}
 spring.servlet.multipart.max-request-size=${KKREPO_MULTIPART_MAX_REQUEST_SIZE:1024MB}
 server.tomcat.max-http-form-post-size=${KKREPO_TOMCAT_MAX_HTTP_FORM_POST_SIZE:1024MB}
+server.tomcat.max-part-count=${KKREPO_TOMCAT_MAX_PART_COUNT:200}
 spring.jackson.default-property-inclusion=non_null
 spring.http.converters.preferred-json-mapper=jackson2
 spring.jackson.time-zone=Asia/Shanghai

--- a/server/src/test/java/com/github/klboke/kkrepo/server/TomcatUploadConfigurationTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/TomcatUploadConfigurationTest.java
@@ -1,0 +1,42 @@
+package com.github.klboke.kkrepo.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.tomcat.autoconfigure.TomcatServerProperties;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.PropertiesPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.support.PropertiesLoaderUtils;
+
+class TomcatUploadConfigurationTest {
+
+  @Test
+  void defaultsMultipartPartLimitAboveTomcatDefault() throws IOException {
+    assertEquals(200, bindTomcatProperties(Map.of()).getMaxPartCount());
+  }
+
+  @Test
+  void exposesMultipartPartLimitThroughKkRepoEnvironmentVariable() throws IOException {
+    assertEquals(321, bindTomcatProperties(Map.of("KKREPO_TOMCAT_MAX_PART_COUNT", 321)).getMaxPartCount());
+  }
+
+  private static TomcatServerProperties bindTomcatProperties(Map<String, Object> overrides)
+      throws IOException {
+    StandardEnvironment environment = new StandardEnvironment();
+    environment.getPropertySources().addFirst(new MapPropertySource("testOverrides", overrides));
+    Properties applicationProperties = PropertiesLoaderUtils.loadProperties(
+        new ClassPathResource("application.properties"));
+    environment.getPropertySources().addLast(
+        new PropertiesPropertySource("kkrepoApplicationProperties", applicationProperties));
+    return Binder.get(environment)
+        .bind("server.tomcat", Bindable.of(TomcatServerProperties.class))
+        .get();
+  }
+}


### PR DESCRIPTION
## Summary

- Raise and explicitly expose the Tomcat multipart part limit through `KKREPO_TOMCAT_MAX_PART_COUNT`, defaulting to 200.
- Forward the setting through both MySQL and PostgreSQL quickstart Compose files and document its memory tradeoff.
- Add server configuration coverage and PyPI black-box coverage for a Twine-shaped upload with more than 50 parts.

## Root cause

Twine expands repeated package metadata such as `Requires-Dist` into separate multipart parts. Tomcat 11 defaults `maxPartCount` to 50, so metadata-heavy packages can receive HTTP 413 even when their request body is far below the configured 1 GiB size limit.

Related discussion: https://github.com/klboke/kkRepo/discussions/253

## Validation

- [x] `mvn -pl server -am -Dtest=TomcatUploadConfigurationTest -Dsurefire.failIfNoSpecifiedTests=false test`
- [x] `mvn -pl compat-test -am -DskipTests package`
- [x] `bash scripts/ci/check-compose-scanner-isolation.sh`
- [x] `bash scripts/ci/test-quickstart-data-permissions.sh`
- [x] Compose config renders 200 by default and 321 when `KKREPO_TOMCAT_MAX_PART_COUNT=321`
- [ ] Targeted live PyPI black-box run: the existing local kkRepo endpoint returned 401 from `/internal/repositories` with the current dev credentials before reaching the upload step.
- [x] Full E2E: not applicable to this configuration-only runtime change; CI can run the targeted live compatibility coverage.
- [x] Native real-client E2E: not applicable; no AOT or runtime-hint changes.

## Compatibility and design checklist

- [x] Compared with the Tomcat connector contract, Twine multipart behavior, and Nexus hosted upload behavior.
- [x] Added compatibility coverage under `compat-test` for a multipart request above Tomcat default 50-part limit.
- [x] No shared state, cache, locking, session, or migration semantics change. The bounded connector limit applies independently and consistently to every replica.
- [x] Migration checklist is not applicable.

## Notes for reviewers

The default is intentionally bounded at 200: it covers common metadata-heavy Python packages while avoiding an unbounded per-request multipart allocation ceiling.