### PR TITLE
Add user registration links to the READMEs

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -206,6 +206,10 @@ AI agent 和贡献者的开发说明见 [AGENTS.md](AGENTS.md)。
 
 用户和管理端 UI 已暴露的 token 类型包括协议专用 token（`NpmToken`、`CargoToken`、`PubToken`、`NuGetApiKey`、`RubyGemsApiKey`），以及面向 Terraform 服务 URL、Ansible Galaxy 客户端、CI、脚本和自定义 HTTP 客户端的 `GenericToken`；`GenericToken` 适用于能够发送已配置 API-key header 或 bearer token 的调用方。
 
+## 谁在使用 kkRepo？
+
+如果你的公司、企业或组织正在使用 kkRepo，欢迎前往[中文用户登记 Issue](https://github.com/klboke/kkRepo/issues/93)或[英文用户登记 Issue](https://github.com/klboke/kkRepo/issues/94)留下部署信息。登记 Issue 仅用于使用方登记；Bug 和功能建议请使用常规 Issue 模板提交。
+
 ## 参与贡献
 
 欢迎提交 issue 和 pull request。贡献流程、PR 要求、兼容性测试要求和多副本设计约束见 [CONTRIBUTING.md](CONTRIBUTING.md)。社区行为准则见 [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)。

--- a/README.cn.md
+++ b/README.cn.md
@@ -208,7 +208,7 @@ AI agent 和贡献者的开发说明见 [AGENTS.md](AGENTS.md)。
 
 ## 谁在使用 kkRepo？
 
-如果你的公司、企业或组织正在使用 kkRepo，欢迎前往[中文用户登记 Issue](https://github.com/klboke/kkRepo/issues/93)或[英文用户登记 Issue](https://github.com/klboke/kkRepo/issues/94)留下部署信息。登记 Issue 仅用于使用方登记；Bug 和功能建议请使用常规 Issue 模板提交。
+如果你的公司、企业或组织正在使用 kkRepo，欢迎前往[用户登记 Issue](https://github.com/klboke/kkRepo/issues/93)留下部署信息。该 Issue 仅用于使用方登记；Bug 和功能建议请使用常规 Issue 模板提交。
 
 ## 参与贡献
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,10 @@ Repository format roadmap:
 
 Token types exposed in the user and admin UI include protocol-specific tokens (`NpmToken`, `CargoToken`, `PubToken`, `NuGetApiKey`, `RubyGemsApiKey`) plus `GenericToken` for Terraform service URLs, Ansible Galaxy clients, CI, scripts, and custom HTTP clients that can send the configured API-key header or bearer token.
 
+## Who Is Using kkRepo?
+
+If your company, enterprise, or organization uses kkRepo, you are welcome to share your deployment in the [English user registration issue](https://github.com/klboke/kkRepo/issues/94) or the [Chinese user registration issue](https://github.com/klboke/kkRepo/issues/93). These issues are for usage registration only; please use the regular issue templates for bug reports and feature requests.
+
 ## Contributing
 
 Issues and pull requests are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the contributor workflow, PR expectations, compatibility testing expectations, and multi-replica design constraints. Community behavior expectations are documented in [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Token types exposed in the user and admin UI include protocol-specific tokens (`
 
 ## Who Is Using kkRepo?
 
-If your company, enterprise, or organization uses kkRepo, you are welcome to share your deployment in the [English user registration issue](https://github.com/klboke/kkRepo/issues/94) or the [Chinese user registration issue](https://github.com/klboke/kkRepo/issues/93). These issues are for usage registration only; please use the regular issue templates for bug reports and feature requests.
+If your company, enterprise, or organization uses kkRepo, you are welcome to share your deployment in the [user registration issue](https://github.com/klboke/kkRepo/issues/94). This issue is for usage registration only; please use the regular issue templates for bug reports and feature requests.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- add a `Who Is Using kkRepo?` section to the English README with its language-matched registration entry
- add a matching `谁在使用 kkRepo？` section to the Chinese README with its language-matched registration entry
- clarify that each registration entry is only for usage registration

## Validation

- `git diff --check`
- verified that each README links only to its matching language registration entry