### PR TITLE
feat(pypi): support configurable remote index paths

### DIFF
--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js
@@ -2399,6 +2399,11 @@ function refreshRepositoryRecipeControls() {
   document.getElementById("repository-alpine-fields").hidden = format !== "alpine";
   document.getElementById("repository-swift-proxy-note").hidden =
     !(format === "swift" && type === "PROXY");
+  const pypiIndexPathVisible = format === "pypi" && type === "PROXY";
+  document.getElementById("repository-pypi-index-path-field").hidden =
+    !pypiIndexPathVisible;
+  document.getElementById("repository-pypi-index-path-note").hidden =
+    !pypiIndexPathVisible;
   const minimumReleaseAgeVisible = format === "npm" && type === "PROXY";
   document.getElementById("repository-minimum-release-age-field").hidden =
     !minimumReleaseAgeVisible;
@@ -2770,6 +2775,11 @@ function repositoryFormPayload() {
       outboundProxyPasswordConfigured:
         document.getElementById("repository-outbound-proxy-password-clear").checked ? false : null
     };
+    if (recipe.format === "pypi") {
+      payload.pypi = {
+        indexPath: document.getElementById("repository-pypi-index-path").value.trim()
+      };
+    }
   } else if (type === "GROUP") {
     payload.group = {
       memberNames: [...memberTransfer.selected]
@@ -2836,6 +2846,7 @@ function setRepositoryFormDefaults() {
   document.getElementById("repository-version-policy").value = "RELEASE";
   document.getElementById("repository-layout-policy").value = "STRICT";
   document.getElementById("repository-remote-url").value = "";
+  document.getElementById("repository-pypi-index-path").value = "/simple";
   document.getElementById("repository-allowed-redirect-hosts").value = "";
   document.getElementById("repository-remote-username").value = "";
   document.getElementById("repository-remote-password").value = "";
@@ -2979,6 +2990,8 @@ function showEditRepositoryForm(name) {
       repo.proxy.minimumReleaseAgeMinutes ?? "0";
     document.getElementById("repository-auto-block").checked = repo.proxy.autoBlock !== false;
   }
+  document.getElementById("repository-pypi-index-path").value =
+    repo.pypi?.indexPath ?? "/simple";
   if (repo.type === "GROUP" && repo.group && Array.isArray(repo.group.memberNames)) {
     memberTransfer.selected = [...repo.group.memberNames];
   }

--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js
@@ -2402,8 +2402,6 @@ function refreshRepositoryRecipeControls() {
   const pypiIndexPathVisible = format === "pypi" && type === "PROXY";
   document.getElementById("repository-pypi-index-path-field").hidden =
     !pypiIndexPathVisible;
-  document.getElementById("repository-pypi-index-path-note").hidden =
-    !pypiIndexPathVisible;
   const minimumReleaseAgeVisible = format === "npm" && type === "PROXY";
   document.getElementById("repository-minimum-release-age-field").hidden =
     !minimumReleaseAgeVisible;

--- a/admin-ui/src/main/resources/META-INF/resources/admin/index.html
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/index.html
@@ -231,15 +231,16 @@
                 <input id="repository-remote-url" type="url" placeholder="https://repo.maven.apache.org/maven2/">
               </label>
               <label id="repository-pypi-index-path-field" hidden>
-                <span>Remote Index Path</span>
+                <span class="field-label">Remote Index Path
+                  <span class="field-help" tabindex="0" role="note"
+                    aria-label="PyPI proxy only. Use /simple for standard package indexes. Leave this empty when the upstream serves project indexes directly from its root, such as the PyTorch package indexes. Client URLs remain under /simple."
+                    data-tooltip="PyPI proxy only. Use /simple for standard package indexes. Leave this empty when the upstream serves project indexes directly from its root, such as the PyTorch package indexes. Client URLs remain under /simple.">
+                    <span class="lucide-icon icon-info" aria-hidden="true"></span>
+                  </span>
+                </span>
                 <input id="repository-pypi-index-path" type="text" value="/simple"
                   spellcheck="false" autocomplete="off" placeholder="/simple">
               </label>
-              <p class="form-note full-width" id="repository-pypi-index-path-note" hidden>
-                PyPI proxy only. Use /simple for standard indexes. Leave this empty when the
-                upstream serves project indexes directly from its root, such as PyTorch package
-                indexes. Client URLs remain under /simple.
-              </p>
               <label>
                 <span class="field-label">Allowed redirect host
                   <span class="field-help" tabindex="0" role="note"

--- a/admin-ui/src/main/resources/META-INF/resources/admin/index.html
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/index.html
@@ -230,6 +230,16 @@
                 <span>Remote URL <span class="required-mark">*</span></span>
                 <input id="repository-remote-url" type="url" placeholder="https://repo.maven.apache.org/maven2/">
               </label>
+              <label id="repository-pypi-index-path-field" hidden>
+                <span>Remote Index Path</span>
+                <input id="repository-pypi-index-path" type="text" value="/simple"
+                  spellcheck="false" autocomplete="off" placeholder="/simple">
+              </label>
+              <p class="form-note full-width" id="repository-pypi-index-path-note" hidden>
+                PyPI proxy only. Use /simple for standard indexes. Leave this empty when the
+                upstream serves project indexes directly from its root, such as PyTorch package
+                indexes. Client URLs remain under /simple.
+              </p>
               <label>
                 <span class="field-label">Allowed redirect host
                   <span class="field-help" tabindex="0" role="note"

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminPypiRemoteIndexPathContractTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminPypiRemoteIndexPathContractTest.java
@@ -1,0 +1,34 @@
+package com.github.klboke.kkrepo.admin.ui;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import org.junit.jupiter.api.Test;
+
+class AdminPypiRemoteIndexPathContractTest {
+
+  @Test
+  void pypiProxyFormPreservesAnEmptyRemoteIndexPath() throws IOException {
+    String index = resource("/META-INF/resources/admin/index.html");
+    String javascript = resource("/META-INF/resources/admin/assets/admin.js");
+
+    assertTrue(index.contains("id=\"repository-pypi-index-path\""));
+    assertTrue(index.contains("Remote Index Path"));
+    assertTrue(index.contains("Leave this empty"));
+    assertTrue(index.contains("Client URLs remain under /simple"));
+    assertTrue(javascript.contains("format === \"pypi\" && type === \"PROXY\""));
+    assertTrue(javascript.contains("payload.pypi = {"));
+    assertTrue(javascript.contains("repo.pypi?.indexPath ?? \"/simple\""));
+    assertTrue(javascript.contains(
+        "document.getElementById(\"repository-pypi-index-path\").value = \"/simple\";"));
+  }
+
+  private String resource(String path) throws IOException {
+    try (InputStream stream = getClass().getResourceAsStream(path)) {
+      return new String(Objects.requireNonNull(stream).readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+}

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminPypiRemoteIndexPathContractTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminPypiRemoteIndexPathContractTest.java
@@ -1,5 +1,6 @@
 package com.github.klboke.kkrepo.admin.ui;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -16,10 +17,13 @@ class AdminPypiRemoteIndexPathContractTest {
     String javascript = resource("/META-INF/resources/admin/assets/admin.js");
 
     assertTrue(index.contains("id=\"repository-pypi-index-path\""));
-    assertTrue(index.contains("Remote Index Path"));
+    assertTrue(index.contains("<span class=\"field-label\">Remote Index Path"));
+    assertTrue(index.contains("data-tooltip=\"PyPI proxy only."));
     assertTrue(index.contains("Leave this empty"));
     assertTrue(index.contains("Client URLs remain under /simple"));
+    assertFalse(index.contains("id=\"repository-pypi-index-path-note\""));
     assertTrue(javascript.contains("format === \"pypi\" && type === \"PROXY\""));
+    assertFalse(javascript.contains("repository-pypi-index-path-note"));
     assertTrue(javascript.contains("payload.pypi = {"));
     assertTrue(javascript.contains("repo.pypi?.indexPath ?? \"/simple\""));
     assertTrue(javascript.contains(

--- a/compat-test/src/test/java/com/github/klboke/kkrepo/compat/PypiRepositoryBlackBoxCompatibilityTest.java
+++ b/compat-test/src/test/java/com/github/klboke/kkrepo/compat/PypiRepositoryBlackBoxCompatibilityTest.java
@@ -113,11 +113,22 @@ class PypiRepositoryBlackBoxCompatibilityTest {
       ensureKkRepoRepositories(config);
     }
 
-    Exchange reference = get(config.nexusRootIndexProxy(), "simple/torch/");
-    Exchange candidate = get(config.nexusPlusRootIndexProxy(), "simple/torch/");
-    assertProjectIndexMatches("proxy empty remote index path", reference, candidate, null);
-    assertFalse(linkMap(candidate.body()).isEmpty(),
-        "PyTorch root index proxy should expose at least one torch distribution");
+    // Nexus 3.94 can expose an empty remote index path directly below the repository root.
+    Exchange reference = getProjectIndexEventually(
+        config.nexusRootIndexProxy(), "simple/torch/", "torch/");
+    Exchange candidate = getProjectIndexEventually(
+        config.nexusPlusRootIndexProxy(), "simple/torch/");
+    assert2xx("proxy empty remote index path reference", reference);
+    assert2xx("proxy empty remote index path candidate", candidate);
+
+    Map<String, String> referencePackages = packageLinks(reference.body());
+    Map<String, String> candidatePackages = packageLinks(candidate.body());
+    assertFalse(referencePackages.isEmpty(),
+        "Nexus root index proxy should expose at least one torch distribution");
+    assertFalse(candidatePackages.isEmpty(),
+        "kkRepo root index proxy should expose at least one torch distribution");
+    assertTrue(referencePackages.entrySet().stream().anyMatch(candidatePackages.entrySet()::contains),
+        "Nexus and kkRepo root index proxies should expose at least one common torch distribution");
   }
 
   @Test
@@ -269,6 +280,14 @@ class PypiRepositoryBlackBoxCompatibilityTest {
     return links;
   }
 
+  private static Map<String, String> packageLinks(byte[] htmlBytes) {
+    Map<String, String> packages = new LinkedHashMap<>();
+    linkMap(htmlBytes).forEach((name, path) -> {
+      if (path.startsWith("packages/")) packages.put(name, path);
+    });
+    return packages;
+  }
+
   private static String localPath(String href) {
     String result = href == null ? "" : href;
     int hash = result.indexOf('#');
@@ -316,6 +335,22 @@ class PypiRepositoryBlackBoxCompatibilityTest {
       last = get(endpoint, path);
       if (last.status() >= 200 && last.status() < 300 && linkMap(last.body()).containsKey(expectedLink)) {
         return last;
+      }
+      Thread.sleep(250);
+    } while (System.nanoTime() < deadline);
+    return last;
+  }
+
+  private static Exchange getProjectIndexEventually(Endpoint endpoint, String... paths) throws Exception {
+    long deadline = System.nanoTime() + INDEX_REBUILD_TIMEOUT.toNanos();
+    Exchange last = null;
+    do {
+      for (String path : paths) {
+        last = get(endpoint, path);
+        if (last.status() >= 200 && last.status() < 300
+            && !packageLinks(last.body()).isEmpty()) {
+          return last;
+        }
       }
       Thread.sleep(250);
     } while (System.nanoTime() < deadline);

--- a/compat-test/src/test/java/com/github/klboke/kkrepo/compat/PypiRepositoryBlackBoxCompatibilityTest.java
+++ b/compat-test/src/test/java/com/github/klboke/kkrepo/compat/PypiRepositoryBlackBoxCompatibilityTest.java
@@ -103,6 +103,24 @@ class PypiRepositoryBlackBoxCompatibilityTest {
   }
 
   @Test
+  void proxyWithEmptyRemoteIndexPathMatchesNexusWhenConfigured() throws Exception {
+    CompatConfig config = CompatConfig.load();
+    assumeTrue(config.configured(),
+        "Set NEXUS_COMPAT_BASE_URL and KKREPO_COMPAT_BASE_URL to run PyPI black-box compatibility");
+
+    if (config.setupEnabled()) {
+      ensureNexusRepositories(config);
+      ensureKkRepoRepositories(config);
+    }
+
+    Exchange reference = get(config.nexusRootIndexProxy(), "simple/torch/");
+    Exchange candidate = get(config.nexusPlusRootIndexProxy(), "simple/torch/");
+    assertProjectIndexMatches("proxy empty remote index path", reference, candidate, null);
+    assertFalse(linkMap(candidate.body()).isEmpty(),
+        "PyTorch root index proxy should expose at least one torch distribution");
+  }
+
+  @Test
   void localVersionDownloadAcceptsLiteralAndPercentEncodedPlusWhenConfigured() throws Exception {
     CompatConfig config = CompatConfig.load();
     assumeTrue(config.configured(),
@@ -338,8 +356,17 @@ class PypiRepositoryBlackBoxCompatibilityTest {
           "/service/rest/v1/repositories/pypi/proxy")
           .header("Content-Type", "application/json")
           .POST(HttpRequest.BodyPublishers.ofString("""
-              {"name":"%s","online":true,"storage":{"blobStoreName":"default","strictContentTypeValidation":true},"proxy":{"remoteUrl":"https://pypi.org/","contentMaxAge":1440,"metadataMaxAge":1440},"negativeCache":{"enabled":true,"timeToLive":1440},"httpClient":{"blocked":false,"autoBlock":true}}
+              {"name":"%s","online":true,"storage":{"blobStoreName":"default","strictContentTypeValidation":true},"proxy":{"remoteUrl":"https://pypi.org/","contentMaxAge":1440,"metadataMaxAge":1440},"negativeCache":{"enabled":true,"timeToLive":1440},"httpClient":{"blocked":false,"autoBlock":true},"pypi":{"indexPath":"/simple"}}
               """.formatted(config.proxyRepository())))));
+    }
+    repositories = send(config.nexusAdmin("/service/rest/v1/repositories").GET()).bodyAsString();
+    if (!repositories.contains("\"name\" : \"" + config.rootIndexProxyRepository() + "\"")) {
+      assert2xx("create Nexus PyPI root-index proxy", send(config.nexusAdmin(
+          "/service/rest/v1/repositories/pypi/proxy")
+          .header("Content-Type", "application/json")
+          .POST(HttpRequest.BodyPublishers.ofString("""
+              {"name":"%s","online":true,"storage":{"blobStoreName":"default","strictContentTypeValidation":true},"proxy":{"remoteUrl":"https://download.pytorch.org/whl/cpu/","contentMaxAge":1440,"metadataMaxAge":1440},"negativeCache":{"enabled":true,"timeToLive":1440},"httpClient":{"blocked":false,"autoBlock":true},"pypi":{"indexPath":""}}
+              """.formatted(config.rootIndexProxyRepository())))));
     }
     repositories = send(config.nexusAdmin("/service/rest/v1/repositories").GET()).bodyAsString();
     if (!repositories.contains("\"name\" : \"" + config.groupRepository() + "\"")) {
@@ -429,8 +456,16 @@ class PypiRepositoryBlackBoxCompatibilityTest {
       assert2xx("create kkrepo PyPI proxy", send(config.nexusPlusInternal("/internal/repositories")
           .header("Content-Type", "application/json")
           .POST(HttpRequest.BodyPublishers.ofString("""
-              {"name":"%s","recipe":"pypi-proxy","online":true,"blobStoreName":"default","strictContentTypeValidation":true,"proxy":{"remoteUrl":"https://pypi.org/","contentMaxAgeMinutes":1440,"metadataMaxAgeMinutes":1440,"autoBlock":true}}
+              {"name":"%s","recipe":"pypi-proxy","online":true,"blobStoreName":"default","strictContentTypeValidation":true,"proxy":{"remoteUrl":"https://pypi.org/","contentMaxAgeMinutes":1440,"metadataMaxAgeMinutes":1440,"autoBlock":true},"pypi":{"indexPath":"/simple"}}
               """.formatted(config.proxyRepository())))));
+    }
+    repositories = send(config.nexusPlusInternal("/internal/repositories").GET()).bodyAsString();
+    if (!repositories.contains("\"name\":\"" + config.rootIndexProxyRepository() + "\"")) {
+      assert2xx("create kkrepo PyPI root-index proxy", send(config.nexusPlusInternal("/internal/repositories")
+          .header("Content-Type", "application/json")
+          .POST(HttpRequest.BodyPublishers.ofString("""
+              {"name":"%s","recipe":"pypi-proxy","online":true,"blobStoreName":"default","strictContentTypeValidation":true,"proxy":{"remoteUrl":"https://download.pytorch.org/whl/cpu/","contentMaxAgeMinutes":1440,"metadataMaxAgeMinutes":1440,"autoBlock":true},"pypi":{"indexPath":""}}
+              """.formatted(config.rootIndexProxyRepository())))));
     }
     String groupPayload = """
         {"name":"%s","recipe":"pypi-group","online":true,"blobStoreName":"default","strictContentTypeValidation":true,"group":{"memberNames":["%s","%s"]}}
@@ -554,6 +589,9 @@ class PypiRepositoryBlackBoxCompatibilityTest {
     Endpoint nexusPlusHosted() { return nexusPlus.withRepository(hostedRepository); }
     Endpoint nexusPlusProxy() { return nexusPlus.withRepository(proxyRepository); }
     Endpoint nexusPlusGroup() { return nexusPlus.withRepository(groupRepository); }
+    String rootIndexProxyRepository() { return proxyRepository + "-root-index"; }
+    Endpoint nexusRootIndexProxy() { return nexus.withRepository(rootIndexProxyRepository()); }
+    Endpoint nexusPlusRootIndexProxy() { return nexusPlus.withRepository(rootIndexProxyRepository()); }
 
     HttpRequest.Builder nexusAdmin(String path) {
       return nexus.raw(path);

--- a/docs/en/repository-guides/pypi.md
+++ b/docs/en/repository-guides/pypi.md
@@ -9,10 +9,23 @@ index for private and public packages.
 | Purpose | Recipe | Recommended configuration |
 | --- | --- | --- |
 | Private distributions | `pypi-hosted` | Blob store, online state, write policy, strict validation |
-| PyPI cache | `pypi-proxy` | Remote URL `https://pypi.org/` and cache TTLs |
+| PyPI cache | `pypi-proxy` | Remote URL `https://pypi.org/`, Remote Index Path `/simple`, and cache TTLs |
 | Unified installs | `pypi-group` | Hosted before proxy |
 
 The examples use `pypi-hosted`, `pypi-proxy`, and `pypi-group` as repository names.
+
+### Proxy indexes without `/simple`
+
+The client-facing URL always remains `/repository/<name>/simple`. `Remote Index Path` controls only
+the path kkRepo appends while fetching the upstream index:
+
+- Keep the default `/simple` for PyPI and conventional PEP 503 indexes.
+- Leave it empty when the remote URL itself is the index root. For example, use Remote URL
+  `https://download.pytorch.org/whl/cpu/` and an empty Remote Index Path for the PyTorch CPU index.
+- A custom path such as `/api/simple` is also supported and is resolved below the Remote URL.
+
+This setting matches the Nexus PyPI proxy `pypi.indexPath` behavior. Existing repositories that do
+not have the setting continue to use `/simple` after an upgrade.
 
 ## Configure pip
 
@@ -61,8 +74,8 @@ the file is shared or managed with source-controlled configuration.
 ## Repository Behavior
 
 - Hosted upload validates distribution metadata and records package, version, filename, and hashes.
-- Proxy repositories fetch the upstream simple index and distribution files, preserving package-name
-  normalization and rewriting download links to kkRepo.
+- Proxy repositories fetch the configured upstream index and distribution files, preserving
+  package-name normalization and rewriting download links to kkRepo.
 - Groups merge simple-index entries in member order and serve cached or hosted files from the bound
   source.
 - Browse and Search operate on parsed package metadata rather than scraping generated HTML.

--- a/docs/zh/blog/setup-python-pypi-private-repository-with-kkrepo.md
+++ b/docs/zh/blog/setup-python-pypi-private-repository-with-kkrepo.md
@@ -39,13 +39,16 @@ pypi-proxy     proxy，用于代理 PyPI 官方仓库
 pypi-group     group，用于 pip 安装依赖的统一入口
 ```
 
-创建 `pypi-proxy` proxy 仓库时，上游地址可以填写 PyPI 官方 simple index 地址：
+创建 `pypi-proxy` proxy 仓库时，Remote URL 填写 PyPI 官方地址，并保留默认的
+Remote Index Path `/simple`：
 
 ```text
-https://pypi.org/simple/
+https://pypi.org/
 ```
 
-如果公司已有内网 PyPI 镜像，也可以把 proxy 的上游地址替换成内部镜像地址。
+如果公司已有内网 PyPI 镜像，也可以把 proxy 的上游地址替换成内部镜像地址。如果上游直接
+从根路径提供项目 index（例如 PyTorch package index），将 Remote Index Path 留空即可；
+客户端仍然使用 kkRepo 的 `/simple` 地址。
 
 创建 `pypi-group` group 仓库时，把下面几个成员仓库加入 group：
 

--- a/docs/zh/repository-guides/pypi.md
+++ b/docs/zh/repository-guides/pypi.md
@@ -8,10 +8,23 @@ proxy 缓存上游 package index，group 为私有包和公共包提供统一的
 | 用途 | Recipe | 推荐配置 |
 | --- | --- | --- |
 | 私有 distribution | `pypi-hosted` | Blob store、online、write policy、strict validation |
-| PyPI 缓存 | `pypi-proxy` | Remote URL `https://pypi.org/` 和缓存 TTL |
+| PyPI 缓存 | `pypi-proxy` | Remote URL `https://pypi.org/`、Remote Index Path `/simple` 和缓存 TTL |
 | 统一安装入口 | `pypi-group` | Hosted 排在 proxy 前面 |
 
 下文使用 `pypi-hosted`、`pypi-proxy` 和 `pypi-group` 作为仓库名。
+
+### 不使用 `/simple` 的上游 index
+
+客户端地址始终保持 `/repository/<name>/simple`。`Remote Index Path` 只控制 kkRepo 回源时在
+Remote URL 后追加的路径：
+
+- PyPI 和常规 PEP 503 index 保持默认值 `/simple`。
+- 当 Remote URL 本身就是 index 根路径时留空。例如代理 PyTorch CPU index 时，Remote URL
+  填写 `https://download.pytorch.org/whl/cpu/`，Remote Index Path 留空。
+- 也支持 `/api/simple` 之类的自定义路径，并始终在 Remote URL 下解析。
+
+该设置与 Nexus PyPI proxy 的 `pypi.indexPath` 行为一致。升级后，没有保存该设置的旧仓库
+会继续使用 `/simple`，行为不变。
 
 ## 配置 pip
 
@@ -59,7 +72,7 @@ secret。
 ## 仓库行为
 
 - Hosted 上传会校验 distribution metadata，并记录 package、version、filename 和 hash。
-- Proxy 会获取上游 simple index 和 distribution file，保持 package name 规范化，并把下载
+- Proxy 会获取配置的上游 index 和 distribution file，保持 package name 规范化，并把下载
   链接重写为 kkRepo 地址。
 - Group 按成员顺序合并 simple-index entry，并从绑定的同一来源提供 hosted 或缓存文件。
 - Browse 与 Search 使用解析后的 package metadata，不依赖抓取生成的 HTML。

--- a/migration-nexus/src/main/java/com/github/klboke/kkrepo/migration/nexus/NexusApiMigrationService.java
+++ b/migration-nexus/src/main/java/com/github/klboke/kkrepo/migration/nexus/NexusApiMigrationService.java
@@ -541,6 +541,9 @@ public class NexusApiMigrationService {
     if (recipe.type() == RepositoryType.PROXY) {
       attributes.put("proxy", proxyAttributes(document, recipe));
     }
+    if (recipe.format() == RepositoryFormat.PYPI && recipe.type() == RepositoryType.PROXY) {
+      attributes.put("pypi", pypiAttributes(document));
+    }
     if (recipe.format().name().equals("RAW")) {
       attributes.put("raw", Map.of("contentDisposition", "ATTACHMENT"));
     }
@@ -1114,6 +1117,17 @@ public class NexusApiMigrationService {
     // The source snapshot already keeps a recursively redacted copy. Do not persist the raw
     // nested httpClient here; runtime credentials live only in the DAO-encrypted fields above.
     return Map.copyOf(attributes);
+  }
+
+  private static Map<String, Object> pypiAttributes(RepositoryDocument document) {
+    Object raw = value(document, "pypi");
+    if (!(raw instanceof Map<?, ?>)) {
+      raw = nested(value(document, "attributes"), "pypi");
+    }
+    Object configured = nested(raw, "indexPath");
+    // Do not use string(...): an explicit empty value selects the upstream root index.
+    String indexPath = configured == null ? "/simple" : String.valueOf(configured).trim();
+    return Map.of("indexPath", indexPath);
   }
 
   private static Map<String, Object> aptAttributes(

--- a/migration-nexus/src/test/java/com/github/klboke/kkrepo/migration/nexus/NexusApiMigrationServiceTest.java
+++ b/migration-nexus/src/test/java/com/github/klboke/kkrepo/migration/nexus/NexusApiMigrationServiceTest.java
@@ -67,6 +67,32 @@ import org.springframework.transaction.support.SimpleTransactionStatus;
 class NexusApiMigrationServiceTest {
 
   @Test
+  void migratesPypiRemoteIndexPathIncludingAnExplicitEmptyValue() {
+    FakeRepositoryDao repositories = new FakeRepositoryDao();
+    NexusApiMigrationService service = service(new FakeBlobStoreDao(), repositories);
+    NexusInventory inventory = new NexusInventory(
+        List.of(Map.of("name", "default")),
+        List.of(
+            repository("pytorch", "pypi", "proxy", Map.of(
+                "storage", storage("default"),
+                "proxy", Map.of("remoteUrl", "https://download.pytorch.org/whl/cpu/"),
+                "pypi", Map.of("indexPath", ""))),
+            repository("pypi-default", "pypi", "proxy", Map.of(
+                "storage", storage("default"),
+                "proxy", Map.of("remoteUrl", "https://pypi.org/")))),
+        NexusSecurityExport.empty(),
+        List.of());
+
+    service.migrateConfig(inventory, request("https://old-nexus.example"));
+
+    Map<?, ?> rootIndex = (Map<?, ?>) repositories.required("pytorch").attributes().get("pypi");
+    Map<?, ?> defaultIndex = (Map<?, ?>) repositories.required("pypi-default")
+        .attributes().get("pypi");
+    assertEquals("", rootIndex.get("indexPath"));
+    assertEquals("/simple", defaultIndex.get("indexPath"));
+  }
+
+  @Test
   void nativeRuntimeDoesNotInstallBouncyCastleProvider() {
     Provider previousProvider = Security.getProvider(BouncyCastleProvider.PROVIDER_NAME);
     Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME);

--- a/server/src/main/java/com/github/klboke/kkrepo/server/pypi/PypiProxyService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/pypi/PypiProxyService.java
@@ -40,6 +40,7 @@ public class PypiProxyService {
   private final ProxyNegativeCache negativeCache;
   private final AssetMetadataCache assetMetadataCache;
   private final NexusLikeCacheController cacheController;
+  private final PypiRepositorySettings repositorySettings;
 
   public PypiProxyService(
       AssetDao assetDao,
@@ -50,7 +51,8 @@ public class PypiProxyService {
       HttpRemoteFetcher fetcher,
       ProxyNegativeCache negativeCache,
       AssetMetadataCache assetMetadataCache,
-      NexusLikeCacheController cacheController) {
+      NexusLikeCacheController cacheController,
+      PypiRepositorySettings repositorySettings) {
     this.assetDao = assetDao;
     this.blobStorageRegistry = blobStorageRegistry;
     this.writer = writer;
@@ -60,6 +62,7 @@ public class PypiProxyService {
     this.negativeCache = negativeCache;
     this.assetMetadataCache = assetMetadataCache;
     this.cacheController = cacheController;
+    this.repositorySettings = repositorySettings;
   }
 
   public PypiResponse getRootIndex(RepositoryRuntime runtime, boolean headOnly) {
@@ -126,7 +129,7 @@ public class PypiProxyService {
       throw new PypiExceptions.BadUpstreamException("Upstream temporarily blocked: " + runtime.proxyRemoteUrl());
     }
 
-    String url = buildRemoteUrl(runtime.proxyRemoteUrl(), path);
+    String url = upstreamIndexUrl(runtime, projectName);
     String etag = null;
     Instant lastModified = null;
     if (cached.isPresent() && cached.get().blob() != null) {
@@ -301,7 +304,9 @@ public class PypiProxyService {
     if (projectName == null || projectName.isBlank()) {
       throw new PypiExceptions.PypiNotFoundException(filename);
     }
-    List<PypiLink> links = fetchRemoteProjectLinks(runtime, projectName);
+    String upstreamIndexPath = upstreamIndexPath(
+        repositorySettings.get(runtime).indexPath(), projectName);
+    List<PypiLink> links = fetchRemoteProjectLinks(runtime, projectName, upstreamIndexPath);
     String rootFilename = filename.endsWith(".asc")
         ? filename.substring(0, filename.length() - 4)
         : filename;
@@ -312,14 +317,15 @@ public class PypiProxyService {
     String href = match.href();
     int hashIdx = href.indexOf('#');
     if (hashIdx >= 0) href = href.substring(0, hashIdx);
-    URI base = RemoteUrlBuilder.repositoryPath(runtime.proxyRemoteUrl(), PypiPaths.indexPath(projectName));
+    URI base = RemoteUrlBuilder.repositoryPath(runtime.proxyRemoteUrl(), upstreamIndexPath);
     return base.resolve(href).toString();
   }
 
-  private List<PypiLink> fetchRemoteProjectLinks(RepositoryRuntime runtime, String projectName) {
+  private List<PypiLink> fetchRemoteProjectLinks(
+      RepositoryRuntime runtime, String projectName, String upstreamIndexPath) {
     String path = PypiPaths.indexPath(projectName);
     HttpRemoteFetcher.Request req = HttpRemoteFetcher.Request.get(
-        buildRemoteUrl(runtime.proxyRemoteUrl(), path))
+        buildRemoteUrl(runtime.proxyRemoteUrl(), upstreamIndexPath))
         .withTimeoutProfile(HttpRemoteFetcher.TimeoutProfile.METADATA)
         .withRepository(runtime);
     try {
@@ -437,6 +443,16 @@ public class PypiProxyService {
 
   private static String buildRemoteUrl(String base, String path) {
     return RemoteUrlBuilder.repositoryPathString(base, path);
+  }
+
+  private String upstreamIndexUrl(RepositoryRuntime runtime, String projectName) {
+    return buildRemoteUrl(runtime.proxyRemoteUrl(), upstreamIndexPath(
+        repositorySettings.get(runtime).indexPath(), projectName));
+  }
+
+  private static String upstreamIndexPath(String configured, String projectName) {
+    String normalizedProject = projectName == null ? null : PypiPaths.normalizeName(projectName);
+    return PypiRemoteIndexPath.upstreamPath(configured, normalizedProject);
   }
 
   private static String stringAttr(Map<String, Object> attrs, String key) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/pypi/PypiRemoteIndexPath.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/pypi/PypiRemoteIndexPath.java
@@ -1,0 +1,61 @@
+package com.github.klboke.kkrepo.server.pypi;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Normalizes the Nexus-compatible PyPI proxy Remote Index Path setting. */
+public final class PypiRemoteIndexPath {
+  public static final String DEFAULT = "/simple";
+
+  private PypiRemoteIndexPath() {
+  }
+
+  /**
+   * Returns a canonical absolute-looking path, or an empty string for a root index.
+   *
+   * <p>The value is still resolved below the configured proxy remote URL. It is not a URL and
+   * cannot change the upstream origin.
+   */
+  public static String normalize(String configured) {
+    if (configured == null) return DEFAULT;
+    String value = configured.trim();
+    if (value.isEmpty() || "/".equals(value)) return "";
+    if (value.indexOf('?') >= 0 || value.indexOf('#') >= 0 || value.indexOf('\\') >= 0) {
+      throw invalid();
+    }
+
+    int start = 0;
+    int end = value.length();
+    while (start < end && value.charAt(start) == '/') start++;
+    while (end > start && value.charAt(end - 1) == '/') end--;
+    if (start == end) return "";
+
+    List<String> segments = new ArrayList<>();
+    for (String segment : value.substring(start, end).split("/", -1)) {
+      if (segment.isEmpty() || ".".equals(segment) || "..".equals(segment)) {
+        throw invalid();
+      }
+      for (int i = 0; i < segment.length(); i++) {
+        if (Character.isISOControl(segment.charAt(i))) throw invalid();
+      }
+      segments.add(segment);
+    }
+    return "/" + String.join("/", segments);
+  }
+
+  /** Builds the relative upstream index path without changing the client-facing /simple path. */
+  static String upstreamPath(String configured, String normalizedProjectName) {
+    String indexPath = normalize(configured);
+    String relative = indexPath.isEmpty() ? "" : indexPath.substring(1);
+    if (normalizedProjectName != null && !normalizedProjectName.isBlank()) {
+      if (!relative.isEmpty()) relative += "/";
+      relative += normalizedProjectName;
+    }
+    return relative.isEmpty() ? "" : relative + "/";
+  }
+
+  private static IllegalArgumentException invalid() {
+    return new IllegalArgumentException(
+        "pypi.indexPath must be an empty value or a path such as /simple");
+  }
+}

--- a/server/src/main/java/com/github/klboke/kkrepo/server/pypi/PypiRepositorySettings.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/pypi/PypiRepositorySettings.java
@@ -1,0 +1,76 @@
+package com.github.klboke.kkrepo.server.pypi;
+
+import com.github.klboke.kkrepo.cache.LocalCache;
+import com.github.klboke.kkrepo.cache.LocalCacheFactory;
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.persistence.jdbc.api.RepositoryDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.model.RepositoryRecord;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
+import java.time.Duration;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Reads PyPI proxy settings from the durable repository definition.
+ *
+ * <p>The local cache is only a parsed-settings hot cache. Repository catalog version changes are
+ * broadcast across replicas and invalidate it; the TTL covers missed broadcasts. The database
+ * remains the source of truth.
+ */
+@Component
+final class PypiRepositorySettings {
+  private final RepositoryRuntimeRegistry repositories;
+  private final LocalCache<Long, CachedSettings> cache;
+  private final boolean cacheEnabled;
+
+  @Autowired
+  PypiRepositorySettings(
+      RepositoryRuntimeRegistry repositories,
+      @Value("${kkrepo.pypi.settings-cache-ttl-seconds:30}") long ttlSeconds) {
+    this.repositories = repositories;
+    this.cacheEnabled = ttlSeconds > 0;
+    this.cache = LocalCacheFactory.standard()
+        .<Long, CachedSettings>builder("pypi-repository-settings")
+        .expireAfterWrite(Duration.ofSeconds(Math.max(1, ttlSeconds)))
+        .maximumSize(100_000)
+        .build();
+  }
+
+  /** Backward-compatible constructor used by focused unit tests. */
+  PypiRepositorySettings(RepositoryDao repositories) {
+    this(new RepositoryRuntimeRegistry(repositories, 0), 30);
+  }
+
+  Settings get(RepositoryRuntime runtime) {
+    if (runtime == null || runtime.format() != RepositoryFormat.PYPI || !runtime.isProxy()) {
+      throw new IllegalArgumentException("PyPI proxy repository runtime is required");
+    }
+    long version = repositories.configurationVersion();
+    if (cacheEnabled) {
+      CachedSettings cached = cache.getIfPresent(runtime.id());
+      if (cached != null && cached.configurationVersion() == version) return cached.settings();
+    }
+    RepositoryRecord repository = repositories.findRecordById(runtime.id())
+        .orElseThrow(() -> new IllegalStateException("PyPI repository definition is missing"));
+    Settings settings = parse(repository);
+    if (cacheEnabled) cache.put(runtime.id(), new CachedSettings(version, settings));
+    return settings;
+  }
+
+  private static Settings parse(RepositoryRecord repository) {
+    Map<String, Object> attributes = repository.attributes() == null
+        ? Map.of() : repository.attributes();
+    Object raw = attributes.get("pypi");
+    Map<?, ?> pypi = raw instanceof Map<?, ?> map ? map : Map.of();
+    Object indexPath = pypi.get("indexPath");
+    return new Settings(PypiRemoteIndexPath.normalize(
+        indexPath == null ? null : indexPath.toString()));
+  }
+
+  private record CachedSettings(long configurationVersion, Settings settings) { }
+
+  record Settings(String indexPath) { }
+}

--- a/server/src/main/java/com/github/klboke/kkrepo/server/repositories/RepositoryCommands.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/repositories/RepositoryCommands.java
@@ -23,7 +23,8 @@ public final class RepositoryCommands {
       CargoSettings cargo,
       GroupSettings group,
       AptSettings apt,
-      AlpineSettings alpine) {
+      AlpineSettings alpine,
+      PypiSettings pypi) {
     public CreateCommand(
         String name,
         String recipe,
@@ -37,7 +38,7 @@ public final class RepositoryCommands {
         CargoSettings cargo,
         GroupSettings group) {
       this(name, recipe, online, blobStoreName, strictContentTypeValidation, hosted, proxy,
-          raw, docker, cargo, group, null, null);
+          raw, docker, cargo, group, null, null, null);
     }
 
     public CreateCommand(
@@ -54,7 +55,26 @@ public final class RepositoryCommands {
         GroupSettings group,
         AptSettings apt) {
       this(name, recipe, online, blobStoreName, strictContentTypeValidation, hosted, proxy,
-          raw, docker, cargo, group, apt, null);
+          raw, docker, cargo, group, apt, null, null);
+    }
+
+    /** Compatibility constructor for callers that predate PyPI proxy index-path settings. */
+    public CreateCommand(
+        String name,
+        String recipe,
+        Boolean online,
+        String blobStoreName,
+        Boolean strictContentTypeValidation,
+        HostedSettings hosted,
+        ProxySettings proxy,
+        RawSettings raw,
+        DockerSettings docker,
+        CargoSettings cargo,
+        GroupSettings group,
+        AptSettings apt,
+        AlpineSettings alpine) {
+      this(name, recipe, online, blobStoreName, strictContentTypeValidation, hosted, proxy,
+          raw, docker, cargo, group, apt, alpine, null);
     }
   }
 
@@ -69,7 +89,8 @@ public final class RepositoryCommands {
       CargoSettings cargo,
       GroupSettings group,
       AptSettings apt,
-      AlpineSettings alpine) {
+      AlpineSettings alpine,
+      PypiSettings pypi) {
     public UpdateCommand(
         Boolean online,
         String blobStoreName,
@@ -81,7 +102,7 @@ public final class RepositoryCommands {
         CargoSettings cargo,
         GroupSettings group) {
       this(online, blobStoreName, strictContentTypeValidation, hosted, proxy, raw, docker,
-          cargo, group, null, null);
+          cargo, group, null, null, null);
     }
 
     public UpdateCommand(
@@ -96,7 +117,24 @@ public final class RepositoryCommands {
         GroupSettings group,
         AptSettings apt) {
       this(online, blobStoreName, strictContentTypeValidation, hosted, proxy, raw, docker,
-          cargo, group, apt, null);
+          cargo, group, apt, null, null);
+    }
+
+    /** Compatibility constructor for callers that predate PyPI proxy index-path settings. */
+    public UpdateCommand(
+        Boolean online,
+        String blobStoreName,
+        Boolean strictContentTypeValidation,
+        HostedSettings hosted,
+        ProxySettings proxy,
+        RawSettings raw,
+        DockerSettings docker,
+        CargoSettings cargo,
+        GroupSettings group,
+        AptSettings apt,
+        AlpineSettings alpine) {
+      this(online, blobStoreName, strictContentTypeValidation, hosted, proxy, raw, docker,
+          cargo, group, apt, alpine, null);
     }
   }
 
@@ -263,6 +301,10 @@ public final class RepositoryCommands {
       String signatureType,
       String description,
       List<String> upstreamPublicKeys) {
+  }
+
+  /** Nexus-compatible PyPI proxy settings. Empty indexPath means the upstream root index. */
+  public record PypiSettings(String indexPath) {
   }
 
   public record GroupSettings(

--- a/server/src/main/java/com/github/klboke/kkrepo/server/repositories/RepositoryService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/repositories/RepositoryService.java
@@ -24,6 +24,7 @@ import com.github.klboke.kkrepo.server.maven.ProxyNegativeCache;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
 import com.github.klboke.kkrepo.server.npm.NpmGroupPackumentCache;
 import com.github.klboke.kkrepo.server.pypi.PypiGroupSimpleIndexCache;
+import com.github.klboke.kkrepo.server.pypi.PypiRemoteIndexPath;
 import com.github.klboke.kkrepo.server.proxy.OutboundProxyConfig;
 import com.github.klboke.kkrepo.server.proxy.ProxiedHttpClientFactory;
 import com.github.klboke.kkrepo.server.cache.GroupMemberAssetCache;
@@ -36,6 +37,7 @@ import com.github.klboke.kkrepo.server.repositories.RepositoryCommands.DockerSet
 import com.github.klboke.kkrepo.server.repositories.RepositoryCommands.GroupSettings;
 import com.github.klboke.kkrepo.server.repositories.RepositoryCommands.HostedSettings;
 import com.github.klboke.kkrepo.server.repositories.RepositoryCommands.ProxySettings;
+import com.github.klboke.kkrepo.server.repositories.RepositoryCommands.PypiSettings;
 import com.github.klboke.kkrepo.server.repositories.RepositoryCommands.RawSettings;
 import com.github.klboke.kkrepo.server.repositories.RepositoryCommands.UpdateCommand;
 import com.github.klboke.kkrepo.server.security.OutboundRequestPolicy;
@@ -303,6 +305,11 @@ public class RepositoryService {
       validateAlpineOperationalSettings(alpine, recipe.type(), online);
       attributes.put("alpine", alpineAttributes(alpine));
     }
+    PypiSettings pypi = null;
+    if (recipe.format() == RepositoryFormat.PYPI && recipe.type() == RepositoryType.PROXY) {
+      pypi = normalizePypi(command.pypi());
+      attributes.put("pypi", pypiAttributes(pypi));
+    }
 
     String versionPolicy = null;
     String layoutPolicy = null;
@@ -417,6 +424,10 @@ public class RepositoryService {
           current, command.alpine(), existing.type(), existing.name());
       validateAlpineOperationalSettings(merged, existing.type(), online);
       attributes.put("alpine", alpineAttributes(merged));
+    }
+    if (recipe.format() == RepositoryFormat.PYPI && existing.type() == RepositoryType.PROXY) {
+      PypiSettings merged = mergePypi(readPypiAttributes(existing), command.pypi());
+      attributes.put("pypi", pypiAttributes(merged));
     }
 
     String versionPolicy = existing.versionPolicy();
@@ -1127,6 +1138,8 @@ public class RepositoryService {
     AptSettings apt = record.format() == RepositoryFormat.APT ? readAptAttributes(record) : null;
     AlpineSettings alpine = record.format() == RepositoryFormat.ALPINE
         ? readAlpineAttributes(record) : null;
+    PypiSettings pypi = record.format() == RepositoryFormat.PYPI
+        && record.type() == RepositoryType.PROXY ? readPypiAttributes(record) : null;
     GroupSettings group = null;
     switch (record.type()) {
       case HOSTED -> hosted = new HostedSettings(
@@ -1139,7 +1152,7 @@ public class RepositoryService {
         record.id(), record.name(), record.recipeName(),
         record.format(), record.type(), record.online(),
         blobStoreName, record.strictContentTypeValidation(), url,
-        hosted, proxy, raw, docker, cargo, group, apt, alpine);
+        hosted, proxy, raw, docker, cargo, group, apt, alpine, pypi);
   }
 
   private Map<Long, String> blobStoreNameIndex() {
@@ -1604,6 +1617,33 @@ public class RepositoryService {
     RawSettings effective = raw == null ? new RawSettings("ATTACHMENT") : raw;
     String disposition = normalizeRawContentDisposition(effective.contentDisposition());
     return Map.of("contentDisposition", disposition);
+  }
+
+  private static PypiSettings normalizePypi(PypiSettings settings) {
+    String configured = settings == null ? null : settings.indexPath();
+    try {
+      return new PypiSettings(PypiRemoteIndexPath.normalize(configured));
+    } catch (IllegalArgumentException e) {
+      throw new RepositoryValidationException(e.getMessage());
+    }
+  }
+
+  private static PypiSettings mergePypi(PypiSettings current, PypiSettings incoming) {
+    if (incoming == null || incoming.indexPath() == null) return normalizePypi(current);
+    return normalizePypi(incoming);
+  }
+
+  private static Map<String, Object> pypiAttributes(PypiSettings settings) {
+    PypiSettings normalized = normalizePypi(settings);
+    return Map.of("indexPath", normalized.indexPath());
+  }
+
+  private static PypiSettings readPypiAttributes(RepositoryRecord record) {
+    Map<String, Object> attributes = record.attributes() == null ? Map.of() : record.attributes();
+    Object raw = attributes.get("pypi");
+    if (!(raw instanceof Map<?, ?> map)) return normalizePypi(null);
+    Object indexPath = map.get("indexPath");
+    return normalizePypi(new PypiSettings(indexPath == null ? null : indexPath.toString()));
   }
 
   private static AptSettings normalizeApt(AptSettings input, RepositoryType type) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/repositories/RepositoryView.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/repositories/RepositoryView.java
@@ -10,6 +10,7 @@ import com.github.klboke.kkrepo.server.repositories.RepositoryCommands.ProxySett
 import com.github.klboke.kkrepo.server.repositories.RepositoryCommands.RawSettings;
 import com.github.klboke.kkrepo.server.repositories.RepositoryCommands.AptSettings;
 import com.github.klboke.kkrepo.server.repositories.RepositoryCommands.AlpineSettings;
+import com.github.klboke.kkrepo.server.repositories.RepositoryCommands.PypiSettings;
 
 public record RepositoryView(
     Long id,
@@ -28,7 +29,8 @@ public record RepositoryView(
     CargoSettings cargo,
     GroupSettings group,
     AptSettings apt,
-    AlpineSettings alpine) {
+    AlpineSettings alpine,
+    PypiSettings pypi) {
   public RepositoryView(
       Long id,
       String name,
@@ -46,7 +48,8 @@ public record RepositoryView(
       CargoSettings cargo,
       GroupSettings group) {
     this(id, name, recipe, format, type, online, blobStoreName,
-        strictContentTypeValidation, url, hosted, proxy, raw, docker, cargo, group, null, null);
+        strictContentTypeValidation, url, hosted, proxy, raw, docker, cargo, group,
+        null, null, null);
   }
 
   public RepositoryView(
@@ -67,6 +70,31 @@ public record RepositoryView(
       GroupSettings group,
       AptSettings apt) {
     this(id, name, recipe, format, type, online, blobStoreName,
-        strictContentTypeValidation, url, hosted, proxy, raw, docker, cargo, group, apt, null);
+        strictContentTypeValidation, url, hosted, proxy, raw, docker, cargo, group,
+        apt, null, null);
+  }
+
+  /** Compatibility constructor for callers that predate PyPI proxy index-path settings. */
+  public RepositoryView(
+      Long id,
+      String name,
+      String recipe,
+      RepositoryFormat format,
+      RepositoryType type,
+      boolean online,
+      String blobStoreName,
+      boolean strictContentTypeValidation,
+      String url,
+      HostedSettings hosted,
+      ProxySettings proxy,
+      RawSettings raw,
+      DockerSettings docker,
+      CargoSettings cargo,
+      GroupSettings group,
+      AptSettings apt,
+      AlpineSettings alpine) {
+    this(id, name, recipe, format, type, online, blobStoreName,
+        strictContentTypeValidation, url, hosted, proxy, raw, docker, cargo, group,
+        apt, alpine, null);
   }
 }

--- a/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiProxyServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiProxyServiceTest.java
@@ -95,6 +95,74 @@ class PypiProxyServiceTest {
   }
 
   @Test
+  void emptyRemoteIndexPathFetchesProjectFromUpstreamRoot() throws Exception {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(1, 7L);
+    when(fixture.settings.get(runtime))
+        .thenReturn(new PypiRepositorySettings.Settings(""));
+    when(fixture.cache.find(eq(10L), eq("simple/torch/"), any()))
+        .thenReturn(Optional.empty());
+    AtomicReference<String> upstreamUrl = new AtomicReference<>();
+    doAnswer(invocation -> {
+      HttpRemoteFetcher.Request request = invocation.getArgument(0);
+      upstreamUrl.set(request.url());
+      @SuppressWarnings("unchecked")
+      HttpRemoteFetcher.ResultHandler<PypiResponse> handler = invocation.getArgument(2);
+      return handler.handle(new HttpRemoteFetcher.Result(
+          404, Map.of(), new ByteArrayInputStream(new byte[0])));
+    }).when(fixture.fetcher).fetchWithBodyRetry(any(), anyString(), any());
+
+    assertThrows(PypiExceptions.PypiNotFoundException.class,
+        () -> fixture.service.getIndex(runtime, "torch", false));
+
+    assertEquals("https://pypi.example.test/torch/", upstreamUrl.get());
+    verify(fixture.negativeCache).rememberNotFound(runtime, "simple/torch/");
+  }
+
+  @Test
+  void emptyRemoteIndexPathResolvesCrossHostPackageLinks() throws Exception {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(1, 7L);
+    String packagePath = "packages/torch/2.7.0/torch-2.7.0.whl";
+    when(fixture.settings.get(runtime))
+        .thenReturn(new PypiRepositorySettings.Settings(""));
+    when(fixture.cache.find(eq(10L), eq(packagePath), any())).thenReturn(Optional.empty());
+    when(fixture.registry.forBlobStoreId(7L)).thenReturn(fixture.storage);
+    AtomicReference<String> projectIndexUrl = new AtomicReference<>();
+    AtomicReference<String> packageUrl = new AtomicReference<>();
+    doAnswer(invocation -> {
+      HttpRemoteFetcher.Request request = invocation.getArgument(0);
+      String path = invocation.getArgument(1);
+      @SuppressWarnings("unchecked")
+      HttpRemoteFetcher.ResultHandler<PypiResponse> handler = invocation.getArgument(2);
+      if (path.startsWith("simple/")) {
+        projectIndexUrl.set(request.url());
+        return handler.handle(new HttpRemoteFetcher.Result(
+            200, Map.of(),
+            new ByteArrayInputStream("""
+                <a href="https://download-r2.pytorch.org/whl/cpu/torch-2.7.0.whl#sha256=abc">
+                  torch-2.7.0.whl
+                </a>
+                """.getBytes(StandardCharsets.UTF_8))));
+      }
+      packageUrl.set(request.url());
+      return handler.handle(new HttpRemoteFetcher.Result(
+          200, Map.of("Content-Type", "application/zip"),
+          new ByteArrayInputStream("wheel".getBytes(StandardCharsets.UTF_8))));
+    }).when(fixture.fetcher).fetchWithBodyRetry(any(), anyString(), any());
+    when(fixture.writer.write(
+        eq(runtime), eq(fixture.storage), eq(7L), eq(packagePath), any(),
+        eq("application/zip"), eq("package"), any(), any(), any(),
+        eq("proxy"), isNull(), eq(false)))
+        .thenReturn(stored(packagePath, "application/zip"));
+
+    assertEquals(200, fixture.service.getPackage(runtime, packagePath, true).status());
+    assertEquals("https://pypi.example.test/torch/", projectIndexUrl.get());
+    assertEquals(
+        "https://download-r2.pytorch.org/whl/cpu/torch-2.7.0.whl", packageUrl.get());
+  }
+
+  @Test
   void resolvesPackageUrlFromRemoteIndexAndCachesPackage() throws Exception {
     Fixture fixture = fixture();
     RepositoryRuntime runtime = runtime(1, 7L);
@@ -212,11 +280,14 @@ class PypiProxyServiceTest {
     HttpRemoteFetcher fetcher = mock(HttpRemoteFetcher.class);
     ProxyNegativeCache negativeCache = mock(ProxyNegativeCache.class);
     AssetMetadataCache cache = mock(AssetMetadataCache.class);
+    PypiRepositorySettings settings = mock(PypiRepositorySettings.class);
     BlobStorage storage = mock(BlobStorage.class);
+    when(settings.get(any())).thenReturn(new PypiRepositorySettings.Settings("/simple"));
     return new Fixture(
-        assetDao, registry, writer, reader, proxyStateDao, fetcher, negativeCache, cache,
+        assetDao, registry, writer, reader, proxyStateDao, fetcher, negativeCache, cache, settings,
         storage, new PypiProxyService(
-            assetDao, registry, writer, reader, proxyStateDao, fetcher, negativeCache, cache, null));
+            assetDao, registry, writer, reader, proxyStateDao, fetcher, negativeCache, cache, null,
+            settings));
   }
 
   private static RepositoryRuntime runtime(int maxAgeMinutes, Long blobStoreId) {
@@ -262,6 +333,7 @@ class PypiProxyServiceTest {
       HttpRemoteFetcher fetcher,
       ProxyNegativeCache negativeCache,
       AssetMetadataCache cache,
+      PypiRepositorySettings settings,
       BlobStorage storage,
       PypiProxyService service) {
   }

--- a/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiRepositoryControllerRangeTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiRepositoryControllerRangeTest.java
@@ -161,7 +161,7 @@ class PypiRepositoryControllerRangeTest {
     private String requestedPath;
 
     private RangeProxyService() {
-      super(null, null, null, null, null, null, null, null, null);
+      super(null, null, null, null, null, null, null, null, null, null);
     }
 
     @Override

--- a/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiRepositorySettingsTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiRepositorySettingsTest.java
@@ -1,0 +1,95 @@
+package com.github.klboke.kkrepo.server.pypi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.jdbc.api.model.RepositoryRecord;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class PypiRepositorySettingsTest {
+  private final RepositoryRuntimeRegistry repositories = mock(RepositoryRuntimeRegistry.class);
+
+  @Test
+  void defaultsLegacyRepositoriesToSimpleAndPreservesAnEmptyRootIndex() {
+    RepositoryRuntime runtime = runtime();
+    when(repositories.findRecordById(runtime.id()))
+        .thenReturn(Optional.of(record(runtime, Map.of())));
+
+    PypiRepositorySettings settings = new PypiRepositorySettings(repositories, 0);
+    assertEquals("/simple", settings.get(runtime).indexPath());
+
+    when(repositories.findRecordById(runtime.id())).thenReturn(Optional.of(record(
+        runtime, Map.of("pypi", Map.of("indexPath", "")))));
+    assertEquals("", settings.get(runtime).indexPath());
+  }
+
+  @Test
+  void canonicalizesCustomPathsAndInvalidatesTheLocalHotCacheByCatalogVersion() {
+    RepositoryRuntime runtime = runtime();
+    when(repositories.configurationVersion()).thenReturn(7L);
+    when(repositories.findRecordById(runtime.id())).thenReturn(Optional.of(record(
+        runtime, Map.of("pypi", Map.of("indexPath", " api/simple/ ")))));
+    PypiRepositorySettings settings = new PypiRepositorySettings(repositories, 30);
+
+    assertEquals("/api/simple", settings.get(runtime).indexPath());
+    assertEquals("/api/simple", settings.get(runtime).indexPath());
+    verify(repositories).findRecordById(runtime.id());
+
+    when(repositories.configurationVersion()).thenReturn(8L);
+    when(repositories.findRecordById(runtime.id())).thenReturn(Optional.of(record(
+        runtime, Map.of("pypi", Map.of("indexPath", "")))));
+    assertEquals("", settings.get(runtime).indexPath());
+    verify(repositories, times(2)).findRecordById(runtime.id());
+  }
+
+  @Test
+  void rejectsNonProxyRuntimeMissingDefinitionAndInvalidPaths() {
+    PypiRepositorySettings settings = new PypiRepositorySettings(repositories, 0);
+    assertThrows(IllegalArgumentException.class, () -> settings.get(null));
+    RepositoryRuntime hosted = new RepositoryRuntime(
+        2L, "pypi-hosted", RepositoryFormat.PYPI, RepositoryType.HOSTED, "pypi-hosted",
+        true, 1L, "ALLOW", null, null, true, null, 1, 1, true, null, List.of());
+    assertThrows(IllegalArgumentException.class, () -> settings.get(hosted));
+
+    RepositoryRuntime runtime = runtime();
+    when(repositories.findRecordById(runtime.id())).thenReturn(Optional.empty());
+    assertThrows(IllegalStateException.class, () -> settings.get(runtime));
+
+    when(repositories.findRecordById(runtime.id())).thenReturn(Optional.of(record(
+        runtime, Map.of("pypi", Map.of("indexPath", "/../private")))));
+    assertThrows(IllegalArgumentException.class, () -> settings.get(runtime));
+  }
+
+  @Test
+  void mapsConfiguredIndexPathBelowTheRemoteUrl() {
+    assertEquals("simple/", PypiRemoteIndexPath.upstreamPath("/simple", null));
+    assertEquals("simple/demo/", PypiRemoteIndexPath.upstreamPath("/simple", "demo"));
+    assertEquals("", PypiRemoteIndexPath.upstreamPath("", null));
+    assertEquals("demo/", PypiRemoteIndexPath.upstreamPath("", "demo"));
+  }
+
+  private static RepositoryRuntime runtime() {
+    return new RepositoryRuntime(
+        1L, "pypi-proxy", RepositoryFormat.PYPI, RepositoryType.PROXY, "pypi-proxy",
+        true, 1L, null, null, null, true, "https://pypi.example/", 1, 1, true, null,
+        List.of());
+  }
+
+  private static RepositoryRecord record(
+      RepositoryRuntime runtime, Map<String, Object> attributes) {
+    return new RepositoryRecord(
+        runtime.id(), runtime.name(), runtime.format(), runtime.type(), runtime.recipeName(), true,
+        runtime.blobStoreId(), null, runtime.proxyRemoteUrl(), null, null, null, true, attributes);
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/repositories/RepositoryServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/repositories/RepositoryServiceTest.java
@@ -37,6 +37,7 @@ import com.github.klboke.kkrepo.server.repositories.RepositoryCommands.DockerSet
 import com.github.klboke.kkrepo.server.repositories.RepositoryCommands.HostedSettings;
 import com.github.klboke.kkrepo.server.repositories.RepositoryCommands.GroupSettings;
 import com.github.klboke.kkrepo.server.repositories.RepositoryCommands.ProxySettings;
+import com.github.klboke.kkrepo.server.repositories.RepositoryCommands.PypiSettings;
 import com.github.klboke.kkrepo.server.repositories.RepositoryCommands.UpdateCommand;
 import com.github.klboke.kkrepo.server.support.InMemoryVersionWatermark;
 import com.github.klboke.kkrepo.server.support.dao.BlobStoreDaoAdapter;
@@ -51,6 +52,36 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class RepositoryServiceTest {
+
+  @Test
+  void pypiProxyRemoteIndexPathDefaultsPreservesEmptyAndRoundTripsUpdates() {
+    StubRepositoryDao repositories = new StubRepositoryDao(repository(1L));
+    RepositoryService service = service(repositories);
+
+    RepositoryView defaulted = service.create(new CreateCommand(
+        "pypi-default", "pypi-proxy", true, "default", true, null,
+        new ProxySettings("https://pypi.org/", 60, 30, true),
+        null, null, null, null, null, null, null));
+    assertEquals("/simple", defaulted.pypi().indexPath());
+
+    RepositoryView rootIndex = service.create(new CreateCommand(
+        "pypi-root", "pypi-proxy", true, "default", true, null,
+        new ProxySettings("https://download.pytorch.org/whl/cpu/", 60, 30, true),
+        null, null, null, null, null, null, new PypiSettings("")));
+    assertEquals("", rootIndex.pypi().indexPath());
+    assertEquals("", ((Map<?, ?>) repositories.findByName("pypi-root").orElseThrow().attributes()
+        .get("pypi")).get("indexPath"));
+
+    RepositoryView updated = service.update("pypi-root", new UpdateCommand(
+        true, null, null, null, null, null, null, null, null, null, null,
+        new PypiSettings(" custom/simple/ ")));
+    assertEquals("/custom/simple", updated.pypi().indexPath());
+
+    assertThrows(RepositoryValidationException.class, () -> service.update(
+        "pypi-root", new UpdateCommand(
+            true, null, null, null, null, null, null, null, null, null, null,
+            new PypiSettings("/../private"))));
+  }
 
   @Test
   void rHostedLifecycleInitializesNamespaceAndDeletesProtocolState() {


### PR DESCRIPTION
## Summary

- Add the Nexus-compatible `pypi.indexPath` setting to PyPI proxy repositories. It defaults to `/simple`, accepts custom paths, and preserves an explicit empty value for upstreams whose package indexes live at the remote root.
- Keep every client-facing and cached path under `/repository/<repo>/simple/...`; the setting changes only upstream index lookup and package-link resolution.
- Persist the setting in repository attributes, invalidate its node-local parsed-settings cache through the distributed repository configuration version (with a TTL safety net), and copy it during Nexus migration.
- Expose **Remote Index Path** in the admin UI, document standard and PyTorch-style configurations, and add unit, admin-contract, migration, and Nexus black-box compatibility coverage.

Related discussion: https://github.com/klboke/kkRepo/discussions/255

## Validation

- [ ] `mvn -pl server -am test` (targeted suites were run instead)
- [x] The template's Maven/npm compatibility command is not applicable to this PyPI-only change.
- [x] Full E2E is not required; targeted live and client workflows are requested below.
- [x] Live compatibility workflow requested with the `run-live-compat` label.
- [x] Real client E2E requested with the `run-client-e2e` label.
- [x] Native real client E2E is not applicable; no AOT/runtime-hint/native-packaging behavior changed.
- [x] Other:
  - `mvn -pl server -am -Dtest='Pypi*Test,CacheAbstractionBoundaryTest' -Dsurefire.failIfNoSpecifiedTests=false test` (45 passed)
  - `mvn -pl server -am -Dtest=PypiProxyServiceTest -Dsurefire.failIfNoSpecifiedTests=false test` (7 passed, including the final cross-host package-link case)
  - `mvn -pl server -am -Dtest=RepositoryServiceTest -Dsurefire.failIfNoSpecifiedTests=false test` (82 passed)
  - `mvn -pl migration-nexus -am -Dtest=NexusApiMigrationServiceTest -Dsurefire.failIfNoSpecifiedTests=false test` (24 passed)
  - `mvn -pl admin-ui -am -Dtest=AdminPypiRemoteIndexPathContractTest -Dsurefire.failIfNoSpecifiedTests=false test` (1 passed)
  - `mvn -pl compat-test -am -DskipTests test` (compatibility suite compiles)
  - `git diff --check`

## Compatibility and design checklist

- [x] Compared the behavior with [PEP 503](https://peps.python.org/pep-0503/), the current Nexus PyPI repository configuration, and Nexus support for an empty Remote Index Path introduced by NEXUS-29440.
- [x] Added a `compat-test` case that configures both Nexus and kkRepo against `https://download.pytorch.org/whl/cpu/` with an empty index path and compares the resulting project index.
- [x] Repository attributes remain the source of truth. The parsed setting uses `LocalCacheFactory`, repository catalog version invalidation across replicas, and a bounded TTL for missed broadcasts.
- [x] Nexus migration remains idempotent and uses the existing dry-run/resume/checksum/reporting workflow; this change only maps the additional repository attribute and preserves an explicit empty value.

## Notes for reviewers

- Existing PyPI proxies without `pypi.indexPath` retain `/simple`, so upgrades do not change their upstream URLs.
- An empty value maps client `/simple/torch/` to upstream `/torch/`, while relative and absolute distribution links are still resolved and cached through the existing proxy path.
