### PR TITLE
Streamline Browse search and unify scrollbar styling

### DIFF
--- a/admin-ui/src/main/resources/META-INF/resources/admin/index.html
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="/admin/assets/favicon.svg?v=20260609-kl-logo-1">
     <link id="kkrepo-theme-stylesheet" rel="stylesheet" href="/browse/assets/themes/default.css?v=20260824-ui-themes-3">
     <script src="/login/assets/ui-theme.js?v=20260824-ui-themes-3"></script>
-    <link rel="stylesheet" href="/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-1">
+  <link rel="stylesheet" href="/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-2">
     <link rel="stylesheet" href="/browse/assets/format-icons.css?v=20260811-conan-1">
     <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260818-user-round-1">
     <link rel="stylesheet" href="./assets/admin.css?v=20260826-ui-theme-preview-1">

--- a/admin-ui/src/main/resources/META-INF/resources/admin/index.html
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="/admin/assets/favicon.svg?v=20260609-kl-logo-1">
     <link id="kkrepo-theme-stylesheet" rel="stylesheet" href="/browse/assets/themes/default.css?v=20260824-ui-themes-3">
     <script src="/login/assets/ui-theme.js?v=20260824-ui-themes-3"></script>
-  <link rel="stylesheet" href="/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-3">
+  <link rel="stylesheet" href="/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-4">
     <link rel="stylesheet" href="/browse/assets/format-icons.css?v=20260811-conan-1">
     <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260818-user-round-1">
     <link rel="stylesheet" href="./assets/admin.css?v=20260826-ui-theme-preview-1">

--- a/admin-ui/src/main/resources/META-INF/resources/admin/index.html
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/index.html
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="/admin/assets/favicon.svg?v=20260609-kl-logo-1">
     <link id="kkrepo-theme-stylesheet" rel="stylesheet" href="/browse/assets/themes/default.css?v=20260824-ui-themes-3">
     <script src="/login/assets/ui-theme.js?v=20260824-ui-themes-3"></script>
+    <link rel="stylesheet" href="/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-1">
     <link rel="stylesheet" href="/browse/assets/format-icons.css?v=20260811-conan-1">
     <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260818-user-round-1">
     <link rel="stylesheet" href="./assets/admin.css?v=20260826-ui-theme-preview-1">

--- a/admin-ui/src/main/resources/META-INF/resources/admin/index.html
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="/admin/assets/favicon.svg?v=20260609-kl-logo-1">
     <link id="kkrepo-theme-stylesheet" rel="stylesheet" href="/browse/assets/themes/default.css?v=20260824-ui-themes-3">
     <script src="/login/assets/ui-theme.js?v=20260824-ui-themes-3"></script>
-  <link rel="stylesheet" href="/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-2">
+  <link rel="stylesheet" href="/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-3">
     <link rel="stylesheet" href="/browse/assets/format-icons.css?v=20260811-conan-1">
     <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260818-user-round-1">
     <link rel="stylesheet" href="./assets/admin.css?v=20260826-ui-theme-preview-1">

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminUiScrollbarContractTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminUiScrollbarContractTest.java
@@ -22,7 +22,7 @@ class AdminUiScrollbarContractTest {
 
     assertTrue(theme >= 0 && scrollbars > theme && components > scrollbars);
     assertTrue(index.contains(
-        "/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-1"));
+        "/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-2"));
     assertFalse(admin.contains("::-webkit-scrollbar"));
     assertFalse(admin.contains("scrollbar-color:"));
     assertFalse(admin.contains("scrollbar-width:"));

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminUiScrollbarContractTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminUiScrollbarContractTest.java
@@ -22,7 +22,7 @@ class AdminUiScrollbarContractTest {
 
     assertTrue(theme >= 0 && scrollbars > theme && components > scrollbars);
     assertTrue(index.contains(
-        "/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-3"));
+        "/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-4"));
     assertFalse(admin.contains("::-webkit-scrollbar"));
     assertFalse(admin.contains("scrollbar-color:"));
     assertFalse(admin.contains("scrollbar-width:"));

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminUiScrollbarContractTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminUiScrollbarContractTest.java
@@ -1,0 +1,36 @@
+package com.github.klboke.kkrepo.admin.ui;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import org.junit.jupiter.api.Test;
+
+class AdminUiScrollbarContractTest {
+
+  @Test
+  void loadsSharedScrollbarStylesAfterTheThemeAndBeforeComponentStyles() throws IOException {
+    String index = resource("/META-INF/resources/admin/index.html");
+    String admin = resource("/META-INF/resources/admin/assets/admin.css");
+
+    int theme = index.indexOf("id=\"kkrepo-theme-stylesheet\"");
+    int scrollbars = index.indexOf("/browse/assets/ui-scrollbars.css");
+    int components = index.indexOf("./assets/admin.css");
+
+    assertTrue(theme >= 0 && scrollbars > theme && components > scrollbars);
+    assertTrue(index.contains(
+        "/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-1"));
+    assertFalse(admin.contains("::-webkit-scrollbar"));
+    assertFalse(admin.contains("scrollbar-color:"));
+    assertFalse(admin.contains("scrollbar-width:"));
+  }
+
+  private String resource(String path) throws IOException {
+    try (InputStream stream = getClass().getResourceAsStream(path)) {
+      return new String(Objects.requireNonNull(stream).readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+}

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminUiScrollbarContractTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminUiScrollbarContractTest.java
@@ -22,7 +22,7 @@ class AdminUiScrollbarContractTest {
 
     assertTrue(theme >= 0 && scrollbars > theme && components > scrollbars);
     assertTrue(index.contains(
-        "/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-2"));
+        "/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-3"));
     assertFalse(admin.contains("::-webkit-scrollbar"));
     assertFalse(admin.contains("scrollbar-color:"));
     assertFalse(admin.contains("scrollbar-width:"));

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
@@ -643,7 +643,8 @@ h1 {
   padding: 0 12px 10px;
 }
 
-.search-form label {
+.search-form label,
+.search-format-field {
   display: grid;
   gap: 6px;
   color: #3c3c3c;
@@ -666,6 +667,160 @@ h1 {
 
 .search-format-field[hidden] {
   display: none;
+}
+
+.search-format-combobox {
+  position: relative;
+  width: 240px;
+}
+
+.search-format-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  height: 36px;
+  gap: 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  color: var(--text);
+  cursor: pointer;
+  padding: 0 10px;
+  text-align: left;
+}
+
+.search-format-trigger:hover,
+.search-format-trigger[aria-expanded="true"] {
+  border-color: var(--active);
+  background: var(--brand-tint);
+}
+
+.search-format-trigger:focus-visible,
+.search-format-option:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 1px;
+}
+
+.search-format-value,
+.search-format-option {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 9px;
+}
+
+.search-format-value {
+  flex: 1;
+  overflow: hidden;
+  font-weight: 400;
+  white-space: nowrap;
+}
+
+.search-format-value > span:last-child,
+.search-format-option > span:nth-child(2) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.search-format-caret {
+  flex: 0 0 auto;
+  color: var(--muted);
+  font-size: 12px;
+  transition: transform 0.12s ease;
+}
+
+.search-format-trigger[aria-expanded="true"] .search-format-caret {
+  transform: rotate(180deg);
+}
+
+.search-format-popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 80;
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: var(--shadow-pop);
+  padding: 6px;
+}
+
+.search-format-filter {
+  width: 100%;
+  height: 36px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: var(--panel);
+  color: var(--text);
+  margin-bottom: 6px;
+  padding: 0 9px;
+}
+
+.search-format-filter:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 1px;
+}
+
+.search-format-options {
+  display: grid;
+  max-height: min(340px, calc(100vh - 270px));
+  gap: 2px;
+  overflow-y: auto;
+}
+
+.search-format-option {
+  width: 100%;
+  min-height: 38px;
+  flex: 0 0 auto;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  padding: 6px 9px;
+  text-align: left;
+}
+
+.search-format-option::after {
+  content: "";
+  width: 6px;
+  height: 11px;
+  flex: 0 0 auto;
+  border: solid var(--active);
+  border-width: 0 2px 2px 0;
+  margin: -2px 3px 0 auto;
+  opacity: 0;
+  transform: rotate(45deg);
+}
+
+.search-format-option:hover,
+.search-format-option.is-active {
+  background: var(--brand-tint);
+}
+
+.search-format-option[aria-selected="true"] {
+  background: var(--brand-tint-strong);
+}
+
+.search-format-option[aria-selected="true"]::after {
+  opacity: 1;
+}
+
+.search-format-value .format-logo,
+.search-format-option .format-logo {
+  width: 20px;
+  height: 20px;
+  flex-basis: 20px;
+}
+
+.search-format-empty {
+  color: var(--muted);
+  font-size: 13px;
+  padding: 16px 10px;
+  text-align: center;
 }
 
 .criteria-button {
@@ -2229,6 +2384,7 @@ h2 {
 }
 
 .search-form label,
+.search-format-field,
 .upload-form label,
 .admin-bootstrap-grid label,
 .token-form label {

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
@@ -748,7 +748,7 @@ h1 {
   padding: 6px;
 }
 
-.search-format-filter {
+.search-form .search-format-filter {
   width: 100%;
   height: 36px;
   border: 1px solid var(--line);
@@ -759,7 +759,7 @@ h1 {
   padding: 0 9px;
 }
 
-.search-format-filter:focus-visible {
+.search-form .search-format-filter:focus-visible {
   outline: 3px solid var(--focus);
   outline-offset: 1px;
 }

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
@@ -638,6 +638,7 @@ h1 {
 .search-form {
   display: flex;
   align-items: end;
+  flex-wrap: wrap;
   gap: 6px;
   padding: 0 12px 10px;
 }
@@ -649,13 +650,22 @@ h1 {
   font-weight: 700;
 }
 
-.search-form input {
+.search-form input,
+.search-form select {
   width: 300px;
   height: 32px;
   border: 1px solid #d3d3d3;
   border-radius: 3px;
   padding: 0 8px;
   font-weight: 400;
+}
+
+.search-form select {
+  width: 220px;
+}
+
+.search-format-field[hidden] {
+  display: none;
 }
 
 .criteria-button {
@@ -2044,6 +2054,7 @@ h2 {
 
 .filter-box,
 .search-form input,
+.search-form select,
 .upload-form input,
 .upload-form select,
 .upload-form textarea,
@@ -2227,6 +2238,7 @@ h2 {
 }
 
 .search-form input,
+.search-form select,
 .upload-form input,
 .upload-form select {
   height: 36px;

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.js
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.js
@@ -23,6 +23,7 @@ let uploadAssetCount = 1;
 let repositorySort = { key: "name", direction: "asc" };
 let activeSearchFormat = "maven2";
 let activeCustomSearchFormat = "maven2";
+let activeCustomSearchFormatOption = null;
 let currentSession = null;
 let currentPermissions = [];
 let adminBootstrapStatus = null;
@@ -4188,15 +4189,195 @@ function clearSearchFormatSelection() {
   });
 }
 
+function customSearchFormatOptionElements() {
+  return Array.from(document.querySelectorAll("[data-custom-search-format]"));
+}
+
+function visibleCustomSearchFormatOptionElements() {
+  return customSearchFormatOptionElements().filter((option) => !option.hidden);
+}
+
+function setActiveCustomSearchFormatOption(format, scroll = false) {
+  const filter = document.getElementById("component-custom-format-filter");
+  activeCustomSearchFormatOption = format || null;
+  let activeOption = null;
+  customSearchFormatOptionElements().forEach((option) => {
+    const active = !option.hidden
+      && option.dataset.customSearchFormat === activeCustomSearchFormatOption;
+    option.classList.toggle("is-active", active);
+    if (active) activeOption = option;
+  });
+  if (activeOption) {
+    filter.setAttribute("aria-activedescendant", activeOption.id);
+    if (scroll) activeOption.scrollIntoView({ block: "nearest" });
+  } else {
+    filter.removeAttribute("aria-activedescendant");
+  }
+}
+
+function filterCustomSearchFormatOptions() {
+  const filter = document.getElementById("component-custom-format-filter");
+  const empty = document.getElementById("component-custom-format-empty");
+  const query = filter.value.trim().toLowerCase();
+  customSearchFormatOptionElements().forEach((option) => {
+    const searchable = `${option.dataset.customSearchFormat} ${option.textContent}`.toLowerCase();
+    option.hidden = Boolean(query) && !searchable.includes(query);
+  });
+  const visible = visibleCustomSearchFormatOptionElements();
+  empty.hidden = visible.length > 0;
+  const currentActive = visible.find(
+      (option) => option.dataset.customSearchFormat === activeCustomSearchFormatOption);
+  const selected = visible.find(
+      (option) => option.dataset.customSearchFormat === activeCustomSearchFormat);
+  setActiveCustomSearchFormatOption(
+      (currentActive || selected || visible[0])?.dataset.customSearchFormat || null);
+}
+
+function syncCustomSearchFormatCombobox() {
+  const select = document.getElementById("component-custom-format");
+  const value = document.getElementById("component-custom-format-value");
+  const normalized = normalizeCustomSearchFormat(activeCustomSearchFormat);
+  activeCustomSearchFormat = normalized;
+  select.value = normalized;
+  value.innerHTML = `
+    <span class="format-logo format-logo-${formatIconName(normalized)}" aria-hidden="true"></span>
+    <span>${escapeHtml(searchFormatLabel(normalized))}</span>
+  `;
+  customSearchFormatOptionElements().forEach((option) => {
+    option.setAttribute(
+        "aria-selected",
+        String(option.dataset.customSearchFormat === normalized));
+  });
+}
+
+function openCustomSearchFormatCombobox() {
+  const trigger = document.getElementById("component-custom-format-trigger");
+  const popover = document.getElementById("component-custom-format-popover");
+  const filter = document.getElementById("component-custom-format-filter");
+  if (!popover.hidden) return;
+  syncCustomSearchFormatCombobox();
+  filter.value = "";
+  activeCustomSearchFormatOption = activeCustomSearchFormat;
+  filterCustomSearchFormatOptions();
+  popover.hidden = false;
+  trigger.setAttribute("aria-expanded", "true");
+  filter.setAttribute("aria-expanded", "true");
+  setTimeout(() => {
+    filter.focus();
+    setActiveCustomSearchFormatOption(activeCustomSearchFormatOption, true);
+  }, 0);
+}
+
+function closeCustomSearchFormatCombobox(focusTrigger = false) {
+  const trigger = document.getElementById("component-custom-format-trigger");
+  const popover = document.getElementById("component-custom-format-popover");
+  const filter = document.getElementById("component-custom-format-filter");
+  popover.hidden = true;
+  trigger.setAttribute("aria-expanded", "false");
+  filter.setAttribute("aria-expanded", "false");
+  filter.removeAttribute("aria-activedescendant");
+  activeCustomSearchFormatOption = null;
+  if (focusTrigger) trigger.focus();
+}
+
+function toggleCustomSearchFormatCombobox() {
+  const popover = document.getElementById("component-custom-format-popover");
+  if (popover.hidden) openCustomSearchFormatCombobox();
+  else closeCustomSearchFormatCombobox(true);
+}
+
+function selectCustomSearchFormat(format) {
+  const select = document.getElementById("component-custom-format");
+  select.value = normalizeCustomSearchFormat(format);
+  select.dispatchEvent(new Event("change", { bubbles: true }));
+  closeCustomSearchFormatCombobox(true);
+}
+
+function moveActiveCustomSearchFormatOption(offset) {
+  const options = visibleCustomSearchFormatOptionElements();
+  if (options.length === 0) return;
+  let currentIndex = options.findIndex(
+      (option) => option.dataset.customSearchFormat === activeCustomSearchFormatOption);
+  if (currentIndex < 0) currentIndex = offset > 0 ? -1 : 0;
+  const nextIndex = (currentIndex + offset + options.length) % options.length;
+  setActiveCustomSearchFormatOption(options[nextIndex].dataset.customSearchFormat, true);
+}
+
+function bindCustomSearchFormatCombobox() {
+  const root = document.getElementById("component-custom-format-combobox");
+  const select = document.getElementById("component-custom-format");
+  const trigger = document.getElementById("component-custom-format-trigger");
+  const filter = document.getElementById("component-custom-format-filter");
+  const options = document.getElementById("component-custom-format-options");
+
+  syncCustomSearchFormatCombobox();
+  customSearchFormatOptionElements().forEach((option) => { option.tabIndex = -1; });
+  trigger.addEventListener("click", toggleCustomSearchFormatCombobox);
+  trigger.addEventListener("keydown", (event) => {
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      openCustomSearchFormatCombobox();
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeCustomSearchFormatCombobox(true);
+    }
+  });
+  select.addEventListener("change", (event) => {
+    activeCustomSearchFormat = normalizeCustomSearchFormat(event.target.value);
+    syncCustomSearchFormatCombobox();
+  });
+  filter.addEventListener("input", filterCustomSearchFormatOptions);
+  filter.addEventListener("keydown", (event) => {
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      moveActiveCustomSearchFormatOption(event.key === "ArrowDown" ? 1 : -1);
+      return;
+    }
+    if (event.key === "Home" || event.key === "End") {
+      event.preventDefault();
+      const visible = visibleCustomSearchFormatOptionElements();
+      const target = event.key === "Home" ? visible[0] : visible.at(-1);
+      setActiveCustomSearchFormatOption(target?.dataset.customSearchFormat || null, true);
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      if (activeCustomSearchFormatOption) {
+        selectCustomSearchFormat(activeCustomSearchFormatOption);
+      }
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeCustomSearchFormatCombobox(true);
+      return;
+    }
+    if (event.key === "Tab") closeCustomSearchFormatCombobox();
+  });
+  options.addEventListener("mousemove", (event) => {
+    const option = event.target.closest("[data-custom-search-format]");
+    if (option) setActiveCustomSearchFormatOption(option.dataset.customSearchFormat);
+  });
+  options.addEventListener("click", (event) => {
+    const option = event.target.closest("[data-custom-search-format]");
+    if (option) selectCustomSearchFormat(option.dataset.customSearchFormat);
+  });
+  document.addEventListener("click", (event) => {
+    if (!root.contains(event.target)) closeCustomSearchFormatCombobox();
+  });
+}
+
 function selectSearchFormat(format, customFormat = activeCustomSearchFormat) {
   activeSearchFormat = normalizeSearchFormat(format);
   activeCustomSearchFormat = normalizeCustomSearchFormat(customFormat);
   document.getElementById("component-search-title").textContent =
     searchPageTitle(activeSearchFormat);
   const customField = document.getElementById("component-custom-format-field");
-  const customSelect = document.getElementById("component-custom-format");
   if (customField) customField.hidden = activeSearchFormat !== CUSTOM_SEARCH_FORMAT;
-  if (customSelect) customSelect.value = activeCustomSearchFormat;
+  syncCustomSearchFormatCombobox();
+  if (activeSearchFormat !== CUSTOM_SEARCH_FORMAT) closeCustomSearchFormatCombobox();
   document.querySelectorAll(".side-subitem").forEach((entry) => {
     entry.classList.toggle("is-active", entry.dataset.searchFormat === activeSearchFormat);
   });
@@ -4337,9 +4518,7 @@ document.querySelectorAll(".side-subitem").forEach((item) => {
 document.getElementById("repository-filter").addEventListener("input", () => {
   if (state.mode === "repos") renderRepoList();
 });
-document.getElementById("component-custom-format").addEventListener("change", (event) => {
-  activeCustomSearchFormat = normalizeCustomSearchFormat(event.target.value);
-});
+bindCustomSearchFormatCombobox();
 document.querySelectorAll("[data-repo-sort]").forEach((button) => {
   button.addEventListener("click", () => toggleRepositorySort(button.dataset.repoSort));
 });

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.js
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.js
@@ -22,6 +22,7 @@ let uploadSpecsCache = new Map();
 let uploadAssetCount = 1;
 let repositorySort = { key: "name", direction: "asc" };
 let activeSearchFormat = "maven2";
+let activeCustomSearchFormat = "maven2";
 let currentSession = null;
 let currentPermissions = [];
 let adminBootstrapStatus = null;
@@ -32,11 +33,14 @@ let latestGeneratedApiToken = "";
 const APP_HASH_PREFIX = "browse";
 const BROWSE_HASH = `${APP_HASH_PREFIX}/browse`;
 const DEFAULT_SEARCH_FORMAT = "maven2";
+const ALL_SEARCH_FORMAT = "all";
+const CUSTOM_SEARCH_FORMAT = "custom";
 const COMPONENT_SEARCH_LIMIT = 20;
 const AUTH_SNAPSHOT_KEY = "nexusPlus.authSnapshot";
 const AUTH_SNAPSHOT_MAX_AGE_MS = 10 * 60 * 1000;
 let pendingLoginReturnTo = readPendingLoginReturnTo();
 const SEARCH_ROUTE_FORMAT = {
+  all: "all",
   custom: "custom",
   cargo: "cargo",
   go: "go",
@@ -58,8 +62,11 @@ const SEARCH_ROUTE_FORMAT = {
   rubygems: "rubygems",
   yum: "yum",
   npm: "npm",
+  docker: "docker",
+  raw: "raw",
 };
 const FORMAT_ROUTE_SEGMENT = {
+  all: "all",
   custom: "custom",
   cargo: "cargo",
   go: "go",
@@ -81,9 +88,12 @@ const FORMAT_ROUTE_SEGMENT = {
   rubygems: "rubygems",
   yum: "yum",
   npm: "npm",
+  docker: "docker",
+  raw: "raw",
 };
 const SEARCH_FORMAT_LABEL = {
-  custom: "All formats",
+  all: "All components",
+  custom: "Custom search",
   cargo: "Cargo",
   go: "Go",
   helm: "Helm",
@@ -104,6 +114,8 @@ const SEARCH_FORMAT_LABEL = {
   rubygems: "RubyGems",
   yum: "Yum",
   npm: "npm",
+  docker: "Docker / OCI",
+  raw: "Raw",
 };
 
 function installCsrfFetch() {
@@ -149,15 +161,36 @@ function normalizeSearchFormat(format) {
   return SEARCH_ROUTE_FORMAT[format] || DEFAULT_SEARCH_FORMAT;
 }
 
+function normalizeCustomSearchFormat(format) {
+  const normalized = SEARCH_ROUTE_FORMAT[format];
+  if (!normalized || normalized === ALL_SEARCH_FORMAT || normalized === CUSTOM_SEARCH_FORMAT) {
+    return DEFAULT_SEARCH_FORMAT;
+  }
+  return normalized;
+}
+
 function searchFormatLabel(format) {
   return SEARCH_FORMAT_LABEL[normalizeSearchFormat(format)];
 }
 
-function searchHash(format, keyword = "") {
+function searchPageTitle(format) {
+  const normalized = normalizeSearchFormat(format);
+  if (normalized === ALL_SEARCH_FORMAT) return "Search all components";
+  if (normalized === CUSTOM_SEARCH_FORMAT) return "Custom search";
+  return `Search ${searchFormatLabel(normalized)}`;
+}
+
+function searchHash(format, keyword = "", customFormat = DEFAULT_SEARCH_FORMAT) {
   const normalized = normalizeSearchFormat(format);
   const base = `#${APP_HASH_PREFIX}/search/${FORMAT_ROUTE_SEGMENT[normalized]}`;
+  const params = new URLSearchParams();
+  if (normalized === CUSTOM_SEARCH_FORMAT) {
+    params.set("format", normalizeCustomSearchFormat(customFormat));
+  }
   const q = String(keyword || "").trim();
-  return q ? `${base}?${new URLSearchParams({ q }).toString()}` : base;
+  if (q) params.set("q", q);
+  const query = params.toString();
+  return query ? `${base}?${query}` : base;
 }
 
 function repositoryBrowseHash(repoName, path = "") {
@@ -237,10 +270,19 @@ function parseBrowseHash() {
     const separator = routeValue.indexOf("?");
     const rawFormat = separator === -1 ? routeValue : routeValue.slice(0, separator);
     const query = separator === -1 ? "" : routeValue.slice(separator + 1);
+    const params = new URLSearchParams(query);
+    let searchFormat = normalizeSearchFormat(rawFormat);
+    // Before Custom search gained a format selector, this route represented all formats.
+    if (searchFormat === CUSTOM_SEARCH_FORMAT && !params.has("format")) {
+      searchFormat = ALL_SEARCH_FORMAT;
+    }
     return {
       view: "search",
-      searchFormat: normalizeSearchFormat(rawFormat),
-      keyword: new URLSearchParams(query).get("q") || "",
+      searchFormat,
+      customSearchFormat: searchFormat === CUSTOM_SEARCH_FORMAT
+        ? normalizeCustomSearchFormat(params.get("format"))
+        : undefined,
+      keyword: params.get("q") || "",
     };
   }
   const prefix = `${BROWSE_HASH}:`;
@@ -701,18 +743,21 @@ async function fetchChildren(repo, path) {
   return data.entries;
 }
 
-function componentSearchParams(format, keyword) {
+function componentSearchParams(format, keyword, customFormat = DEFAULT_SEARCH_FORMAT) {
   const params = new URLSearchParams();
   const q = (keyword || "").trim();
   if (q) params.set("q", q);
   const normalizedFormat = normalizeSearchFormat(format);
-  if (normalizedFormat !== "custom") params.set("format", normalizedFormat);
+  const effectiveFormat = normalizedFormat === CUSTOM_SEARCH_FORMAT
+    ? normalizeCustomSearchFormat(customFormat)
+    : normalizedFormat;
+  if (effectiveFormat !== ALL_SEARCH_FORMAT) params.set("format", effectiveFormat);
   params.set("limit", String(COMPONENT_SEARCH_LIMIT));
   return params;
 }
 
-async function fetchSearchComponents(format, keyword) {
-  const params = componentSearchParams(format, keyword);
+async function fetchSearchComponents(format, keyword, customFormat = DEFAULT_SEARCH_FORMAT) {
+  const params = componentSearchParams(format, keyword, customFormat);
   const res = await fetch(`/internal/search/components?${params.toString()}`, {
     headers: { Accept: "application/json" },
     cache: "no-store",
@@ -1217,18 +1262,28 @@ async function copyGeneratedToken() {
   setTimeout(() => { button.textContent = "Copy"; }, 1200);
 }
 
-function activateSearch(format = DEFAULT_SEARCH_FORMAT, syncHash = true) {
+function activateSearch(
+    format = DEFAULT_SEARCH_FORMAT,
+    syncHash = true,
+    customFormat = activeCustomSearchFormat) {
   const normalized = normalizeSearchFormat(format);
-  if (syncHash) pushBrowseRoute(searchHash(normalized));
+  activeCustomSearchFormat = normalizeCustomSearchFormat(customFormat);
+  if (syncHash) pushBrowseRoute(searchHash(normalized, "", activeCustomSearchFormat));
   setSearchSubnavOpen(true);
   switchView("search");
-  selectSearchFormat(normalized);
+  selectSearchFormat(normalized, activeCustomSearchFormat);
   return normalized;
 }
 
-function showSearch(format = DEFAULT_SEARCH_FORMAT, syncHash = true, keyword = null) {
+function showSearch(
+    format = DEFAULT_SEARCH_FORMAT,
+    syncHash = true,
+    keyword = null,
+    customFormat = activeCustomSearchFormat) {
   if (keyword !== null) document.getElementById("component-keyword").value = keyword;
-  renderSearch(activateSearch(format, syncHash));
+  renderSearch(
+      activateSearch(format, syncHash, customFormat),
+      activeCustomSearchFormat);
 }
 
 function openSearchResult(component) {
@@ -4036,10 +4091,14 @@ async function uploadError(response) {
   }
 }
 
-async function renderSearch(format = DEFAULT_SEARCH_FORMAT) {
+async function renderSearch(
+    format = DEFAULT_SEARCH_FORMAT,
+    customFormat = activeCustomSearchFormat) {
   const seq = ++searchRequestSeq;
+  const normalizedFormat = normalizeSearchFormat(format);
+  activeCustomSearchFormat = normalizeCustomSearchFormat(customFormat);
   const keyword = document.getElementById("component-keyword").value.trim().toLowerCase();
-  const target = `/browse/${searchHash(format, keyword)}`;
+  const target = `/browse/${searchHash(normalizedFormat, keyword, activeCustomSearchFormat)}`;
   const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
   if (current !== target) window.history.replaceState(null, "", target);
   window.kkrepoGlobalComponentSearch?.setKeyword(document, keyword);
@@ -4047,7 +4106,10 @@ async function renderSearch(format = DEFAULT_SEARCH_FORMAT) {
     '<tr><td colspan="7" class="muted-row">Searching...</td></tr>';
   let payload;
   try {
-    payload = await fetchSearchComponents(format, keyword);
+    payload = await fetchSearchComponents(
+        normalizedFormat,
+        keyword,
+        activeCustomSearchFormat);
   } catch (error) {
     if (seq !== searchRequestSeq) return;
     document.getElementById("component-total").textContent = "0";
@@ -4126,10 +4188,15 @@ function clearSearchFormatSelection() {
   });
 }
 
-function selectSearchFormat(format) {
+function selectSearchFormat(format, customFormat = activeCustomSearchFormat) {
   activeSearchFormat = normalizeSearchFormat(format);
-  document.getElementById("component-search-format").textContent =
-    searchFormatLabel(activeSearchFormat);
+  activeCustomSearchFormat = normalizeCustomSearchFormat(customFormat);
+  document.getElementById("component-search-title").textContent =
+    searchPageTitle(activeSearchFormat);
+  const customField = document.getElementById("component-custom-format-field");
+  const customSelect = document.getElementById("component-custom-format");
+  if (customField) customField.hidden = activeSearchFormat !== CUSTOM_SEARCH_FORMAT;
+  if (customSelect) customSelect.value = activeCustomSearchFormat;
   document.querySelectorAll(".side-subitem").forEach((entry) => {
     entry.classList.toggle("is-active", entry.dataset.searchFormat === activeSearchFormat);
   });
@@ -4154,7 +4221,7 @@ function applyHashRoute() {
     return true;
   }
   if (route.view === "search") {
-    showSearch(route.searchFormat, false, route.keyword);
+    showSearch(route.searchFormat, false, route.keyword, route.customSearchFormat);
     return true;
   }
   switchView("browse");
@@ -4270,6 +4337,9 @@ document.querySelectorAll(".side-subitem").forEach((item) => {
 document.getElementById("repository-filter").addEventListener("input", () => {
   if (state.mode === "repos") renderRepoList();
 });
+document.getElementById("component-custom-format").addEventListener("change", (event) => {
+  activeCustomSearchFormat = normalizeCustomSearchFormat(event.target.value);
+});
 document.querySelectorAll("[data-repo-sort]").forEach((button) => {
   button.addEventListener("click", () => toggleRepositorySort(button.dataset.repoSort));
 });
@@ -4282,7 +4352,7 @@ document.getElementById("upload-fields").addEventListener("input", updateUploadP
 document.getElementById("upload-fields").addEventListener("change", updateUploadPath);
 document.getElementById("component-search-form").addEventListener("submit", (event) => {
   event.preventDefault();
-  renderSearch(activeSearchFormat);
+  renderSearch(activeSearchFormat, activeCustomSearchFormat);
 });
 document.getElementById("upload-form").addEventListener("submit", uploadSelectedAsset);
 document.getElementById("my-token-form").addEventListener("submit", createCurrentApiKey);

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/global-component-search.js
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/global-component-search.js
@@ -4,7 +4,7 @@
   root.kkrepoGlobalComponentSearch = api;
   if (root.document && root.location) api.bind(root.document, root.location);
 }(typeof globalThis !== "undefined" ? globalThis : this, function () {
-  const SEARCH_ROUTE = "/browse/#browse/search/custom";
+  const SEARCH_ROUTE = "/browse/#browse/search/all";
 
   function normalizeKeyword(value) {
     return String(value || "").trim();

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/ui-scrollbars.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/ui-scrollbars.css
@@ -2,15 +2,15 @@
 
 :root {
   --ui-scrollbar-size: 6px;
-  --ui-scrollbar-thumb: rgba(36, 50, 46, 0.54);
-  --ui-scrollbar-thumb-hover: rgba(36, 50, 46, 0.7);
+  --ui-scrollbar-thumb: rgba(18, 33, 29, 0.5);
+  --ui-scrollbar-thumb-hover: rgba(18, 33, 29, 0.6);
 }
 
 @supports (color: color-mix(in srgb, black, transparent)) {
   :root {
     /* Stays translucent while retaining at least 3:1 contrast in bundled themes. */
-    --ui-scrollbar-thumb: color-mix(in srgb, var(--ink-2) 54%, transparent);
-    --ui-scrollbar-thumb-hover: color-mix(in srgb, var(--ink-2) 70%, transparent);
+    --ui-scrollbar-thumb: color-mix(in srgb, var(--ink-1) 50%, transparent);
+    --ui-scrollbar-thumb-hover: color-mix(in srgb, var(--ink-1) 60%, transparent);
   }
 }
 

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/ui-scrollbars.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/ui-scrollbars.css
@@ -2,13 +2,9 @@
 
 :root {
   --ui-scrollbar-size: 6px;
-  --ui-scrollbar-thumb: color-mix(in srgb, var(--ink-3) 24%, transparent);
-  --ui-scrollbar-thumb-hover: color-mix(in srgb, var(--ink-3) 42%, transparent);
-}
-
-* {
-  scrollbar-color: var(--ui-scrollbar-thumb) transparent;
-  scrollbar-width: thin;
+  /* Stays translucent while retaining at least 3:1 contrast in bundled themes. */
+  --ui-scrollbar-thumb: color-mix(in srgb, var(--ink-2) 54%, transparent);
+  --ui-scrollbar-thumb-hover: color-mix(in srgb, var(--ink-2) 70%, transparent);
 }
 
 *::-webkit-scrollbar {
@@ -30,4 +26,12 @@
 
 *::-webkit-scrollbar-thumb:hover {
   background-color: var(--ui-scrollbar-thumb-hover);
+}
+
+/* Chromium/Safari let the standard properties override the WebKit treatment. */
+@supports not selector(::-webkit-scrollbar) {
+  * {
+    scrollbar-color: var(--ui-scrollbar-thumb) transparent;
+    scrollbar-width: thin;
+  }
 }

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/ui-scrollbars.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/ui-scrollbars.css
@@ -1,0 +1,33 @@
+/* Shared scrollbar treatment for every kkRepo UI scroll container. */
+
+:root {
+  --ui-scrollbar-size: 6px;
+  --ui-scrollbar-thumb: color-mix(in srgb, var(--ink-3) 24%, transparent);
+  --ui-scrollbar-thumb-hover: color-mix(in srgb, var(--ink-3) 42%, transparent);
+}
+
+* {
+  scrollbar-color: var(--ui-scrollbar-thumb) transparent;
+  scrollbar-width: thin;
+}
+
+*::-webkit-scrollbar {
+  width: var(--ui-scrollbar-size);
+  height: var(--ui-scrollbar-size);
+}
+
+*::-webkit-scrollbar-track,
+*::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  border: 1px solid transparent;
+  border-radius: var(--r-pill, 999px);
+  background-color: var(--ui-scrollbar-thumb);
+  background-clip: padding-box;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background-color: var(--ui-scrollbar-thumb-hover);
+}

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/ui-scrollbars.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/ui-scrollbars.css
@@ -2,9 +2,16 @@
 
 :root {
   --ui-scrollbar-size: 6px;
-  /* Stays translucent while retaining at least 3:1 contrast in bundled themes. */
-  --ui-scrollbar-thumb: color-mix(in srgb, var(--ink-2) 54%, transparent);
-  --ui-scrollbar-thumb-hover: color-mix(in srgb, var(--ink-2) 70%, transparent);
+  --ui-scrollbar-thumb: rgba(36, 50, 46, 0.54);
+  --ui-scrollbar-thumb-hover: rgba(36, 50, 46, 0.7);
+}
+
+@supports (color: color-mix(in srgb, black, transparent)) {
+  :root {
+    /* Stays translucent while retaining at least 3:1 contrast in bundled themes. */
+    --ui-scrollbar-thumb: color-mix(in srgb, var(--ink-2) 54%, transparent);
+    --ui-scrollbar-thumb-hover: color-mix(in srgb, var(--ink-2) 70%, transparent);
+  }
 }
 
 *::-webkit-scrollbar {

--- a/browse-ui/src/main/resources/META-INF/resources/browse/index.html
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/index.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-4">
     <link rel="stylesheet" href="/browse/assets/format-icons.css?v=20260811-conan-1">
     <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260818-user-round-1">
-    <link rel="stylesheet" href="/browse/assets/browse.css?v=20260826-tree-scroll-1">
+    <link rel="stylesheet" href="/browse/assets/browse.css?v=20260826-search-menu-1">
     <link rel="stylesheet" href="/browse/assets/account-menu.css?v=20260824-ui-themes-3">
     <link rel="stylesheet" href="/browse/assets/global-component-search.css?v=20260819-topbar-control-height-1">
     <link rel="stylesheet" href="/login/assets/login-modal.css?v=20260818-login-icons-1">
@@ -89,27 +89,16 @@
             <span class="side-caret lucide-icon icon-chevron-down" aria-hidden="true"></span>
           </button>
           <div class="search-subnav" id="search-subnav" hidden>
-            <button class="side-subitem" data-search-format="custom" type="button"><span class="search-all-icon lucide-icon icon-package-search" aria-hidden="true"></span><span>All formats</span></button>
-            <button class="side-subitem" data-search-format="cargo" type="button"><span class="format-logo format-logo-cargo" aria-hidden="true"></span><span>Cargo</span></button>
+            <button class="side-subitem" data-search-format="all" type="button"><span class="search-all-icon lucide-icon icon-package-search" aria-hidden="true"></span><span>All components</span></button>
+            <button class="side-subitem" data-search-format="custom" type="button"><span class="search-all-icon lucide-icon icon-list-filter" aria-hidden="true"></span><span>Custom search</span></button>
+            <button class="side-subitem" data-search-format="maven2" type="button"><span class="format-logo format-logo-maven" aria-hidden="true"></span><span>Maven</span></button>
+            <button class="side-subitem" data-search-format="npm" type="button"><span class="format-logo format-logo-npm" aria-hidden="true"></span><span>npm</span></button>
+            <button class="side-subitem" data-search-format="pypi" type="button"><span class="format-logo format-logo-pypi" aria-hidden="true"></span><span>PyPI</span></button>
+            <button class="side-subitem" data-search-format="docker" type="button"><span class="format-logo format-logo-docker" aria-hidden="true"></span><span>Docker / OCI</span></button>
+            <button class="side-subitem" data-search-format="nuget" type="button"><span class="format-logo format-logo-nuget" aria-hidden="true"></span><span>NuGet</span></button>
             <button class="side-subitem" data-search-format="go" type="button"><span class="format-logo format-logo-go" aria-hidden="true"></span><span>Go</span></button>
             <button class="side-subitem" data-search-format="helm" type="button"><span class="format-logo format-logo-helm" aria-hidden="true"></span><span>Helm</span></button>
-            <button class="side-subitem" data-search-format="maven2" type="button"><span class="format-logo format-logo-maven" aria-hidden="true"></span><span>Maven</span></button>
-            <button class="side-subitem" data-search-format="nuget" type="button"><span class="format-logo format-logo-nuget" aria-hidden="true"></span><span>NuGet</span></button>
-            <button class="side-subitem" data-search-format="pub" type="button"><span class="format-logo format-logo-pub" aria-hidden="true"></span><span>Pub</span></button>
-            <button class="side-subitem" data-search-format="composer" type="button"><span class="format-logo format-logo-composer" aria-hidden="true"></span><span>Composer</span></button>
-            <button class="side-subitem" data-search-format="terraform" type="button"><span class="format-logo format-logo-terraform" aria-hidden="true"></span><span>Terraform</span></button>
-            <button class="side-subitem" data-search-format="swift" type="button"><span class="format-logo format-logo-swift" aria-hidden="true"></span><span>Swift</span></button>
-            <button class="side-subitem" data-search-format="ansiblegalaxy" type="button"><span class="format-logo format-logo-ansiblegalaxy" aria-hidden="true"></span><span>Ansible Galaxy</span></button>
-            <button class="side-subitem" data-search-format="conda" type="button"><span class="format-logo format-logo-conda" aria-hidden="true"></span><span>Conda</span></button>
-            <button class="side-subitem" data-search-format="conan" type="button"><span class="format-logo format-logo-conan" aria-hidden="true"></span><span>Conan 2</span></button>
-            <button class="side-subitem" data-search-format="apt" type="button"><span class="format-logo format-logo-apt" aria-hidden="true"></span><span>APT / Debian</span></button>
-            <button class="side-subitem" data-search-format="alpine" type="button"><span class="format-logo format-logo-alpine" aria-hidden="true"></span><span>Alpine / APK</span></button>
-            <button class="side-subitem" data-search-format="r" type="button"><span class="format-logo format-logo-r" aria-hidden="true"></span><span>R / CRAN</span></button>
-            <button class="side-subitem" data-search-format="huggingface" type="button"><span class="format-logo format-logo-huggingface" aria-hidden="true"></span><span>Hugging Face Models</span></button>
-            <button class="side-subitem" data-search-format="pypi" type="button"><span class="format-logo format-logo-pypi" aria-hidden="true"></span><span>PyPI</span></button>
-            <button class="side-subitem" data-search-format="rubygems" type="button"><span class="format-logo format-logo-rubygems" aria-hidden="true"></span><span>RubyGems</span></button>
-            <button class="side-subitem" data-search-format="yum" type="button"><span class="format-logo format-logo-yum" aria-hidden="true"></span><span>Yum</span></button>
-            <button class="side-subitem" data-search-format="npm" type="button"><span class="format-logo format-logo-npm" aria-hidden="true"></span><span>npm</span></button>
+            <button class="side-subitem" data-search-format="cargo" type="button"><span class="format-logo format-logo-cargo" aria-hidden="true"></span><span>Cargo</span></button>
           </div>
           <button class="side-item" data-view="browse" type="button">
             <span class="side-icon lucide-icon icon-library" aria-hidden="true"></span>
@@ -372,10 +361,37 @@
         <section class="view" id="search-view">
           <div class="page-heading">
             <span class="heading-icon"><span class="lucide-icon icon-search" aria-hidden="true"></span></span>
-            <h1><span>Search</span> <span id="component-search-format">Maven</span></h1>
+            <h1 id="component-search-title">Search Maven</h1>
             <span class="heading-copy">Search for components by attribute</span>
           </div>
           <form class="search-form" id="component-search-form">
+            <label class="search-format-field" id="component-custom-format-field" hidden>
+              <span>Format</span>
+              <select id="component-custom-format">
+                <option value="maven2">Maven</option>
+                <option value="npm">npm</option>
+                <option value="pypi">PyPI</option>
+                <option value="cargo">Cargo</option>
+                <option value="pub">Pub</option>
+                <option value="composer">Composer</option>
+                <option value="go">Go</option>
+                <option value="helm">Helm</option>
+                <option value="docker">Docker / OCI</option>
+                <option value="nuget">NuGet</option>
+                <option value="rubygems">RubyGems</option>
+                <option value="yum">Yum</option>
+                <option value="terraform">Terraform</option>
+                <option value="swift">Swift</option>
+                <option value="ansiblegalaxy">Ansible Galaxy</option>
+                <option value="conda">Conda</option>
+                <option value="conan">Conan 2</option>
+                <option value="apt">APT / Debian</option>
+                <option value="alpine">Alpine / APK</option>
+                <option value="r">R / CRAN</option>
+                <option value="huggingface">Hugging Face Models</option>
+                <option value="raw">Raw</option>
+              </select>
+            </label>
             <label>
               <span>Keyword</span>
               <input id="component-keyword" type="search" placeholder="Any">
@@ -486,7 +502,7 @@
     <script src="/login/assets/ui-i18n.js?v=20260824-ui-themes-2"></script>
     <script src="/login/assets/product-update.js?v=20260819-version-update-1"></script>
     <script src="/login/assets/login-modal.js?v=20260818-login-icons-3"></script>
-    <script src="/browse/assets/global-component-search.js?v=20260817-global-search-2"></script>
-    <script src="/browse/assets/browse.js?v=20260826-tree-scroll-1"></script>
+    <script src="/browse/assets/global-component-search.js?v=20260826-search-menu-1"></script>
+    <script src="/browse/assets/browse.js?v=20260826-search-menu-1"></script>
   </body>
 </html>

--- a/browse-ui/src/main/resources/META-INF/resources/browse/index.html
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/index.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-4">
     <link rel="stylesheet" href="/browse/assets/format-icons.css?v=20260811-conan-1">
     <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260818-user-round-1">
-    <link rel="stylesheet" href="/browse/assets/browse.css?v=20260826-search-menu-3">
+    <link rel="stylesheet" href="/browse/assets/browse.css?v=20260826-search-menu-4">
     <link rel="stylesheet" href="/browse/assets/account-menu.css?v=20260824-ui-themes-3">
     <link rel="stylesheet" href="/browse/assets/global-component-search.css?v=20260819-topbar-control-height-1">
     <link rel="stylesheet" href="/login/assets/login-modal.css?v=20260818-login-icons-1">

--- a/browse-ui/src/main/resources/META-INF/resources/browse/index.html
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/index.html
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="/browse/assets/favicon.svg?v=20260609-kl-logo-1">
     <link id="kkrepo-theme-stylesheet" rel="stylesheet" href="/browse/assets/themes/default.css?v=20260824-ui-themes-3">
     <script src="/login/assets/ui-theme.js?v=20260824-ui-themes-3"></script>
+    <link rel="stylesheet" href="/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-1">
     <link rel="stylesheet" href="/browse/assets/format-icons.css?v=20260811-conan-1">
     <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260818-user-round-1">
     <link rel="stylesheet" href="/browse/assets/browse.css?v=20260826-tree-scroll-1">

--- a/browse-ui/src/main/resources/META-INF/resources/browse/index.html
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/index.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-4">
     <link rel="stylesheet" href="/browse/assets/format-icons.css?v=20260811-conan-1">
     <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260818-user-round-1">
-    <link rel="stylesheet" href="/browse/assets/browse.css?v=20260826-search-menu-1">
+    <link rel="stylesheet" href="/browse/assets/browse.css?v=20260826-search-menu-3">
     <link rel="stylesheet" href="/browse/assets/account-menu.css?v=20260824-ui-themes-3">
     <link rel="stylesheet" href="/browse/assets/global-component-search.css?v=20260819-topbar-control-height-1">
     <link rel="stylesheet" href="/login/assets/login-modal.css?v=20260818-login-icons-1">
@@ -365,9 +365,10 @@
             <span class="heading-copy">Search for components by attribute</span>
           </div>
           <form class="search-form" id="component-search-form">
-            <label class="search-format-field" id="component-custom-format-field" hidden>
-              <span>Format</span>
-              <select id="component-custom-format">
+            <div class="search-format-field" id="component-custom-format-field" hidden>
+              <span id="component-custom-format-label">Format</span>
+              <div class="search-format-combobox" id="component-custom-format-combobox">
+                <select id="component-custom-format" hidden aria-hidden="true" tabindex="-1">
                 <option value="maven2">Maven</option>
                 <option value="npm">npm</option>
                 <option value="pypi">PyPI</option>
@@ -390,8 +391,65 @@
                 <option value="r">R / CRAN</option>
                 <option value="huggingface">Hugging Face Models</option>
                 <option value="raw">Raw</option>
-              </select>
-            </label>
+                </select>
+                <button
+                    class="search-format-trigger"
+                    id="component-custom-format-trigger"
+                    type="button"
+                    aria-haspopup="listbox"
+                    aria-expanded="false"
+                    aria-controls="component-custom-format-options"
+                    aria-labelledby="component-custom-format-label component-custom-format-value">
+                  <span class="search-format-value" id="component-custom-format-value">
+                    <span class="format-logo format-logo-maven" aria-hidden="true"></span>
+                    <span>Maven</span>
+                  </span>
+                  <span class="search-format-caret lucide-icon icon-chevron-down" aria-hidden="true"></span>
+                </button>
+                <div class="search-format-popover" id="component-custom-format-popover" hidden>
+                  <input
+                      class="search-format-filter"
+                      id="component-custom-format-filter"
+                      type="search"
+                      placeholder="Filter formats"
+                      role="combobox"
+                      aria-autocomplete="list"
+                      aria-controls="component-custom-format-options"
+                      aria-expanded="false"
+                      aria-label="Filter repository formats"
+                      autocomplete="off">
+                  <div
+                      class="search-format-options"
+                      id="component-custom-format-options"
+                      role="listbox"
+                      aria-labelledby="component-custom-format-label">
+                    <button class="search-format-option" id="component-custom-format-option-maven2" type="button" role="option" aria-selected="true" data-custom-search-format="maven2"><span class="format-logo format-logo-maven" aria-hidden="true"></span><span>Maven</span></button>
+                    <button class="search-format-option" id="component-custom-format-option-npm" type="button" role="option" aria-selected="false" data-custom-search-format="npm"><span class="format-logo format-logo-npm" aria-hidden="true"></span><span>npm</span></button>
+                    <button class="search-format-option" id="component-custom-format-option-pypi" type="button" role="option" aria-selected="false" data-custom-search-format="pypi"><span class="format-logo format-logo-pypi" aria-hidden="true"></span><span>PyPI</span></button>
+                    <button class="search-format-option" id="component-custom-format-option-cargo" type="button" role="option" aria-selected="false" data-custom-search-format="cargo"><span class="format-logo format-logo-cargo" aria-hidden="true"></span><span>Cargo</span></button>
+                    <button class="search-format-option" id="component-custom-format-option-pub" type="button" role="option" aria-selected="false" data-custom-search-format="pub"><span class="format-logo format-logo-pub" aria-hidden="true"></span><span>Pub</span></button>
+                    <button class="search-format-option" id="component-custom-format-option-composer" type="button" role="option" aria-selected="false" data-custom-search-format="composer"><span class="format-logo format-logo-composer" aria-hidden="true"></span><span>Composer</span></button>
+                    <button class="search-format-option" id="component-custom-format-option-go" type="button" role="option" aria-selected="false" data-custom-search-format="go"><span class="format-logo format-logo-go" aria-hidden="true"></span><span>Go</span></button>
+                    <button class="search-format-option" id="component-custom-format-option-helm" type="button" role="option" aria-selected="false" data-custom-search-format="helm"><span class="format-logo format-logo-helm" aria-hidden="true"></span><span>Helm</span></button>
+                    <button class="search-format-option" id="component-custom-format-option-docker" type="button" role="option" aria-selected="false" data-custom-search-format="docker"><span class="format-logo format-logo-docker" aria-hidden="true"></span><span>Docker / OCI</span></button>
+                    <button class="search-format-option" id="component-custom-format-option-nuget" type="button" role="option" aria-selected="false" data-custom-search-format="nuget"><span class="format-logo format-logo-nuget" aria-hidden="true"></span><span>NuGet</span></button>
+                    <button class="search-format-option" id="component-custom-format-option-rubygems" type="button" role="option" aria-selected="false" data-custom-search-format="rubygems"><span class="format-logo format-logo-rubygems" aria-hidden="true"></span><span>RubyGems</span></button>
+                    <button class="search-format-option" id="component-custom-format-option-yum" type="button" role="option" aria-selected="false" data-custom-search-format="yum"><span class="format-logo format-logo-yum" aria-hidden="true"></span><span>Yum</span></button>
+                    <button class="search-format-option" id="component-custom-format-option-terraform" type="button" role="option" aria-selected="false" data-custom-search-format="terraform"><span class="format-logo format-logo-terraform" aria-hidden="true"></span><span>Terraform</span></button>
+                    <button class="search-format-option" id="component-custom-format-option-swift" type="button" role="option" aria-selected="false" data-custom-search-format="swift"><span class="format-logo format-logo-swift" aria-hidden="true"></span><span>Swift</span></button>
+                    <button class="search-format-option" id="component-custom-format-option-ansiblegalaxy" type="button" role="option" aria-selected="false" data-custom-search-format="ansiblegalaxy"><span class="format-logo format-logo-ansiblegalaxy" aria-hidden="true"></span><span>Ansible Galaxy</span></button>
+                    <button class="search-format-option" id="component-custom-format-option-conda" type="button" role="option" aria-selected="false" data-custom-search-format="conda"><span class="format-logo format-logo-conda" aria-hidden="true"></span><span>Conda</span></button>
+                    <button class="search-format-option" id="component-custom-format-option-conan" type="button" role="option" aria-selected="false" data-custom-search-format="conan"><span class="format-logo format-logo-conan" aria-hidden="true"></span><span>Conan 2</span></button>
+                    <button class="search-format-option" id="component-custom-format-option-apt" type="button" role="option" aria-selected="false" data-custom-search-format="apt"><span class="format-logo format-logo-apt" aria-hidden="true"></span><span>APT / Debian</span></button>
+                    <button class="search-format-option" id="component-custom-format-option-alpine" type="button" role="option" aria-selected="false" data-custom-search-format="alpine"><span class="format-logo format-logo-alpine" aria-hidden="true"></span><span>Alpine / APK</span></button>
+                    <button class="search-format-option" id="component-custom-format-option-r" type="button" role="option" aria-selected="false" data-custom-search-format="r"><span class="format-logo format-logo-r" aria-hidden="true"></span><span>R / CRAN</span></button>
+                    <button class="search-format-option" id="component-custom-format-option-huggingface" type="button" role="option" aria-selected="false" data-custom-search-format="huggingface"><span class="format-logo format-logo-huggingface" aria-hidden="true"></span><span>Hugging Face Models</span></button>
+                    <button class="search-format-option" id="component-custom-format-option-raw" type="button" role="option" aria-selected="false" data-custom-search-format="raw"><span class="format-logo format-logo-raw" aria-hidden="true"></span><span>Raw</span></button>
+                  </div>
+                  <div class="search-format-empty" id="component-custom-format-empty" role="status" hidden>No matching formats</div>
+                </div>
+              </div>
+            </div>
             <label>
               <span>Keyword</span>
               <input id="component-keyword" type="search" placeholder="Any">
@@ -502,7 +560,7 @@
     <script src="/login/assets/ui-i18n.js?v=20260824-ui-themes-2"></script>
     <script src="/login/assets/product-update.js?v=20260819-version-update-1"></script>
     <script src="/login/assets/login-modal.js?v=20260818-login-icons-3"></script>
-    <script src="/browse/assets/global-component-search.js?v=20260826-search-menu-1"></script>
-    <script src="/browse/assets/browse.js?v=20260826-search-menu-1"></script>
+    <script src="/browse/assets/global-component-search.js?v=20260826-search-menu-3"></script>
+    <script src="/browse/assets/browse.js?v=20260826-search-menu-3"></script>
   </body>
 </html>

--- a/browse-ui/src/main/resources/META-INF/resources/browse/index.html
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="/browse/assets/favicon.svg?v=20260609-kl-logo-1">
     <link id="kkrepo-theme-stylesheet" rel="stylesheet" href="/browse/assets/themes/default.css?v=20260824-ui-themes-3">
     <script src="/login/assets/ui-theme.js?v=20260824-ui-themes-3"></script>
-  <link rel="stylesheet" href="/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-3">
+  <link rel="stylesheet" href="/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-4">
     <link rel="stylesheet" href="/browse/assets/format-icons.css?v=20260811-conan-1">
     <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260818-user-round-1">
     <link rel="stylesheet" href="/browse/assets/browse.css?v=20260826-tree-scroll-1">

--- a/browse-ui/src/main/resources/META-INF/resources/browse/index.html
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="/browse/assets/favicon.svg?v=20260609-kl-logo-1">
     <link id="kkrepo-theme-stylesheet" rel="stylesheet" href="/browse/assets/themes/default.css?v=20260824-ui-themes-3">
     <script src="/login/assets/ui-theme.js?v=20260824-ui-themes-3"></script>
-    <link rel="stylesheet" href="/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-1">
+  <link rel="stylesheet" href="/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-2">
     <link rel="stylesheet" href="/browse/assets/format-icons.css?v=20260811-conan-1">
     <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260818-user-round-1">
     <link rel="stylesheet" href="/browse/assets/browse.css?v=20260826-tree-scroll-1">

--- a/browse-ui/src/main/resources/META-INF/resources/browse/index.html
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="/browse/assets/favicon.svg?v=20260609-kl-logo-1">
     <link id="kkrepo-theme-stylesheet" rel="stylesheet" href="/browse/assets/themes/default.css?v=20260824-ui-themes-3">
     <script src="/login/assets/ui-theme.js?v=20260824-ui-themes-3"></script>
-  <link rel="stylesheet" href="/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-2">
+  <link rel="stylesheet" href="/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-3">
     <link rel="stylesheet" href="/browse/assets/format-icons.css?v=20260811-conan-1">
     <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260818-user-round-1">
     <link rel="stylesheet" href="/browse/assets/browse.css?v=20260826-tree-scroll-1">

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseAlpineRepositoryContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseAlpineRepositoryContractTest.java
@@ -17,7 +17,7 @@ class BrowseAlpineRepositoryContractTest {
     String stylesheet = resource("/META-INF/resources/browse/assets/format-icons.css");
     String browseStylesheet = resource("/META-INF/resources/browse/assets/browse.css");
 
-    assertTrue(index.contains("data-search-format=\"alpine\""));
+    assertTrue(index.contains("<option value=\"alpine\">Alpine / APK</option>"));
     assertTrue(index.contains("data-format=\"alpine\""));
     assertTrue(index.contains("Alpine / APK"));
     assertTrue(javascript.contains("function alpineUsageDetail"));

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseAnsibleGalaxyContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseAnsibleGalaxyContractTest.java
@@ -15,7 +15,7 @@ class BrowseAnsibleGalaxyContractTest {
     String index = resource("/META-INF/resources/browse/index.html");
     String javascript = resource("/META-INF/resources/browse/assets/browse.js");
 
-    assertTrue(index.contains("data-search-format=\"ansiblegalaxy\""));
+    assertTrue(index.contains("<option value=\"ansiblegalaxy\">Ansible Galaxy</option>"));
     assertTrue(index.contains("data-format=\"ansiblegalaxy\""));
     assertTrue(javascript.contains("function ansibleGalaxyUsageDetail"));
     assertTrue(javascript.contains("renderAttributeGroup(\"Ansible Galaxy\", detail.ansible)"));

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseAptRepositoryContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseAptRepositoryContractTest.java
@@ -17,7 +17,7 @@ class BrowseAptRepositoryContractTest {
     String javascript = resource("/META-INF/resources/browse/assets/browse.js");
     String stylesheet = resource("/META-INF/resources/browse/assets/format-icons.css");
 
-    assertTrue(index.contains("data-search-format=\"apt\""));
+    assertTrue(index.contains("<option value=\"apt\">APT / Debian</option>"));
     assertTrue(index.contains("data-format=\"apt\""));
     assertTrue(index.contains("APT / Debian"));
     assertTrue(javascript.contains("function aptUsageDetail"));

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseConanRepositoryContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseConanRepositoryContractTest.java
@@ -16,7 +16,7 @@ class BrowseConanRepositoryContractTest {
     String javascript = resource("/META-INF/resources/browse/assets/browse.js");
     String stylesheet = resource("/META-INF/resources/browse/assets/format-icons.css");
 
-    assertTrue(index.contains("data-search-format=\"conan\""));
+    assertTrue(index.contains("<option value=\"conan\">Conan 2</option>"));
     assertTrue(index.contains("data-format=\"conan\""));
     assertTrue(javascript.contains("function conanUsageDetail"));
     assertTrue(javascript.contains("conan remote add"));

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseCondaContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseCondaContractTest.java
@@ -17,7 +17,7 @@ class BrowseCondaContractTest {
     String javascript = resource("/META-INF/resources/browse/assets/browse.js");
     String stylesheet = resource("/META-INF/resources/browse/assets/format-icons.css");
 
-    assertTrue(index.contains("data-search-format=\"conda\""));
+    assertTrue(index.contains("<option value=\"conda\">Conda</option>"));
     assertTrue(index.contains("data-format=\"conda\""));
     assertTrue(javascript.contains("renderAttributeGroup(\"Conda\", detail.conda)"));
     assertTrue(javascript.contains("function condaUsageDetail(entry, detail = null)"));

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseGlobalComponentSearchContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseGlobalComponentSearchContractTest.java
@@ -70,7 +70,7 @@ class BrowseGlobalComponentSearchContractTest {
     assertTrue(javascript.contains("moveActiveCustomSearchFormatOption"));
 
     assertTrue(browseStylesheet.contains(".search-format-popover"));
-    assertTrue(browseStylesheet.contains(".search-format-filter"));
+    assertTrue(browseStylesheet.contains(".search-form .search-format-filter"));
     assertTrue(browseStylesheet.contains("top: calc(100% + 6px);"));
     assertTrue(browseStylesheet.contains(".search-format-option .format-logo"));
 

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseGlobalComponentSearchContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseGlobalComponentSearchContractTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 class BrowseGlobalComponentSearchContractTest {
 
   @Test
-  void browseExposesGlobalAndAllFormatSearch() throws IOException {
+  void browseExposesGlobalAllAndCustomFormatSearch() throws IOException {
     String index = resource("/META-INF/resources/browse/index.html");
     String javascript = resource("/META-INF/resources/browse/assets/browse.js");
     String sharedJavascript =
@@ -28,22 +28,31 @@ class BrowseGlobalComponentSearchContractTest {
         < index.indexOf("<form class=\"global-component-search\""));
     assertTrue(index.contains("placeholder=\"Search components\""));
     assertFalse(index.contains("<button type=\"submit\">Search</button>"));
+    assertTrue(index.contains("data-search-format=\"all\""));
+    assertTrue(index.contains("<span>All components</span>"));
     assertTrue(index.contains("data-search-format=\"custom\""));
-    assertTrue(index.contains("<span>All formats</span>"));
+    assertTrue(index.contains("<span>Custom search</span>"));
+    assertEquals(10L, index.lines()
+        .filter(line -> line.contains("class=\"side-subitem\""))
+        .count());
     assertTrue(index.contains("<form class=\"search-form\" id=\"component-search-form\">"));
-    assertTrue(index.contains("<span id=\"component-search-format\">Maven</span>"));
+    assertTrue(index.contains("<select id=\"component-custom-format\">"));
+    assertTrue(index.contains("<h1 id=\"component-search-title\">Search Maven</h1>"));
     assertTrue(index.contains(
         "/browse/assets/global-component-search.css?v=20260819-topbar-control-height-1"));
     assertTrue(index.contains("/browse/assets/global-component-search.js"));
 
+    assertTrue(javascript.contains("all: \"all\""));
     assertTrue(javascript.contains("custom: \"custom\""));
-    assertTrue(javascript.contains("if (normalizedFormat !== \"custom\")"));
-    assertTrue(javascript.contains("keyword: new URLSearchParams(query).get(\"q\") || \"\""));
-    assertTrue(javascript.contains("showSearch(route.searchFormat, false, route.keyword)"));
+    assertTrue(javascript.contains("effectiveFormat !== ALL_SEARCH_FORMAT"));
+    assertTrue(javascript.contains("normalizeCustomSearchFormat(customFormat)"));
+    assertTrue(javascript.contains("keyword: params.get(\"q\") || \"\""));
+    assertTrue(javascript.contains(
+        "showSearch(route.searchFormat, false, route.keyword, route.customSearchFormat)"));
     assertTrue(javascript.contains("document.getElementById(\"component-search-form\")"));
-    assertTrue(javascript.contains("searchFormatLabel(activeSearchFormat)"));
+    assertTrue(javascript.contains("searchPageTitle(activeSearchFormat)"));
 
-    assertTrue(sharedJavascript.contains("/browse/#browse/search/custom"));
+    assertTrue(sharedJavascript.contains("/browse/#browse/search/all"));
     assertTrue(sharedJavascript.contains("locationRef.assign(destination)"));
     assertTrue(sharedStylesheet.contains(".global-component-search input:focus-visible"));
     assertFalse(sharedStylesheet.contains("height: 34px;"));

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseGlobalComponentSearchContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseGlobalComponentSearchContractTest.java
@@ -16,6 +16,7 @@ class BrowseGlobalComponentSearchContractTest {
   void browseExposesGlobalAllAndCustomFormatSearch() throws IOException {
     String index = resource("/META-INF/resources/browse/index.html");
     String javascript = resource("/META-INF/resources/browse/assets/browse.js");
+    String browseStylesheet = resource("/META-INF/resources/browse/assets/browse.css");
     String sharedJavascript =
         resource("/META-INF/resources/browse/assets/global-component-search.js");
     String sharedStylesheet =
@@ -36,7 +37,20 @@ class BrowseGlobalComponentSearchContractTest {
         .filter(line -> line.contains("class=\"side-subitem\""))
         .count());
     assertTrue(index.contains("<form class=\"search-form\" id=\"component-search-form\">"));
-    assertTrue(index.contains("<select id=\"component-custom-format\">"));
+    assertTrue(index.contains(
+        "<select id=\"component-custom-format\" hidden aria-hidden=\"true\" tabindex=\"-1\">"));
+    assertTrue(index.contains("aria-haspopup=\"listbox\""));
+    assertTrue(index.contains("placeholder=\"Filter formats\""));
+    assertTrue(index.contains("id=\"component-custom-format-options\""));
+    assertTrue(index.indexOf("id=\"component-custom-format-filter\"")
+        < index.indexOf("id=\"component-custom-format-options\""));
+    assertEquals(22L, index.lines()
+        .filter(line -> line.contains("class=\"search-format-option\""))
+        .count());
+    assertTrue(index.contains(
+        "data-custom-search-format=\"docker\"><span class=\"format-logo format-logo-docker\""));
+    assertTrue(index.contains(
+        "data-custom-search-format=\"huggingface\"><span class=\"format-logo format-logo-huggingface\""));
     assertTrue(index.contains("<h1 id=\"component-search-title\">Search Maven</h1>"));
     assertTrue(index.contains(
         "/browse/assets/global-component-search.css?v=20260819-topbar-control-height-1"));
@@ -51,6 +65,14 @@ class BrowseGlobalComponentSearchContractTest {
         "showSearch(route.searchFormat, false, route.keyword, route.customSearchFormat)"));
     assertTrue(javascript.contains("document.getElementById(\"component-search-form\")"));
     assertTrue(javascript.contains("searchPageTitle(activeSearchFormat)"));
+    assertTrue(javascript.contains("bindCustomSearchFormatCombobox();"));
+    assertTrue(javascript.contains("filterCustomSearchFormatOptions"));
+    assertTrue(javascript.contains("moveActiveCustomSearchFormatOption"));
+
+    assertTrue(browseStylesheet.contains(".search-format-popover"));
+    assertTrue(browseStylesheet.contains(".search-format-filter"));
+    assertTrue(browseStylesheet.contains("top: calc(100% + 6px);"));
+    assertTrue(browseStylesheet.contains(".search-format-option .format-logo"));
 
     assertTrue(sharedJavascript.contains("/browse/#browse/search/all"));
     assertTrue(sharedJavascript.contains("locationRef.assign(destination)"));

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseRepositoryFormatIconsContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseRepositoryFormatIconsContractTest.java
@@ -13,10 +13,9 @@ class BrowseRepositoryFormatIconsContractTest {
   private static final List<String> FORMATS = List.of(
       "maven2", "npm", "pypi", "cargo", "pub", "composer", "terraform", "swift",
       "ansiblegalaxy", "conda", "conan", "apt", "alpine", "huggingface", "go",
-      "helm", "docker", "nuget", "rubygems", "yum", "raw");
+      "helm", "docker", "nuget", "rubygems", "yum", "r", "raw");
   private static final List<String> SEARCH_FORMATS = List.of(
-      "cargo", "go", "helm", "maven2", "nuget",
-      "pub", "pypi", "rubygems", "swift", "ansiblegalaxy", "conda", "conan", "apt", "alpine", "huggingface", "yum", "npm");
+      "maven2", "npm", "pypi", "docker", "nuget", "go", "helm", "cargo");
 
   @Test
   void repositoryFormatColumnUsesSharedBrandIcons() throws IOException {
@@ -38,6 +37,7 @@ class BrowseRepositoryFormatIconsContractTest {
               + iconName(format) + "\""), format);
     }
     for (String format : FORMATS) {
+      assertTrue(index.contains("<option value=\"" + format + "\">"), format);
       assertTrue(javascript.contains(format + ": \"" + iconName(format) + "\""), format);
     }
   }

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseTerraformUploadContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseTerraformUploadContractTest.java
@@ -39,7 +39,7 @@ class BrowseTerraformUploadContractTest {
     assertTrue(javascript.contains("const repoUrl = repositoryBaseUrl().replace(/\\/+$/, \"\")"));
     assertTrue(javascript.contains("crumbIcon: repositoryFormatIcon()"));
     assertTrue(javascript.contains("await activateTreeBranch(entry, toggleExpand)"));
-    assertTrue(index.contains("/browse/assets/browse.js?v=20260826-search-menu-1"));
+    assertTrue(index.contains("/browse/assets/browse.js?v=20260826-search-menu-3"));
   }
 
   private String resource(String path) throws IOException {

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseTerraformUploadContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseTerraformUploadContractTest.java
@@ -39,7 +39,7 @@ class BrowseTerraformUploadContractTest {
     assertTrue(javascript.contains("const repoUrl = repositoryBaseUrl().replace(/\\/+$/, \"\")"));
     assertTrue(javascript.contains("crumbIcon: repositoryFormatIcon()"));
     assertTrue(javascript.contains("await activateTreeBranch(entry, toggleExpand)"));
-    assertTrue(index.contains("/browse/assets/browse.js?v=20260826-tree-scroll-1"));
+    assertTrue(index.contains("/browse/assets/browse.js?v=20260826-search-menu-1"));
   }
 
   private String resource(String path) throws IOException {

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseUiScrollbarContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseUiScrollbarContractTest.java
@@ -21,7 +21,7 @@ class BrowseUiScrollbarContractTest {
 
     assertTrue(theme >= 0 && scrollbars > theme && components > scrollbars);
     assertTrue(index.contains(
-        "/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-2"));
+        "/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-3"));
   }
 
   @Test
@@ -30,6 +30,9 @@ class BrowseUiScrollbarContractTest {
     String browse = resource("/META-INF/resources/browse/assets/browse.css");
 
     assertTrue(shared.contains("--ui-scrollbar-size: 6px"));
+    assertTrue(shared.contains("--ui-scrollbar-thumb: rgba(36, 50, 46, 0.54)"));
+    assertTrue(shared.contains("--ui-scrollbar-thumb-hover: rgba(36, 50, 46, 0.7)"));
+    assertTrue(shared.contains("@supports (color: color-mix(in srgb, black, transparent))"));
     assertTrue(shared.contains("color-mix(in srgb, var(--ink-2) 54%, transparent)"));
     assertTrue(shared.contains("color-mix(in srgb, var(--ink-2) 70%, transparent)"));
     assertTrue(shared.contains("*::-webkit-scrollbar"));

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseUiScrollbarContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseUiScrollbarContractTest.java
@@ -1,0 +1,51 @@
+package com.github.klboke.kkrepo.browse.ui;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import org.junit.jupiter.api.Test;
+
+class BrowseUiScrollbarContractTest {
+
+  @Test
+  void loadsSharedScrollbarStylesAfterTheThemeAndBeforeComponentStyles() throws IOException {
+    String index = resource("/META-INF/resources/browse/index.html");
+
+    int theme = index.indexOf("id=\"kkrepo-theme-stylesheet\"");
+    int scrollbars = index.indexOf("/browse/assets/ui-scrollbars.css");
+    int components = index.indexOf("/browse/assets/browse.css");
+
+    assertTrue(theme >= 0 && scrollbars > theme && components > scrollbars);
+    assertTrue(index.contains(
+        "/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-1"));
+  }
+
+  @Test
+  void appliesOneThinTransparentThemeAwareStyleToEveryScrollContainer() throws IOException {
+    String shared = resource("/META-INF/resources/browse/assets/ui-scrollbars.css");
+    String browse = resource("/META-INF/resources/browse/assets/browse.css");
+
+    assertTrue(shared.contains("--ui-scrollbar-size: 6px"));
+    assertTrue(shared.contains("color-mix(in srgb, var(--ink-3) 24%, transparent)"));
+    assertTrue(shared.contains("* {\n"
+        + "  scrollbar-color: var(--ui-scrollbar-thumb) transparent;\n"
+        + "  scrollbar-width: thin;\n"
+        + "}"));
+    assertTrue(shared.contains("*::-webkit-scrollbar"));
+    assertTrue(shared.contains("height: var(--ui-scrollbar-size)"));
+    assertTrue(shared.contains("*::-webkit-scrollbar-thumb:hover"));
+    assertFalse(browse.contains("::-webkit-scrollbar"));
+    assertFalse(browse.contains("scrollbar-color:"));
+    assertFalse(browse.contains("scrollbar-width:"));
+  }
+
+  private String resource(String path) throws IOException {
+    try (InputStream stream = getClass().getResourceAsStream(path)) {
+      return new String(Objects.requireNonNull(stream).readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+}

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseUiScrollbarContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseUiScrollbarContractTest.java
@@ -21,7 +21,7 @@ class BrowseUiScrollbarContractTest {
 
     assertTrue(theme >= 0 && scrollbars > theme && components > scrollbars);
     assertTrue(index.contains(
-        "/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-3"));
+        "/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-4"));
   }
 
   @Test
@@ -30,11 +30,11 @@ class BrowseUiScrollbarContractTest {
     String browse = resource("/META-INF/resources/browse/assets/browse.css");
 
     assertTrue(shared.contains("--ui-scrollbar-size: 6px"));
-    assertTrue(shared.contains("--ui-scrollbar-thumb: rgba(36, 50, 46, 0.54)"));
-    assertTrue(shared.contains("--ui-scrollbar-thumb-hover: rgba(36, 50, 46, 0.7)"));
+    assertTrue(shared.contains("--ui-scrollbar-thumb: rgba(18, 33, 29, 0.5)"));
+    assertTrue(shared.contains("--ui-scrollbar-thumb-hover: rgba(18, 33, 29, 0.6)"));
     assertTrue(shared.contains("@supports (color: color-mix(in srgb, black, transparent))"));
-    assertTrue(shared.contains("color-mix(in srgb, var(--ink-2) 54%, transparent)"));
-    assertTrue(shared.contains("color-mix(in srgb, var(--ink-2) 70%, transparent)"));
+    assertTrue(shared.contains("color-mix(in srgb, var(--ink-1) 50%, transparent)"));
+    assertTrue(shared.contains("color-mix(in srgb, var(--ink-1) 60%, transparent)"));
     assertTrue(shared.contains("*::-webkit-scrollbar"));
     assertTrue(shared.contains("height: var(--ui-scrollbar-size)"));
     assertTrue(shared.contains("*::-webkit-scrollbar-thumb:hover"));

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseUiScrollbarContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseUiScrollbarContractTest.java
@@ -21,7 +21,7 @@ class BrowseUiScrollbarContractTest {
 
     assertTrue(theme >= 0 && scrollbars > theme && components > scrollbars);
     assertTrue(index.contains(
-        "/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-1"));
+        "/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-2"));
   }
 
   @Test
@@ -30,14 +30,14 @@ class BrowseUiScrollbarContractTest {
     String browse = resource("/META-INF/resources/browse/assets/browse.css");
 
     assertTrue(shared.contains("--ui-scrollbar-size: 6px"));
-    assertTrue(shared.contains("color-mix(in srgb, var(--ink-3) 24%, transparent)"));
-    assertTrue(shared.contains("* {\n"
-        + "  scrollbar-color: var(--ui-scrollbar-thumb) transparent;\n"
-        + "  scrollbar-width: thin;\n"
-        + "}"));
+    assertTrue(shared.contains("color-mix(in srgb, var(--ink-2) 54%, transparent)"));
+    assertTrue(shared.contains("color-mix(in srgb, var(--ink-2) 70%, transparent)"));
     assertTrue(shared.contains("*::-webkit-scrollbar"));
     assertTrue(shared.contains("height: var(--ui-scrollbar-size)"));
     assertTrue(shared.contains("*::-webkit-scrollbar-thumb:hover"));
+    assertTrue(shared.contains("@supports not selector(::-webkit-scrollbar)"));
+    assertTrue(shared.contains("scrollbar-color: var(--ui-scrollbar-thumb) transparent"));
+    assertTrue(shared.contains("scrollbar-width: thin"));
     assertFalse(browse.contains("::-webkit-scrollbar"));
     assertFalse(browse.contains("scrollbar-color:"));
     assertFalse(browse.contains("scrollbar-width:"));

--- a/browse-ui/src/test/js/browse-layout-scroll.test.js
+++ b/browse-ui/src/test/js/browse-layout-scroll.test.js
@@ -20,7 +20,7 @@ test("keeps the expanded navigation inside the sidebar scroll container", () => 
 test("cache-busts the current Browse assets", () => {
   const html = readFileSync(resolve(browseRoot, "index.html"), "utf8");
 
-  assert.match(html, /browse\.css\?v=20260826-search-menu-3/);
+  assert.match(html, /browse\.css\?v=20260826-search-menu-4/);
   assert.match(html, /browse\.js\?v=20260826-search-menu-3/);
 });
 
@@ -29,6 +29,7 @@ test("keeps the icon format picker below its trigger", () => {
   const css = readFileSync(resolve(browseRoot, "assets/browse.css"), "utf8");
   const comboboxRule = css.match(/\.search-format-combobox\s*\{([^}]*)\}/)?.[1] || "";
   const popoverRule = css.match(/\.search-format-popover\s*\{([^}]*)\}/)?.[1] || "";
+  const filterRule = css.match(/\.search-form \.search-format-filter\s*\{([^}]*)\}/)?.[1] || "";
 
   assert.equal((html.match(/class="search-format-option"/g) || []).length, 22);
   assert.match(html, /aria-haspopup="listbox"/);
@@ -43,4 +44,5 @@ test("keeps the icon format picker below its trigger", () => {
   assert.match(popoverRule, /position:\s*absolute/);
   assert.match(popoverRule, /top:\s*calc\(100% \+ 6px\)/);
   assert.doesNotMatch(popoverRule, /bottom:/);
+  assert.match(filterRule, /width:\s*100%/);
 });

--- a/browse-ui/src/test/js/browse-layout-scroll.test.js
+++ b/browse-ui/src/test/js/browse-layout-scroll.test.js
@@ -17,9 +17,9 @@ test("keeps the expanded navigation inside the sidebar scroll container", () => 
   assert.match(sidebarRule, /overflow-y:\s*auto/);
 });
 
-test("cache-busts the tree scroll fix assets", () => {
+test("cache-busts the current Browse assets", () => {
   const html = readFileSync(resolve(browseRoot, "index.html"), "utf8");
 
-  assert.match(html, /browse\.css\?v=20260826-tree-scroll-1/);
-  assert.match(html, /browse\.js\?v=20260826-tree-scroll-1/);
+  assert.match(html, /browse\.css\?v=20260826-search-menu-1/);
+  assert.match(html, /browse\.js\?v=20260826-search-menu-1/);
 });

--- a/browse-ui/src/test/js/browse-layout-scroll.test.js
+++ b/browse-ui/src/test/js/browse-layout-scroll.test.js
@@ -20,6 +20,27 @@ test("keeps the expanded navigation inside the sidebar scroll container", () => 
 test("cache-busts the current Browse assets", () => {
   const html = readFileSync(resolve(browseRoot, "index.html"), "utf8");
 
-  assert.match(html, /browse\.css\?v=20260826-search-menu-1/);
-  assert.match(html, /browse\.js\?v=20260826-search-menu-1/);
+  assert.match(html, /browse\.css\?v=20260826-search-menu-3/);
+  assert.match(html, /browse\.js\?v=20260826-search-menu-3/);
+});
+
+test("keeps the icon format picker below its trigger", () => {
+  const html = readFileSync(resolve(browseRoot, "index.html"), "utf8");
+  const css = readFileSync(resolve(browseRoot, "assets/browse.css"), "utf8");
+  const comboboxRule = css.match(/\.search-format-combobox\s*\{([^}]*)\}/)?.[1] || "";
+  const popoverRule = css.match(/\.search-format-popover\s*\{([^}]*)\}/)?.[1] || "";
+
+  assert.equal((html.match(/class="search-format-option"/g) || []).length, 22);
+  assert.match(html, /aria-haspopup="listbox"/);
+  assert.match(html, /placeholder="Filter formats"/);
+  assert.ok(
+    html.indexOf('id="component-custom-format-filter"')
+      < html.indexOf('id="component-custom-format-options"'),
+  );
+  assert.match(html, /data-custom-search-format="maven2"[^>]*>.*format-logo-maven/);
+  assert.match(html, /data-custom-search-format="raw"[^>]*>.*format-logo-raw/);
+  assert.match(comboboxRule, /width:\s*240px/);
+  assert.match(popoverRule, /position:\s*absolute/);
+  assert.match(popoverRule, /top:\s*calc\(100% \+ 6px\)/);
+  assert.doesNotMatch(popoverRule, /bottom:/);
 });

--- a/browse-ui/src/test/js/global-component-search.test.js
+++ b/browse-ui/src/test/js/global-component-search.test.js
@@ -47,6 +47,7 @@ function loadBrowseSearchHelpers() {
     ${source.slice(openResultStart, openResultEnd)}
     globalThis.searchHash = searchHash;
     globalThis.searchFormatLabel = searchFormatLabel;
+    globalThis.searchPageTitle = searchPageTitle;
     globalThis.repositoryBrowseHash = repositoryBrowseHash;
     globalThis.componentBrowsePath = componentBrowsePath;
     globalThis.parseBrowseHash = parseBrowseHash;
@@ -57,13 +58,13 @@ function loadBrowseSearchHelpers() {
   return context;
 }
 
-test("builds a custom search target and restores its keyword", () => {
+test("builds an all-component search target and restores its keyword", () => {
   assert.equal(
     globalSearch.target("  grpcur  "),
-    "/browse/#browse/search/custom?q=grpcur",
+    "/browse/#browse/search/all?q=grpcur",
   );
   assert.equal(
-    globalSearch.keywordFromHash("#browse/search/custom?q=grpcurl+linux"),
+    globalSearch.keywordFromHash("#browse/search/all?q=grpcurl+linux"),
     "grpcurl linux",
   );
   assert.equal(globalSearch.target("   "), null);
@@ -89,7 +90,7 @@ test("binds the topbar form, focuses empty input, and navigates on submit", () =
     },
   };
   const locationRef = {
-    hash: "#browse/search/custom?q=existing",
+    hash: "#browse/search/all?q=existing",
     assign(value) { assigned = value; },
   };
 
@@ -103,39 +104,58 @@ test("binds the topbar form, focuses empty input, and navigates on submit", () =
 
   input.value = " grpcurl ";
   submit({ preventDefault() {} });
-  assert.equal(assigned, "/browse/#browse/search/custom?q=grpcurl");
+  assert.equal(assigned, "/browse/#browse/search/all?q=grpcurl");
 });
 
-test("custom route omits format while format-specific search keeps it", () => {
+test("all route omits format while custom and quick searches keep one format", () => {
   const helpers = loadBrowseSearchHelpers();
 
   assert.equal(
-    helpers.searchHash("custom", " grpcur "),
-    "#browse/search/custom?q=grpcur",
+    helpers.searchHash("all", " grpcur "),
+    "#browse/search/all?q=grpcur",
   );
   assert.equal(
-    helpers.componentSearchParams("custom", "grpcur").toString(),
+    helpers.componentSearchParams("all", "grpcur").toString(),
     "q=grpcur&limit=20",
+  );
+  assert.equal(
+    helpers.searchHash("custom", " nginx ", "docker"),
+    "#browse/search/custom?format=docker&q=nginx",
+  );
+  assert.equal(
+    helpers.componentSearchParams("custom", "nginx", "docker").toString(),
+    "q=nginx&format=docker&limit=20",
   );
   assert.equal(
     helpers.componentSearchParams("maven2", "junit").toString(),
     "q=junit&format=maven2&limit=20",
   );
 
-  helpers.window.location.hash = "#browse/search/custom?q=grpcurl+linux";
-  const route = helpers.parseBrowseHash();
-  assert.equal(route.view, "search");
-  assert.equal(route.searchFormat, "custom");
-  assert.equal(route.keyword, "grpcurl linux");
+  helpers.window.location.hash = "#browse/search/custom?format=go&q=grpcurl+linux";
+  const customRoute = helpers.parseBrowseHash();
+  assert.equal(customRoute.view, "search");
+  assert.equal(customRoute.searchFormat, "custom");
+  assert.equal(customRoute.customSearchFormat, "go");
+  assert.equal(customRoute.keyword, "grpcurl linux");
+
+  helpers.window.location.hash = "#browse/search/custom?q=legacy";
+  const legacyRoute = helpers.parseBrowseHash();
+  assert.equal(legacyRoute.searchFormat, "all");
+  assert.equal(legacyRoute.keyword, "legacy");
 });
 
 test("uses the selected repository format in the search page title", () => {
   const helpers = loadBrowseSearchHelpers();
 
-  assert.equal(helpers.searchFormatLabel("custom"), "All formats");
+  assert.equal(helpers.searchFormatLabel("all"), "All components");
+  assert.equal(helpers.searchFormatLabel("custom"), "Custom search");
   assert.equal(helpers.searchFormatLabel("maven2"), "Maven");
+  assert.equal(helpers.searchFormatLabel("docker"), "Docker / OCI");
   assert.equal(helpers.searchFormatLabel("ansiblegalaxy"), "Ansible Galaxy");
   assert.equal(helpers.searchFormatLabel("alpine"), "Alpine / APK");
+  assert.equal(helpers.searchPageTitle("all"), "Search all components");
+  assert.equal(helpers.searchPageTitle("custom"), "Custom search");
+  assert.equal(helpers.searchPageTitle("docker"), "Search Docker / OCI");
 });
 
 test("opens a Hugging Face search result at its immutable revision path", () => {


### PR DESCRIPTION
## Summary

- add one theme-aware scrollbar stylesheet shared by Admin and Browse
- apply a thin 6px treatment with transparent tracks, translucent thumbs, and stronger hover feedback to every scroll container
- keep Chromium and Safari on the precise WebKit treatment while Firefox uses the standard thin-scrollbar fallback
- retain at least 3:1 thumb contrast across all bundled theme surfaces
- reduce the Browse Search submenu to All components, Custom search, and eight mainstream format shortcuts
- add a compact, icon-rich single-format Custom search picker covering every supported repository format
- keep its filterable list fixed below the trigger, constrain the filter field inside the picker, and support keyboard navigation with empty-state feedback
- keep topbar search as an all-format search and preserve legacy all-format search routes
- add contract coverage for shared scrollbar styling and the streamlined search flow

## Validation

- `mvn -pl admin-ui,browse-ui test`
- `node --test browse-ui/src/test/js/*.test.js`
- `mvn -pl server -am -DskipTests package spring-boot:repackage`
- verified the expanded Search menu, 22 icon choices, format filtering, single-format routing, and shared scrollbar styling on the local runtime
