### PR TITLE
Fix MySQL component searches containing stopwords

### DIFF
--- a/persistence-mysql/src/main/java/com/github/klboke/kkrepo/persistence/mysql/MySqlDatabaseDialect.java
+++ b/persistence-mysql/src/main/java/com/github/klboke/kkrepo/persistence/mysql/MySqlDatabaseDialect.java
@@ -21,6 +21,7 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 import org.springframework.jdbc.core.ConnectionCallback;
 import org.springframework.jdbc.core.JdbcOperations;
@@ -500,6 +501,10 @@ public final class MySqlDatabaseDialect implements DatabaseDialect {
 
   private static final class MySqlSearchPersistenceDialect implements SearchPersistenceDialect {
     private static final int DEFAULT_INNODB_FT_MIN_TOKEN_SIZE = 3;
+    private static final Set<String> DEFAULT_INNODB_FT_STOPWORDS = Set.of(
+        "a", "about", "an", "are", "as", "at", "be", "by", "com", "de", "en", "for",
+        "from", "how", "i", "in", "is", "it", "la", "of", "on", "or", "that", "the",
+        "this", "to", "was", "what", "when", "where", "who", "will", "with", "und", "www");
     private static final Pattern ALIAS = Pattern.compile("[A-Za-z0-9_]+");
 
     @Override
@@ -570,11 +575,13 @@ public final class MySqlDatabaseDialect implements DatabaseDialect {
 
     private static void addTerm(List<String> terms, StringBuilder token) {
       if (!token.isEmpty()) {
+        String term = token.toString();
         // Requiring a term omitted by InnoDB's default FULLTEXT parser makes the whole boolean
-        // query unmatchable. Keep short terms optional while retaining AND semantics for indexed
-        // terms.
-        boolean indexedByDefault = token.length() >= DEFAULT_INNODB_FT_MIN_TOKEN_SIZE;
-        terms.add((indexedByDefault ? "+" : "") + token + "*");
+        // query unmatchable. Keep short terms and stopwords optional while retaining AND semantics
+        // for terms indexed by the default configuration.
+        boolean indexedByDefault = term.length() >= DEFAULT_INNODB_FT_MIN_TOKEN_SIZE
+            && !DEFAULT_INNODB_FT_STOPWORDS.contains(term);
+        terms.add((indexedByDefault ? "+" : "") + term + "*");
         token.setLength(0);
       }
     }

--- a/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/MySqlDatabaseDialectTest.java
+++ b/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/MySqlDatabaseDialectTest.java
@@ -43,7 +43,7 @@ class MySqlDatabaseDialectTest {
         "MATCH(s.namespace, s.name, s.version, s.keywords) AGAINST (? IN BOOLEAN MODE)",
         dialect.search().componentSearchPredicate("s"));
     assertEquals(
-        "+com* +example* +artifact* 1* 0*",
+        "com* +example* +artifact* 1* 0*",
         dialect.search().prepareComponentQuery("\"".repeat(4096) + "Com.Example artifact-1.0"));
     assertEquals(
         "+kkrepo* +alpine* +migration* +app* +datastore_h2_31894582966_1*",
@@ -78,6 +78,13 @@ class MySqlDatabaseDialectTest {
     assertEquals(
         "qh* +agent* +spec* +agentscope*",
         dialect.search().prepareComponentQuery("qh-agent-spec-agentscope"));
+  }
+
+  @Test
+  void keepsDefaultInnoDbStopwordsOptional() {
+    assertEquals(
+        "com* +qunhe* +android* +analytics*",
+        dialect.search().prepareComponentQuery("com.qunhe.android.analytics"));
   }
 
   @Test

--- a/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/ComponentDaoTest.java
+++ b/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/ComponentDaoTest.java
@@ -238,7 +238,7 @@ class ComponentDaoTest {
     String keyword = "\"".repeat(4096) + "Com.Example artifact-1.0";
 
     Assertions.assertEquals(
-        "+com* +example* +artifact* 1* 0*",
+        "com* +example* +artifact* 1* 0*",
         DIALECT.search().prepareComponentQuery(keyword));
   }
 

--- a/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/ComponentSearchMySqlIntegrationTest.java
+++ b/persistence-mysql/src/test/java/com/github/klboke/kkrepo/persistence/mysql/dao/ComponentSearchMySqlIntegrationTest.java
@@ -40,4 +40,30 @@ class ComponentSearchMySqlIntegrationTest extends MySqlIntegrationTestSupport {
             .map(ComponentSearchRow::name)
             .toList());
   }
+
+  @Test
+  void searchFindsMavenNamespaceWhoseLeadingSegmentIsAStopword() {
+    long repositoryId = insertRepository("maven-analytics", "maven2");
+    ComponentDao components = new JdbcComponentDao(jdbc(), jsonColumns(), dialect());
+    String namespace = "com.qunhe.android.analytics";
+    String name = "SensorsAnalyticsSDK";
+    String version = "1.10.16";
+    components.insert(new ComponentRecord(
+        null,
+        repositoryId,
+        RepositoryFormat.MAVEN2,
+        namespace,
+        name,
+        version,
+        "release",
+        HashColumns.componentCoordinateHash(namespace, name, version),
+        Map.of(),
+        Instant.parse("2026-08-25T00:00:00Z")));
+
+    assertEquals(
+        List.of(name),
+        components.search(namespace, RepositoryFormat.MAVEN2, 20).stream()
+            .map(ComponentSearchRow::name)
+            .toList());
+  }
 }


### PR DESCRIPTION
## 变更说明

- 构造 MySQL BOOLEAN MODE 前缀查询时，将 InnoDB 默认停用词作为非必需查询项。
- 普通可索引词仍保留必需操作符，继续维持多关键词查询的 AND 语义。
- 修复 `com.qunhe.android.analytics` 等组件无法被搜索到的问题：`com` 属于 MySQL 默认停用词，生成 `+com*` 会导致整条查询无法命中。
- 增加 MySQL 8 集成回归测试，覆盖包含默认停用词的组件搜索。

## 验证

- [x] `mvn -pl persistence-mysql -am clean -Dtest=MySqlDatabaseDialectTest,ComponentDaoTest,ComponentSearchMySqlIntegrationTest -Dsurefire.failIfNoSpecifiedTests=false test`（23 个测试通过）
- [x] 完整 E2E 不适用：本次为范围明确的持久层查询修复。
- [x] 在线兼容性测试不适用：未修改协议或管理 API 行为。
- [x] 真实客户端 E2E 不适用：未修改包管理客户端行为。
- [x] Native 客户端 E2E 不适用：未涉及 AOT 或 runtime hints。
- [x] 其他：已通过 Testcontainers 在 MySQL 8 上验证。

## 兼容性与设计检查

- [x] 本 PR 不改变官方协议行为，仅修复内部组件搜索语义。
- [x] 协议兼容性测试不适用；已由 MySQL 方言、DAO 和 MySQL 8 集成测试覆盖回归。
- [x] 未引入状态、缓存、锁、session、后台任务、上传/删除、metadata 或权限相关变更。
- [x] 不包含数据库迁移。

## 审阅说明

MySQL 默认 InnoDB 停用词表包含 `com`。此前为该词添加 BOOLEAN MODE 必需操作符后会生成 `+com*`，但全文索引中并不存在该 token，导致其他部分本可匹配的组件名称也被过滤。本次调整让默认停用词保持可选，同时继续要求正常索引词必须匹配。

## 问题截图

**1. 搜索 `com.qunhe.android` 可返回 11 条结果**

<img width="1912" height="956" alt="搜索 com.qunhe.android 返回 11 条结果" src="https://github.com/user-attachments/assets/7ad57b4b-312e-4ef1-a418-0cd3b8364bf8" />

**2. 搜索 `com.qunhe.android.analytics` 返回 0 条结果**

<img width="1912" height="956" alt="搜索 com.qunhe.android.analytics 返回 0 条结果" src="https://github.com/user-attachments/assets/2f1896dc-7a3c-4e28-a293-bc755a236548" />

**3. 按组件名 `SensorsAnalyticsSDK` 搜索，可确认对应组件的 group 为 `com.qunhe.android.analytics`**

<img width="1912" height="956" alt="按组件名搜索可看到 com.qunhe.android.analytics 组件" src="https://github.com/user-attachments/assets/436f7beb-4001-4648-813c-3c8f39789a24" />
