### PR TITLE
Preview admin theme selections before saving

### DIFF
--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
@@ -899,6 +899,14 @@ body {
   line-height: 1.45;
 }
 
+.ui-theme-preview-status {
+  padding: 8px 10px;
+  border: 1px solid var(--warning-line);
+  border-radius: var(--r-sm);
+  background: var(--warning-bg);
+  color: var(--warning);
+}
+
 .form-grid input,
 .form-grid select,
 .form-grid textarea {

--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js
@@ -3467,15 +3467,22 @@ function syncUiSettingsForm() {
     const themes = settings.supportedDefaultThemes?.length
       ? settings.supportedDefaultThemes
       : ["default"];
+    const savedTheme = settings.defaultTheme || "default";
+    const hasPreview = previewTheme
+      && themes.includes(previewTheme)
+      && previewTheme !== savedTheme;
     themeSelect.replaceChildren(...themes.map((theme) => {
       const option = document.createElement("option");
       option.value = theme;
       option.textContent = uiThemeLabel(theme);
       return option;
     }));
-    themeSelect.value = previewTheme && themes.includes(previewTheme)
-      ? previewTheme
-      : settings.defaultTheme || "default";
+    themeSelect.value = hasPreview ? previewTheme : savedTheme;
+    if (hasPreview) {
+      // Loading persisted settings applies their theme before dispatching the
+      // change event, so restore the administrator's unsaved preview here.
+      window.kkrepoTheme?.applyTheme(themeSelect.value, themes);
+    }
   }
   syncUiThemePreviewStatus();
   clearRequiredFieldErrors(uiSettingsRequiredFields);

--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js
@@ -3434,10 +3434,32 @@ function uiThemeLabel(theme) {
     .join(" ");
 }
 
+function syncUiThemePreviewStatus() {
+  const settings = window.kkrepoI18n?.settings?.();
+  const themeSelect = document.getElementById("ui-default-theme");
+  const previewStatus = document.getElementById("ui-theme-preview-status");
+  if (!settings || !themeSelect || !previewStatus) return;
+  previewStatus.hidden = themeSelect.value === (settings.defaultTheme || "default");
+}
+
+function previewUiTheme() {
+  const settings = window.kkrepoI18n?.settings?.();
+  const themeSelect = document.getElementById("ui-default-theme");
+  if (!settings || !themeSelect || !window.kkrepoTheme) return;
+  themeSelect.value = window.kkrepoTheme.applyTheme(
+    themeSelect.value,
+    settings.supportedDefaultThemes);
+  syncUiThemePreviewStatus();
+}
+
 function syncUiSettingsForm() {
   const settings = window.kkrepoI18n?.settings?.();
   const languageSelect = document.getElementById("ui-default-language");
   const themeSelect = document.getElementById("ui-default-theme");
+  const previewStatus = document.getElementById("ui-theme-preview-status");
+  const previewTheme = themeSelect && previewStatus && !previewStatus.hidden
+    ? themeSelect.value
+    : null;
   if (languageSelect && settings) {
     languageSelect.value = settings.defaultLanguage || "en";
   }
@@ -3451,8 +3473,11 @@ function syncUiSettingsForm() {
       option.textContent = uiThemeLabel(theme);
       return option;
     }));
-    themeSelect.value = settings.defaultTheme || "default";
+    themeSelect.value = previewTheme && themes.includes(previewTheme)
+      ? previewTheme
+      : settings.defaultTheme || "default";
   }
+  syncUiThemePreviewStatus();
   clearRequiredFieldErrors(uiSettingsRequiredFields);
 }
 
@@ -7809,6 +7834,7 @@ document.getElementById("ui-settings-form").addEventListener("submit", (event) =
   event.preventDefault();
   saveUiSettings();
 });
+document.getElementById("ui-default-theme").addEventListener("change", previewUiTheme);
 bindRequiredFieldErrors(uiSettingsRequiredFields);
 window.addEventListener("kkrepo:i18n-change", syncUiSettingsForm);
 

--- a/admin-ui/src/main/resources/META-INF/resources/admin/index.html
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/index.html
@@ -9,7 +9,7 @@
     <script src="/login/assets/ui-theme.js?v=20260824-ui-themes-3"></script>
     <link rel="stylesheet" href="/browse/assets/format-icons.css?v=20260811-conan-1">
     <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260818-user-round-1">
-    <link rel="stylesheet" href="./assets/admin.css?v=20260824-ui-themes-2">
+    <link rel="stylesheet" href="./assets/admin.css?v=20260826-ui-theme-preview-1">
     <link rel="stylesheet" href="/browse/assets/account-menu.css?v=20260824-ui-themes-3">
     <link rel="stylesheet" href="/browse/assets/global-component-search.css?v=20260819-topbar-control-height-1">
   </head>
@@ -1770,6 +1770,7 @@
                 </select>
               </label>
               <p class="form-note full-width">These preferences are stored in the database and apply to the administration, browse, and sign-in UI on every replica. The current kkRepo design is provided as the default CSS theme template.</p>
+              <p class="form-note full-width ui-theme-preview-status" id="ui-theme-preview-status" role="status" aria-live="polite" hidden>Theme preview is active. Save UI settings to make it the default.</p>
             </div>
             <div class="form-actions">
               <button class="create-button" id="save-ui-settings-button" type="button">Save UI settings</button>
@@ -1831,10 +1832,10 @@
       </main>
     </div>
 
-    <script src="/login/assets/ui-i18n.js?v=20260824-ui-themes-2"></script>
+    <script src="/login/assets/ui-i18n.js?v=20260826-ui-theme-preview-1"></script>
     <script src="/login/assets/product-update.js?v=20260819-version-update-1"></script>
     <script src="./assets/admin-filter.js?v=20260706-wildcard-filter-1"></script>
     <script src="/browse/assets/global-component-search.js?v=20260817-global-search-2"></script>
-    <script src="./assets/admin.js?v=20260824-ui-themes-4"></script>
+    <script src="./assets/admin.js?v=20260826-ui-theme-preview-1"></script>
   </body>
 </html>

--- a/admin-ui/src/main/resources/META-INF/resources/login/assets/ui-i18n.js
+++ b/admin-ui/src/main/resources/META-INF/resources/login/assets/ui-i18n.js
@@ -318,6 +318,7 @@
     "English": "英文",
     "Save UI settings": "保存界面设置",
     "These preferences are stored in the database and apply to the administration, browse, and sign-in UI on every replica. The current kkRepo design is provided as the default CSS theme template.": "这些设置存储在数据库中，对所有副本的管理、浏览和登录界面均生效。当前 kkRepo 设计作为默认 CSS 主题模板提供。",
+    "Theme preview is active. Save UI settings to make it the default.": "正在预览所选主题。保存界面设置后，它才会成为默认主题。",
     "Welcome": "欢迎",
     "Enterprise-grade artifact management for modern software delivery": "面向现代软件交付的企业级制品管理",
     "Initial administrator setup": "初始管理员设置",

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminUiThemeContractTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminUiThemeContractTest.java
@@ -33,6 +33,7 @@ class AdminUiThemeContractTest {
     assertTrue(index.contains("id=\"ui-theme-preview-status\" role=\"status\" aria-live=\"polite\" hidden"));
     assertTrue(javascript.contains("saveSettings(languageSelect.value, themeSelect.value)"));
     assertTrue(javascript.contains("window.kkrepoTheme.applyTheme("));
+    assertTrue(javascript.contains("window.kkrepoTheme?.applyTheme(themeSelect.value, themes)"));
     assertTrue(javascript.contains("addEventListener(\"change\", previewUiTheme)"));
     assertTrue(javascript.contains("settings.supportedDefaultThemes"));
     assertTrue(javascript.contains("if (theme === \"jfrog\") return \"JFrog\""));

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminUiThemeContractTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminUiThemeContractTest.java
@@ -26,15 +26,23 @@ class AdminUiThemeContractTest {
   void exposesDefaultThemeSelectionInUiSettings() throws IOException {
     String index = resource("/META-INF/resources/admin/index.html");
     String javascript = resource("/META-INF/resources/admin/assets/admin.js");
+    String i18n = resource("/META-INF/resources/login/assets/ui-i18n.js");
 
     assertTrue(index.contains("id=\"ui-default-theme\" required"));
     assertTrue(index.contains("value=\"default\" selected>Default</option>"));
+    assertTrue(index.contains("id=\"ui-theme-preview-status\" role=\"status\" aria-live=\"polite\" hidden"));
     assertTrue(javascript.contains("saveSettings(languageSelect.value, themeSelect.value)"));
+    assertTrue(javascript.contains("window.kkrepoTheme.applyTheme("));
+    assertTrue(javascript.contains("addEventListener(\"change\", previewUiTheme)"));
     assertTrue(javascript.contains("settings.supportedDefaultThemes"));
     assertTrue(javascript.contains("if (theme === \"jfrog\") return \"JFrog\""));
-    assertTrue(index.contains("./assets/admin.js?v=20260824-ui-themes-4"));
+    assertTrue(i18n.contains("正在预览所选主题。保存界面设置后，它才会成为默认主题。"));
+    assertTrue(index.contains("./assets/admin.css?v=20260826-ui-theme-preview-1"));
+    assertTrue(index.contains("/login/assets/ui-i18n.js?v=20260826-ui-theme-preview-1"));
+    assertTrue(index.contains("./assets/admin.js?v=20260826-ui-theme-preview-1"));
     assertFalse(index.contains("id=\"ui-settings-status\""));
     assertFalse(javascript.contains("Default language: ${"));
+    assertFalse(javascript.contains("setDefaultTheme(themeSelect.value)"));
   }
 
   private String resource(String path) throws IOException {

--- a/admin-ui/src/test/js/ui-theme.test.js
+++ b/admin-ui/src/test/js/ui-theme.test.js
@@ -10,6 +10,7 @@ const uiTheme = require(resolve(
 function fixture(cachedSettings) {
   const stylesheetAttributes = new Map();
   const rootAttributes = new Map();
+  const storageWrites = [];
   const stylesheet = {
     onerror: null,
     setAttribute(name, value) { stylesheetAttributes.set(name, value); },
@@ -28,10 +29,13 @@ function fixture(cachedSettings) {
         assert.equal(key, "kkrepo.uiSettings");
         return JSON.stringify(cachedSettings || {});
       },
+      setItem(key, value) {
+        storageWrites.push([key, value]);
+      },
     },
   };
   const binding = uiTheme.bind(documentRef, windowRef);
-  return { binding, rootAttributes, stylesheet, stylesheetAttributes };
+  return { binding, rootAttributes, stylesheet, stylesheetAttributes, storageWrites };
 }
 
 test("boots with the current kkRepo CSS as the default theme", () => {
@@ -60,6 +64,20 @@ test("loads every registered bundled theme template from cached UI settings", ()
       `/browse/assets/themes/${theme}.css?v=20260824-ui-themes-3`,
     );
   }
+});
+
+test("previews a selected theme without persisting browser settings", () => {
+  const themes = ["default", "indigo", "ocean", "sunset", "jfrog"];
+  const view = fixture({ defaultTheme: "default", supportedDefaultThemes: themes });
+
+  assert.equal(view.binding.applyTheme("jfrog", themes), "jfrog");
+  assert.equal(view.binding.currentTheme(), "jfrog");
+  assert.equal(view.rootAttributes.get("data-theme"), "jfrog");
+  assert.equal(
+    view.stylesheetAttributes.get("href"),
+    "/browse/assets/themes/jfrog.css?v=20260824-ui-themes-3",
+  );
+  assert.deepEqual(view.storageWrites, []);
 });
 
 test("rejects unregistered and path-like theme identifiers", () => {


### PR DESCRIPTION
## Summary

- apply the selected admin theme immediately as an in-page preview
- keep previews local to the current page until UI settings are saved
- show an accessible unsaved-preview notice and preserve it across admin view navigation
- keep browser and database settings unchanged until the existing save action succeeds

## Testing

- `node --test admin-ui/src/test/js/ui-theme.test.js`
- `mvn -B -ntp -pl admin-ui -am test`
- `node --check admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.js`
- `node --check admin-ui/src/main/resources/META-INF/resources/login/assets/ui-i18n.js`