### PR TITLE
修复进入包详情后页面整体上移的问题

### DIFF
--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
@@ -277,6 +277,9 @@ select {
 
 .nx-sidebar {
   grid-row: 2;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
   background: var(--sidebar);
 }
 

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.js
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.js
@@ -1547,6 +1547,18 @@ function pathSelectorValue(path) {
   return String(path).replaceAll("\\", "\\\\").replaceAll('"', '\\"');
 }
 
+function centerTreeRow(row) {
+  const tree = row?.closest?.(".tree-left");
+  if (!tree) return;
+  const treeRect = tree.getBoundingClientRect();
+  const rowRect = row.getBoundingClientRect();
+  const target = tree.scrollTop
+    + rowRect.top + (rowRect.height / 2)
+    - treeRect.top - (tree.clientHeight / 2);
+  const maxScrollTop = Math.max(0, tree.scrollHeight - tree.clientHeight);
+  tree.scrollTop = Math.min(maxScrollTop, Math.max(0, target));
+}
+
 async function selectInitialTreePath() {
   if (!state.path) return;
   await revealTreePath(state.path);
@@ -1554,7 +1566,7 @@ async function selectInitialTreePath() {
   const row = node?.querySelector(":scope > .tree-row");
   if (!row) return;
   selectRow(row);
-  row.scrollIntoView({ block: "center" });
+  centerTreeRow(row);
   const entry = treeNodeEntries.get(node) || findCachedTreeEntry(state.path);
   if (!entry) return;
   if (entry.leaf) await showAssetDetail(entry);

--- a/browse-ui/src/main/resources/META-INF/resources/browse/index.html
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/index.html
@@ -9,7 +9,7 @@
     <script src="/login/assets/ui-theme.js?v=20260824-ui-themes-3"></script>
     <link rel="stylesheet" href="/browse/assets/format-icons.css?v=20260811-conan-1">
     <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260818-user-round-1">
-    <link rel="stylesheet" href="/browse/assets/browse.css?v=20260824-ui-themes-2">
+    <link rel="stylesheet" href="/browse/assets/browse.css?v=20260826-tree-scroll-1">
     <link rel="stylesheet" href="/browse/assets/account-menu.css?v=20260824-ui-themes-3">
     <link rel="stylesheet" href="/browse/assets/global-component-search.css?v=20260819-topbar-control-height-1">
     <link rel="stylesheet" href="/login/assets/login-modal.css?v=20260818-login-icons-1">
@@ -486,6 +486,6 @@
     <script src="/login/assets/product-update.js?v=20260819-version-update-1"></script>
     <script src="/login/assets/login-modal.js?v=20260818-login-icons-3"></script>
     <script src="/browse/assets/global-component-search.js?v=20260817-global-search-2"></script>
-    <script src="/browse/assets/browse.js?v=20260818-account-menu-2"></script>
+    <script src="/browse/assets/browse.js?v=20260826-tree-scroll-1"></script>
   </body>
 </html>

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseTerraformUploadContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseTerraformUploadContractTest.java
@@ -39,7 +39,7 @@ class BrowseTerraformUploadContractTest {
     assertTrue(javascript.contains("const repoUrl = repositoryBaseUrl().replace(/\\/+$/, \"\")"));
     assertTrue(javascript.contains("crumbIcon: repositoryFormatIcon()"));
     assertTrue(javascript.contains("await activateTreeBranch(entry, toggleExpand)"));
-    assertTrue(index.contains("/browse/assets/browse.js?v=20260818-account-menu-2"));
+    assertTrue(index.contains("/browse/assets/browse.js?v=20260826-tree-scroll-1"));
   }
 
   private String resource(String path) throws IOException {

--- a/browse-ui/src/test/js/browse-layout-scroll.test.js
+++ b/browse-ui/src/test/js/browse-layout-scroll.test.js
@@ -1,0 +1,25 @@
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const { resolve } = require("node:path");
+const test = require("node:test");
+
+const browseRoot = resolve(
+  __dirname,
+  "../../main/resources/META-INF/resources/browse",
+);
+
+test("keeps the expanded navigation inside the sidebar scroll container", () => {
+  const css = readFileSync(resolve(browseRoot, "assets/browse.css"), "utf8");
+  const sidebarRule = css.match(/\.nx-sidebar\s*\{([^}]*)\}/)?.[1] || "";
+
+  assert.match(sidebarRule, /min-height:\s*0/);
+  assert.match(sidebarRule, /overflow-x:\s*hidden/);
+  assert.match(sidebarRule, /overflow-y:\s*auto/);
+});
+
+test("cache-busts the tree scroll fix assets", () => {
+  const html = readFileSync(resolve(browseRoot, "index.html"), "utf8");
+
+  assert.match(html, /browse\.css\?v=20260826-tree-scroll-1/);
+  assert.match(html, /browse\.js\?v=20260826-tree-scroll-1/);
+});

--- a/browse-ui/src/test/js/browse-terraform-details.test.js
+++ b/browse-ui/src/test/js/browse-terraform-details.test.js
@@ -93,7 +93,7 @@ test("uses the rendered tree entry when restoring a direct asset URL", async () 
   const source = readFileSync(resolve(
     __dirname,
     "../../main/resources/META-INF/resources/browse/assets/browse.js"), "utf8");
-  const start = source.indexOf("async function selectInitialTreePath");
+  const start = source.indexOf("function centerTreeRow");
   const end = source.indexOf("async function revealTreePath", start);
   assert.notEqual(start, -1);
   assert.notEqual(end, -1);
@@ -101,7 +101,17 @@ test("uses the rendered tree entry when restoring a direct asset URL", async () 
   const path = "v1/providers/acme/demo/1.0.10/download/linux/amd64/"
     + "terraform-provider-demo_1.0.10_linux_amd64.zip";
   const entry = { path, name: path.split("/").at(-1), leaf: true };
-  const row = { scrollIntoView() {} };
+  const tree = {
+    clientHeight: 200,
+    scrollHeight: 1000,
+    scrollTop: 20,
+    getBoundingClientRect: () => ({ top: 100 }),
+  };
+  const row = {
+    closest: (selector) => selector === ".tree-left" ? tree : null,
+    getBoundingClientRect: () => ({ top: 250, height: 20 }),
+    scrollIntoView: () => { throw new Error("must not scroll the page"); },
+  };
   const node = { querySelector: () => row };
   let displayed = null;
   const context = vm.createContext({
@@ -123,6 +133,7 @@ test("uses the rendered tree entry when restoring a direct asset URL", async () 
   );
   await context.selectInitialTreePath();
   assert.equal(displayed, entry);
+  assert.equal(tree.scrollTop, 80);
 });
 
 test("renders folder details with the repository format icon", async () => {


### PR DESCRIPTION
## 问题说明

当左侧“搜索”格式列表处于展开状态时，从组件搜索结果进入包详情，页面整体会向上偏移，顶部导航可能被部分或完全推出视口。

## 原因

恢复深链选中节点时使用了 `row.scrollIntoView({ block: "center" })`。左侧导航内容超过可用高度后，外层 `.nx-shell` 也会成为该调用影响的滚动祖先，定位目录树节点时同时滚动了整个应用外壳。

## 修复内容

- 将左侧导航限制为独立的纵向滚动区域，并隐藏横向溢出。
- 使用目录树容器自身的 `scrollTop` 居中选中节点，不再触发页面级 `scrollIntoView`。
- 更新浏览页 CSS/JS 静态资源版本，避免浏览器继续命中旧缓存。
- 增加回归测试，覆盖目录树定位及侧栏滚动边界。

## 验证

- [x] `node --check browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.js`
- [x] `node --test browse-ui/src/test/js/*.test.js`（19 个测试通过）
- [x] `mvn -pl browse-ui -am -Dtest=BrowseUploadSpecContractTest -Dsurefire.failIfNoSpecifiedTests=false test`
- [x] 使用本分支静态资源连接 SIT 只读接口复现原操作路径：进入详情前后 `.nx-shell.scrollTop` 均为 `0`，顶栏保持在 `top: 0`，仅目录树内部滚动。

## 兼容性说明

本次修改只涉及浏览端滚动与布局，不改变仓库协议、服务端状态、缓存、上传或多副本语义。

## 问题截图

下图展示了进入包详情后页面整体上移、顶部导航离开视口的现象：

![进入包详情后页面整体上移](https://raw.githubusercontent.com/rocklin945/kkRepo/pr-assets-258/.github/pr-assets/browse-detail-scroll/layout-shift.jpg)
