### PR TITLE
fix: render upload directories by repository capability

### DIFF
--- a/admin-ui/src/main/resources/META-INF/resources/login/assets/ui-i18n.js
+++ b/admin-ui/src/main/resources/META-INF/resources/login/assets/ui-i18n.js
@@ -337,6 +337,10 @@
     "Version": "版本",
     "Upload": "上传",
     "Upload content to the repository": "上传内容到仓库",
+    "Directory": "目录",
+    "Filename": "文件名",
+    "Add asset": "添加文件",
+    "Remove": "移除",
     "My Token": "我的 Token",
     "API keys for package clients": "包客户端使用的 API Key",
     "NpmToken": "NpmToken",
@@ -516,7 +520,7 @@
     "DISABLED": "DISABLED",
     "SUCCESS": "SUCCESS",
     "FAILURE": "FAILURE",
-    "File": "File",
+    "File": "文件",
     "AWS S3 SDK": "AWS S3 SDK",
     "OSS Native SDK": "OSS Native SDK"
   };

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
@@ -759,6 +759,18 @@ h1 {
   grid-column: 1 / 3;
 }
 
+.upload-spec-asset-row {
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+}
+
+.upload-spec-asset-row .upload-file {
+  grid-column: auto;
+}
+
+.upload-spec-asset-row .upload-file:only-child {
+  grid-column: 1 / -1;
+}
+
 .secondary-button {
   height: 32px;
   border: 1px solid #c5c5c5;
@@ -2365,6 +2377,15 @@ code,
 }
 
 @media (max-width: 520px) {
+  .upload-spec-asset-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .upload-spec-asset-row .upload-file,
+  .upload-spec-asset-row .upload-file:only-child {
+    grid-column: 1;
+  }
+
   .format-showcase-heading {
     align-items: start;
     flex-direction: column;

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.js
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.js
@@ -3138,6 +3138,10 @@ function selectedUploadRepository() {
   return uploadRepositoriesCache.find((repo) => repo.name === name) || null;
 }
 
+function selectedUploadSpec(repo = selectedUploadRepository()) {
+  return repo ? uploadSpecsCache.get(repo.format) || null : null;
+}
+
 function renderUploadFields() {
   const repo = selectedUploadRepository();
   const fields = document.getElementById("upload-fields");
@@ -3430,16 +3434,134 @@ function renderUploadFields() {
     `;
     return;
   }
-  fields.innerHTML = `
-    <label class="upload-file">
-      <span>File</span>
-      <input id="upload-file" type="file" required>
-    </label>
-    <label class="upload-path">
-      <span>Asset</span>
-      <input id="upload-path" type="text" readonly>
+  renderUploadSpecFields(repo);
+}
+
+function uploadSpecFieldLabel(name) {
+  const labels = {
+    asset: "File",
+    directory: "Directory",
+    filename: "Filename",
+  };
+  return labels[name] || name
+    .replaceAll("-", " ")
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function uploadSpecComponentField(field) {
+  const label = uploadSpecFieldLabel(field.name);
+  const id = `upload-spec-component-${field.name}`;
+  if (field.type === "BOOLEAN") {
+    return `
+      <label class="upload-check">
+        <input id="${escapeHtml(id)}" data-upload-component-field="${escapeHtml(field.name)}" type="checkbox">
+        <span>${escapeHtml(label)}</span>
+      </label>
+    `;
+  }
+  const value = field.name === "directory" ? "/" : "";
+  return `
+    <label class="${field.name === "directory" ? "full-width" : ""}">
+      <span>${escapeHtml(label)}</span>
+      <input id="${escapeHtml(id)}" data-upload-component-field="${escapeHtml(field.name)}"
+        type="text" value="${escapeHtml(value)}"
+        placeholder="${escapeHtml(field.description || "")}" ${field.optional ? "" : "required"}>
     </label>
   `;
+}
+
+function uploadSpecAssetRow(spec, index) {
+  const fields = [...(spec.assetFields || [])]
+    .sort((left, right) => (left.type === "FILE" ? -1 : right.type === "FILE" ? 1 : 0))
+    .map((field) => {
+      const label = uploadSpecFieldLabel(field.name);
+      if (field.type === "FILE") {
+        return `
+          <label class="upload-file">
+            <span>${escapeHtml(label)}</span>
+            <input class="upload-spec-file" data-upload-asset-field="${escapeHtml(field.name)}"
+              type="file" ${field.optional ? "" : "required"}>
+          </label>
+        `;
+      }
+      return `
+        <label>
+          <span>${escapeHtml(label)}</span>
+          <input class="upload-spec-asset-field" data-upload-asset-field="${escapeHtml(field.name)}"
+            data-upload-autofill="${field.name === "filename" ? "true" : "false"}"
+            type="text" placeholder="${escapeHtml(field.description || "")}" ${field.optional ? "" : "required"}>
+        </label>
+      `;
+    }).join("");
+  return `
+    <div class="upload-asset-row upload-spec-asset-row" data-asset-index="${index}">
+      ${fields}
+      ${spec.multipleUpload
+        ? `<button class="secondary-button upload-spec-remove-asset" type="button">Remove</button>`
+        : ""}
+    </div>
+  `;
+}
+
+function renderUploadSpecFields(repo) {
+  const fields = document.getElementById("upload-fields");
+  const spec = selectedUploadSpec(repo);
+  if (!spec) {
+    fields.innerHTML = '<div class="muted-row upload-empty">No upload definition is available.</div>';
+    return;
+  }
+  fields.innerHTML = `
+    ${(spec.componentFields || []).map(uploadSpecComponentField).join("")}
+    <div class="upload-assets" id="upload-spec-assets">
+      ${Array.from({ length: uploadAssetCount }, (_, index) => uploadSpecAssetRow(spec, index + 1)).join("")}
+    </div>
+    ${spec.multipleUpload
+      ? '<button class="secondary-button upload-add-asset" id="upload-spec-add-asset" type="button">Add asset</button>'
+      : ""}
+    <label class="upload-path">
+      <span>Path</span>
+      <textarea id="upload-path" readonly></textarea>
+    </label>
+  `;
+  document.querySelectorAll(".upload-spec-asset-row").forEach(bindUploadSpecAssetRow);
+  syncUploadSpecRemoveButtons();
+  document.getElementById("upload-spec-add-asset")?.addEventListener("click", () => {
+    uploadAssetCount += 1;
+    const assets = document.getElementById("upload-spec-assets");
+    assets.insertAdjacentHTML("beforeend", uploadSpecAssetRow(spec, uploadAssetCount));
+    bindUploadSpecAssetRow(assets.lastElementChild);
+    syncUploadSpecRemoveButtons();
+    updateUploadPath();
+  });
+}
+
+function bindUploadSpecAssetRow(row) {
+  const file = row.querySelector(".upload-spec-file");
+  const filename = row.querySelector('[data-upload-asset-field="filename"]');
+  file?.addEventListener("change", () => {
+    if (filename && (filename.dataset.uploadAutofill === "true" || !filename.value.trim())) {
+      filename.value = file.files?.[0]?.name || "";
+      filename.dataset.uploadAutofill = "true";
+    }
+    updateUploadPath();
+  });
+  filename?.addEventListener("input", () => {
+    filename.dataset.uploadAutofill = "false";
+  });
+  row.querySelector(".upload-spec-remove-asset")?.addEventListener("click", () => {
+    if (document.querySelectorAll(".upload-spec-asset-row").length <= 1) return;
+    row.remove();
+    uploadAssetCount = document.querySelectorAll(".upload-spec-asset-row").length;
+    syncUploadSpecRemoveButtons();
+    updateUploadPath();
+  });
+}
+
+function syncUploadSpecRemoveButtons() {
+  const disabled = document.querySelectorAll(".upload-spec-asset-row").length <= 1;
+  document.querySelectorAll(".upload-spec-remove-asset").forEach((button) => {
+    button.disabled = disabled;
+  });
 }
 
 function updateTerraformUploadKind() {
@@ -3534,6 +3656,16 @@ function uploadFieldValue(id) {
 function computedUploadPaths() {
   const repo = selectedUploadRepository();
   if (!repo) return [];
+  const specRows = Array.from(document.querySelectorAll(".upload-spec-asset-row"));
+  if (specRows.length) {
+    const directory = document.querySelector('[data-upload-component-field="directory"]')?.value || "/";
+    const prefix = directory.trim().replaceAll("\\", "/").replace(/^\/+|\/+$/g, "");
+    return specRows.map((row) => {
+      const filename = row.querySelector('[data-upload-asset-field="filename"]')?.value?.trim()
+        || row.querySelector(".upload-spec-file")?.files?.[0]?.name;
+      return filename ? `/${[prefix, filename.replace(/^\/+/, "")].filter(Boolean).join("/")}` : "";
+    }).filter(Boolean);
+  }
   if (repo.format === "conan") {
     const name = uploadFieldValue("upload-conan-name");
     const version = uploadFieldValue("upload-conan-version");
@@ -3849,9 +3981,36 @@ function buildUploadForm(repo, form) {
     form.append("r.asset", file, file.name);
     return;
   }
-  const file = document.getElementById("upload-file")?.files?.[0];
-  if (!file) throw new Error("File is required.");
-  form.append(`${repo.format}.asset`, file, file.name);
+  const spec = selectedUploadSpec(repo);
+  const rows = Array.from(document.querySelectorAll(".upload-spec-asset-row"));
+  if (!spec || !rows.length) throw new Error("Upload definition is unavailable.");
+  (spec.componentFields || []).forEach((field) => {
+    const node = document.querySelector(`[data-upload-component-field="${CSS.escape(field.name)}"]`);
+    const value = field.type === "BOOLEAN" ? (node?.checked ? "true" : "") : node?.value?.trim();
+    if (!field.optional && !value) throw new Error(`${uploadSpecFieldLabel(field.name)} is required.`);
+    if (value) form.append(`${repo.format}.${field.name}`, value);
+  });
+  if (!spec.multipleUpload && rows.length !== 1) {
+    throw new Error("This repository format accepts exactly one asset.");
+  }
+  rows.forEach((row, index) => {
+    const fileField = (spec.assetFields || []).find((field) => field.type === "FILE");
+    const fileInput = fileField
+      ? row.querySelector(`[data-upload-asset-field="${CSS.escape(fileField.name)}"]`)
+      : null;
+    const file = fileInput?.files?.[0];
+    if (!fileField || !file) throw new Error("File is required.");
+    const assetKey = spec.multipleUpload && fileField.name === "asset"
+      ? `${repo.format}.asset${index + 1}`
+      : `${repo.format}.${fileField.name}`;
+    form.append(assetKey, file, file.name);
+    (spec.assetFields || []).filter((field) => field.type !== "FILE").forEach((field) => {
+      const node = row.querySelector(`[data-upload-asset-field="${CSS.escape(field.name)}"]`);
+      const value = field.type === "BOOLEAN" ? (node?.checked ? "true" : "") : node?.value?.trim();
+      if (!field.optional && !value) throw new Error(`${uploadSpecFieldLabel(field.name)} is required.`);
+      if (value) form.append(`${assetKey}.${field.name}`, value);
+    });
+  });
 }
 
 async function uploadError(response) {

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseUploadSpecContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseUploadSpecContractTest.java
@@ -1,0 +1,54 @@
+package com.github.klboke.kkrepo.browse.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class BrowseUploadSpecContractTest {
+
+  @Test
+  void nonMavenUploadSpecJavascriptContract() throws Exception {
+    assumeTrue(nodeIsAvailable(), "Node.js is required for browse-ui JavaScript tests");
+
+    Process process = new ProcessBuilder(
+        "node",
+        "--test",
+        Path.of("src/test/js/browse-upload-spec.test.js").toString())
+        .redirectErrorStream(true)
+        .start();
+
+    if (!process.waitFor(30, TimeUnit.SECONDS)) {
+      process.destroyForcibly();
+      process.waitFor(5, TimeUnit.SECONDS);
+      String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+      fail("Timed out running browse upload-spec JavaScript tests:\n" + output);
+    }
+    String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    assertEquals(0, process.exitValue(), () -> output);
+  }
+
+  private static boolean nodeIsAvailable() {
+    try {
+      Process process = new ProcessBuilder("node", "--version")
+          .redirectErrorStream(true)
+          .start();
+      boolean exited = process.waitFor(5, TimeUnit.SECONDS);
+      if (!exited) {
+        process.destroyForcibly();
+        return false;
+      }
+      return process.exitValue() == 0;
+    } catch (IOException exception) {
+      return false;
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      return false;
+    }
+  }
+}

--- a/browse-ui/src/test/js/browse-upload-spec.test.js
+++ b/browse-ui/src/test/js/browse-upload-spec.test.js
@@ -1,0 +1,156 @@
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const { resolve } = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+function uploadSpec(format, multipleUpload, componentFields, assetFields) {
+  return { format, multipleUpload, componentFields, assetFields };
+}
+
+function field(name, type, optional = false, description = "") {
+  return { name, type, optional, description };
+}
+
+function loadUploadHelpers(documentRef = {}) {
+  const source = readFileSync(resolve(
+    __dirname,
+    "../../main/resources/META-INF/resources/browse/assets/browse.js",
+  ), "utf8");
+  const selectedStart = source.indexOf("function selectedUploadSpec");
+  const selectedEnd = source.indexOf("function renderUploadFields", selectedStart);
+  const renderStart = source.indexOf("function uploadSpecFieldLabel");
+  const renderEnd = source.indexOf("function updateTerraformUploadKind", renderStart);
+  const pathsStart = source.indexOf("function computedUploadPaths");
+  const pathsEnd = source.indexOf("function updateUploadPath", pathsStart);
+  const formStart = source.indexOf("function buildUploadForm");
+  const formEnd = source.indexOf("async function uploadError", formStart);
+  for (const boundary of [
+    selectedStart, selectedEnd, renderStart, renderEnd,
+    pathsStart, pathsEnd, formStart, formEnd,
+  ]) {
+    assert.notEqual(boundary, -1, "browse upload helper boundary should exist");
+  }
+
+  const context = vm.createContext({
+    CSS: { escape: (value) => value },
+    document: documentRef,
+    escapeHtml: (value) => String(value),
+    selectedUploadRepository: () => documentRef.selectedRepository,
+  });
+  vm.runInContext(`
+    let uploadAssetCount = 1;
+    let uploadSpecsCache = new Map();
+    ${source.slice(selectedStart, selectedEnd)}
+    ${source.slice(renderStart, renderEnd)}
+    ${source.slice(pathsStart, pathsEnd)}
+    ${source.slice(formStart, formEnd)}
+    globalThis.setUploadSpecs = (specs) => { uploadSpecsCache = new Map(specs); };
+    globalThis.renderUploadSpecFields = renderUploadSpecFields;
+    globalThis.computedUploadPaths = computedUploadPaths;
+    globalThis.buildUploadForm = buildUploadForm;
+  `, context);
+  return context;
+}
+
+function rawSpec() {
+  return uploadSpec(
+    "raw",
+    true,
+    [field("directory", "STRING")],
+    [field("filename", "STRING"), field("asset", "FILE")],
+  );
+}
+
+function row(filename, fileName) {
+  const file = new File(["fixture"], fileName, { type: "application/octet-stream" });
+  return {
+    querySelector(selector) {
+      if (selector === '[data-upload-asset-field="asset"]') return { files: [file] };
+      if (selector === '[data-upload-asset-field="filename"]') return { value: filename };
+      if (selector === ".upload-spec-file") return { files: [file] };
+      return null;
+    },
+  };
+}
+
+test("renders directory and multi-asset controls only when the upload spec declares them", () => {
+  const mount = { innerHTML: "" };
+  const documentRef = {
+    getElementById(id) {
+      if (id === "upload-fields") return mount;
+      return null;
+    },
+    querySelectorAll() { return []; },
+  };
+  const context = loadUploadHelpers(documentRef);
+  const raw = rawSpec();
+  const npm = uploadSpec("npm", false, [], [field("asset", "FILE")]);
+  context.setUploadSpecs([["raw", raw], ["npm", npm]]);
+
+  context.renderUploadSpecFields({ format: "raw" });
+  assert.match(mount.innerHTML, /data-upload-component-field="directory"/);
+  assert.match(mount.innerHTML, /value="\/"/);
+  assert.match(mount.innerHTML, /data-upload-asset-field="filename"/);
+  assert.match(mount.innerHTML, /id="upload-spec-add-asset"/);
+
+  context.renderUploadSpecFields({ format: "npm" });
+  assert.doesNotMatch(mount.innerHTML, /data-upload-component-field="directory"/);
+  assert.doesNotMatch(mount.innerHTML, /data-upload-asset-field="filename"/);
+  assert.doesNotMatch(mount.innerHTML, /id="upload-spec-add-asset"/);
+  assert.match(mount.innerHTML, /data-upload-asset-field="asset"/);
+});
+
+test("builds Raw multi-file keys and previews each destination path", () => {
+  const rows = [row("one.zip", "local-one.zip"), row("two.zip", "local-two.zip")];
+  const directory = { value: " /team/releases/ " };
+  const documentRef = {
+    selectedRepository: { format: "raw" },
+    querySelector(selector) {
+      if (selector === '[data-upload-component-field="directory"]') return directory;
+      return null;
+    },
+    querySelectorAll(selector) {
+      return selector === ".upload-spec-asset-row" ? rows : [];
+    },
+  };
+  const context = loadUploadHelpers(documentRef);
+  context.setUploadSpecs([["raw", rawSpec()]]);
+  const form = new FormData();
+
+  context.buildUploadForm({ format: "raw" }, form);
+
+  assert.deepEqual(Array.from(form.keys()), [
+    "raw.directory",
+    "raw.asset1",
+    "raw.asset1.filename",
+    "raw.asset2",
+    "raw.asset2.filename",
+  ]);
+  assert.equal(form.get("raw.directory"), "/team/releases/");
+  assert.equal(form.get("raw.asset1").name, "local-one.zip");
+  assert.equal(form.get("raw.asset2.filename"), "two.zip");
+  assert.deepEqual(Array.from(context.computedUploadPaths()), [
+    "/team/releases/one.zip",
+    "/team/releases/two.zip",
+  ]);
+});
+
+test("keeps a single-asset format on its unnumbered multipart key", () => {
+  const rows = [row("", "package.tgz")];
+  const documentRef = {
+    querySelector() { return null; },
+    querySelectorAll(selector) {
+      return selector === ".upload-spec-asset-row" ? rows : [];
+    },
+  };
+  const context = loadUploadHelpers(documentRef);
+  const npm = uploadSpec("npm", false, [], [field("asset", "FILE")]);
+  context.setUploadSpecs([["npm", npm]]);
+  const form = new FormData();
+
+  context.buildUploadForm({ format: "npm" }, form);
+
+  assert.deepEqual(Array.from(form.keys()), ["npm.asset"]);
+  assert.equal(form.get("npm.asset").name, "package.tgz");
+});

--- a/compat-test/src/test/java/com/github/klboke/kkrepo/compat/ComponentUploadBlackBoxCompatibilityTest.java
+++ b/compat-test/src/test/java/com/github/klboke/kkrepo/compat/ComponentUploadBlackBoxCompatibilityTest.java
@@ -205,7 +205,8 @@ class ComponentUploadBlackBoxCompatibilityTest {
   }
 
   private static Map<String, SpecShape> supportedSpecs(byte[] body) throws Exception {
-    Set<String> supported = Set.of("maven2", "npm", "pypi", "helm");
+    Set<String> supported = Set.of(
+        "maven2", "npm", "pypi", "helm", "raw", "yum", "nuget", "rubygems");
     Map<String, SpecShape> result = new LinkedHashMap<>();
     for (Map<String, Object> spec : MAPPER.readValue(body, LIST_MAP)) {
       String format = String.valueOf(spec.get("format"));

--- a/server/src/main/java/com/github/klboke/kkrepo/server/upload/ComponentUploadService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/upload/ComponentUploadService.java
@@ -144,9 +144,9 @@ public class ComponentUploadService {
                   "Repository namespace")),
           List.of(field("asset", "FILE", "Alpine .apk package", false, null))),
       singleAsset("r"),
-      rawLikeUpload("nuget"),
-      rawLikeUpload("rubygems"),
-      rawLikeUpload("yum"),
+      singleAsset("nuget"),
+      singleAsset("rubygems"),
+      yumUpload(),
       rawUpload());
 
   private final RepositoryRuntimeRegistry registry;
@@ -328,8 +328,8 @@ public class ComponentUploadService {
       case HUGGINGFACE -> throw new UploadValidationException(
           "Hugging Face Models repositories are proxy-only");
       case DOCKER -> throw new UploadValidationException("Docker hosted upload must use the Docker Registry V2 API");
-      case NUGET -> uploadRaw(runtime, upload, createdBy, createdByIp);
-      case RUBYGEMS -> uploadRaw(runtime, upload, createdBy, createdByIp);
+      case NUGET -> uploadSingleRaw(runtime, upload, "NuGet", createdBy, createdByIp);
+      case RUBYGEMS -> uploadSingleRaw(runtime, upload, "RubyGems", createdBy, createdByIp);
       case YUM -> uploadYum(runtime, upload, createdBy, createdByIp);
       case RAW -> uploadRaw(runtime, upload, createdBy, createdByIp);
     };
@@ -751,17 +751,33 @@ public class ComponentUploadService {
       NormalizedUpload upload,
       String createdBy,
       String createdByIp) throws IOException {
-    AssetUpload asset = singleAsset(upload, "Raw");
-    String filename = blankToNull(asset.fields().get("filename"));
-    if (filename == null) {
-      filename = originalFilename(asset.file());
+    List<RawUploadItem> items = new ArrayList<>(upload.assets().size());
+    for (AssetUpload asset : upload.assets()) {
+      String filename = blankToNull(asset.fields().get("filename"));
+      if (filename == null) {
+        filename = originalFilename(asset.file());
+      }
+      items.add(new RawUploadItem(
+          rawPath(upload.fields().get("directory"), filename), asset.file()));
     }
-    String path = rawPath(upload.fields().get("directory"), filename);
-    ensureNoExistingAssets(runtime, List.of(path));
-    try (var input = asset.file().getInputStream()) {
-      rawHosted.put(runtime, path, input, asset.file().getContentType(), createdBy, createdByIp);
+    ensureNoExistingAssets(runtime, items.stream().map(RawUploadItem::path).toList());
+    for (RawUploadItem item : items) {
+      try (var input = item.file().getInputStream()) {
+        rawHosted.put(
+            runtime, item.path(), input, item.file().getContentType(), createdBy, createdByIp);
+      }
     }
-    return List.of(path);
+    return items.stream().map(RawUploadItem::path).toList();
+  }
+
+  private List<String> uploadSingleRaw(
+      RepositoryRuntime runtime,
+      NormalizedUpload upload,
+      String label,
+      String createdBy,
+      String createdByIp) throws IOException {
+    singleAsset(upload, label);
+    return uploadRaw(runtime, upload, createdBy, createdByIp);
   }
 
   private List<String> uploadYum(
@@ -851,9 +867,9 @@ public class ComponentUploadService {
             field("asset", "FILE", "Asset", false, null)));
   }
 
-  private static UploadDefinition rawLikeUpload(String format) {
-    return new UploadDefinition(format, true,
-        List.of(field("directory", "STRING", "Destination for uploaded files", false,
+  private static UploadDefinition yumUpload() {
+    return new UploadDefinition("yum", false,
+        List.of(field("directory", "STRING", "Destination for uploaded files", true,
             "Component attributes")),
         List.of(
             field("filename", "STRING", "Filename", false, null),
@@ -1138,4 +1154,6 @@ public class ComponentUploadService {
   private record ConanUploadAsset(String path, AssetUpload asset) {}
 
   private record MavenUploadItem(String path, String contentType, MultipartFile file, byte[] body) {}
+
+  private record RawUploadItem(String path, MultipartFile file) {}
 }

--- a/server/src/test/java/com/github/klboke/kkrepo/server/upload/ComponentUploadServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/upload/ComponentUploadServiceTest.java
@@ -41,6 +41,7 @@ import com.github.klboke.kkrepo.server.yum.YumService;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -178,6 +179,117 @@ class ComponentUploadServiceTest {
     verify(apt).publish(
         any(RepositoryRuntime.class), eq("demo_1.0_amd64.deb"), any(InputStream.class),
         isNull(), isNull(), eq("alice"), eq("127.0.0.1"));
+  }
+
+  @Test
+  void nexusCompatiblePathUploadDefinitionsOnlyExposeDirectoryWhereSupported() {
+    ComponentUploadService service = service(mock(CargoHostedService.class));
+
+    UploadDefinition raw = service.definition("raw");
+    assertTrue(raw.multipleUpload());
+    assertEquals(List.of("directory"),
+        raw.componentFields().stream().map(UploadFieldDefinition::name).toList());
+    assertFalse(raw.componentFields().getFirst().optional());
+    assertEquals(List.of("filename", "asset"),
+        raw.assetFields().stream().map(UploadFieldDefinition::name).toList());
+
+    UploadDefinition yum = service.definition("yum");
+    assertFalse(yum.multipleUpload());
+    assertEquals(List.of("directory"),
+        yum.componentFields().stream().map(UploadFieldDefinition::name).toList());
+    assertTrue(yum.componentFields().getFirst().optional());
+    assertTrue(service.definition("nuget").componentFields().isEmpty());
+    assertTrue(service.definition("rubygems").componentFields().isEmpty());
+  }
+
+  @Test
+  void rawComponentUploadHonorsDirectoryFilenamesAndMultipleAssets() throws Exception {
+    RepositoryRuntime runtime = runtime("raw-hosted", RepositoryFormat.RAW);
+    RepositoryRuntimeRegistry registry = mock(RepositoryRuntimeRegistry.class);
+    when(registry.resolve(runtime.name())).thenReturn(Optional.of(runtime));
+    AssetDao assets = mock(AssetDao.class);
+    RawHostedService rawHosted = mock(RawHostedService.class);
+    ComponentUploadService service = new ComponentUploadService(
+        registry,
+        assets,
+        mock(MavenHostedService.class),
+        mock(NpmHostedService.class),
+        mock(PypiHostedService.class),
+        mock(HelmHostedService.class),
+        mock(CargoHostedService.class),
+        mock(PubHostedService.class),
+        rawHosted,
+        mock(YumService.class));
+    LinkedMultiValueMap<String, MultipartFile> uploads = new LinkedMultiValueMap<>();
+    uploads.add("raw.asset1", new MockMultipartFile(
+        "raw.asset1", "local-one.zip", "application/zip", new byte[] {1}));
+    uploads.add("raw.asset2", new MockMultipartFile(
+        "raw.asset2", "local-two.zip", "application/zip", new byte[] {2}));
+
+    ComponentUploadService.UploadResult result = service.upload(
+        runtime.name(),
+        Map.of(
+            "raw.directory", new String[] {" /team/releases/ "},
+            "raw.asset1.filename", new String[] {"one.zip"}),
+        uploads,
+        "alice",
+        "127.0.0.1");
+
+    assertEquals(
+        List.of("team/releases/one.zip", "team/releases/local-two.zip"), result.paths());
+    InOrder order = inOrder(rawHosted);
+    order.verify(rawHosted).put(
+        any(), eq("team/releases/one.zip"), any(InputStream.class), eq("application/zip"),
+        eq("alice"), eq("127.0.0.1"));
+    order.verify(rawHosted).put(
+        any(), eq("team/releases/local-two.zip"), any(InputStream.class), eq("application/zip"),
+        eq("alice"), eq("127.0.0.1"));
+  }
+
+  @Test
+  void nugetAndRubyGemsComponentUploadsAcceptOneAssetAndRejectMultipleAssets() throws Exception {
+    for (RepositoryFormat format : List.of(RepositoryFormat.NUGET, RepositoryFormat.RUBYGEMS)) {
+      String formatName = format.name().toLowerCase(Locale.ROOT);
+      RepositoryRuntime runtime = runtime(formatName + "-hosted", format);
+      RepositoryRuntimeRegistry registry = mock(RepositoryRuntimeRegistry.class);
+      when(registry.resolve(runtime.name())).thenReturn(Optional.of(runtime));
+      RawHostedService rawHosted = mock(RawHostedService.class);
+      ComponentUploadService service = new ComponentUploadService(
+          registry,
+          mock(AssetDao.class),
+          mock(MavenHostedService.class),
+          mock(NpmHostedService.class),
+          mock(PypiHostedService.class),
+          mock(HelmHostedService.class),
+          mock(CargoHostedService.class),
+          mock(PubHostedService.class),
+          rawHosted,
+          mock(YumService.class));
+
+      ComponentUploadService.UploadResult result = service.upload(
+          runtime.name(), Map.of(), files(formatName + ".asset", "one.zip"),
+          "alice", "127.0.0.1");
+
+      assertEquals(List.of("one.zip"), result.paths());
+      verify(rawHosted).put(
+          any(), eq("one.zip"), any(InputStream.class), eq("application/x-tar"),
+          eq("alice"), eq("127.0.0.1"));
+
+      LinkedMultiValueMap<String, MultipartFile> uploads = files(
+          formatName + ".asset", "one.zip");
+      uploads.add(formatName + ".asset2", new MockMultipartFile(
+          formatName + ".asset2",
+          "two.zip",
+          "application/zip",
+          new byte[] {2}));
+
+      UploadValidationException error = assertThrows(
+          UploadValidationException.class,
+          () -> service.upload(runtime.name(), Map.of(), uploads, "alice", "127.0.0.1"));
+
+      String label = format == RepositoryFormat.NUGET ? "NuGet" : "RubyGems";
+      assertEquals(label + " upload requires exactly one asset", error.getMessage());
+    }
   }
 
   @Test


### PR DESCRIPTION
## 问题背景

kkRepo 原有的 Raw 仓库上传页面只提供文件选择，没有提供目录和可编辑文件名。用户无法指定制品在仓库内的目标路径，文件只能上传到仓库根目录。

Nexus 的 Raw 上传表单会提供以下能力：

- 为本次上传指定 Directory
- 为每个文件指定 Filename
- 通过 Add another asset 一次上传多个文件

同时，目录字段不能简单地展示给所有非 Maven 仓库。最终行为应以 Nexus 兼容的 upload specs 为准：只有声明支持自定义目录的仓库格式才显示目录字段，未指定目录时默认使用根目录 `/`。

## 问题截图

### kkRepo 修复前

Raw 上传页面缺少目录、可编辑文件名和多文件入口：

![kkRepo 修复前的 Raw 上传页面](https://raw.githubusercontent.com/rocklin945/kkRepo/pr-assets-258/.github/pr-assets/258/kkrepo-upload-before.jpg)

### Nexus 3.27 参考行为

Nexus Raw 上传支持 Directory、Filename 和 Add another asset：

![Nexus 3.27 Raw 上传参考页面](https://raw.githubusercontent.com/rocklin945/kkRepo/pr-assets-258/.github/pr-assets/258/nexus-upload-reference.jpg)

## 变更说明

- 根据 Nexus 兼容的上传规格动态渲染非 Maven 仓库上传表单
- 仅对声明支持自定义目录的仓库格式显示目录字段，支持目录时默认使用根目录 `/`
- 保留 Raw 仓库多文件上传能力，并允许每个文件单独修改文件名
- 对齐 Yum、NuGet 和 RubyGems 的上传规格
- 增加窄屏布局，避免文件选择、文件名和移除按钮相互挤压

## 根据 Review 的优化

- NuGet、RubyGems 恢复严格的单文件约束：单文件继续复用原有 Raw 存储路径，两个文件的 API 请求会被拒绝
- upload spec 黑盒对比增加 `raw`、`yum`、`nuget`、`rubygems`，现共覆盖 Maven、npm、PyPI、Helm 和本次涉及的四种格式
- Browse UI 测试由源码字符串断言升级为可执行的 DOM/FormData 行为测试，覆盖字段显隐、Raw 多文件 multipart key、路径预览和单文件格式 key

## 测试

- `mvn -pl server,browse-ui -am -Dtest=ComponentUploadServiceTest,BrowseUploadSpecContractTest -Dsurefire.failIfNoSpecifiedTests=false test`
  - 34 个模块构建成功
  - `ComponentUploadServiceTest` 29 个通过
  - `BrowseUploadSpecContractTest` 1 个通过
- `node --test browse-ui/src/test/js/browse-upload-spec.test.js`
  - 3 个行为测试通过
- `node --check browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.js`
- `git diff --check`

已针对 head `3072b6a` 完成 Nexus 3.94 live compatibility：上游 PR 的候选镜像构建和 `Nexus compatibility` job 均成功，[查看上游运行结果](https://github.com/klboke/kkRepo/actions/runs/32838424259)。fork 上的独立运行也成功，[查看 fork 运行结果](https://github.com/rocklin945/kkRepo/actions/runs/32838041018)。