### PR TITLE
Add a Nexus-inspired UI theme

### DIFF
--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
@@ -318,7 +318,7 @@ select {
   place-items: center;
   margin-left: 3px;
   border-radius: var(--r-xs);
-  color: var(--brand-bright);
+  color: var(--topbar-active);
   font-size: 15px;
   line-height: 1;
   text-decoration: none;

--- a/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/assets/admin.css
@@ -332,7 +332,7 @@ select {
 }
 
 .product-update-link:focus-visible {
-  outline: 2px solid #ffffff;
+  outline: 2px solid var(--topbar-focus-outline);
   outline-offset: 1px;
 }
 
@@ -394,7 +394,7 @@ select {
 .product-link:focus-visible,
 .product-version:focus-visible {
   border-radius: 3px;
-  outline: 2px solid #ffffff;
+  outline: 2px solid var(--topbar-focus-outline);
   outline-offset: 2px;
 }
 

--- a/admin-ui/src/main/resources/META-INF/resources/admin/index.html
+++ b/admin-ui/src/main/resources/META-INF/resources/admin/index.html
@@ -5,12 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>kkrepo administration</title>
     <link rel="icon" type="image/svg+xml" href="/admin/assets/favicon.svg?v=20260609-kl-logo-1">
-    <link id="kkrepo-theme-stylesheet" rel="stylesheet" href="/browse/assets/themes/default.css?v=20260824-ui-themes-3">
-    <script src="/login/assets/ui-theme.js?v=20260824-ui-themes-3"></script>
+    <link id="kkrepo-theme-stylesheet" rel="stylesheet" href="/browse/assets/themes/default.css?v=20260826-nexus-a11y-1">
+    <script src="/login/assets/ui-theme.js?v=20260826-nexus-a11y-1"></script>
   <link rel="stylesheet" href="/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-4">
     <link rel="stylesheet" href="/browse/assets/format-icons.css?v=20260811-conan-1">
     <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260818-user-round-1">
-    <link rel="stylesheet" href="./assets/admin.css?v=20260826-ui-theme-preview-1">
+    <link rel="stylesheet" href="./assets/admin.css?v=20260826-nexus-a11y-1">
     <link rel="stylesheet" href="/browse/assets/account-menu.css?v=20260824-ui-themes-3">
     <link rel="stylesheet" href="/browse/assets/global-component-search.css?v=20260819-topbar-control-height-1">
   </head>

--- a/admin-ui/src/main/resources/META-INF/resources/login/assets/ui-theme.js
+++ b/admin-ui/src/main/resources/META-INF/resources/login/assets/ui-theme.js
@@ -25,7 +25,7 @@
   }
 
   function stylesheetHref(theme) {
-    return `/browse/assets/themes/${encodeURIComponent(theme)}.css?v=20260824-ui-themes-3`;
+    return `/browse/assets/themes/${encodeURIComponent(theme)}.css?v=20260826-nexus-a11y-1`;
   }
 
   function bind(documentRef, windowRef) {

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminUiThemeContractTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminUiThemeContractTest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 
 class AdminUiThemeContractTest {
@@ -28,6 +29,8 @@ class AdminUiThemeContractTest {
 
     assertTrue(stylesheet.contains("outline: 2px solid var(--topbar-focus-outline)"));
     assertFalse(stylesheet.contains("outline: 2px solid #ffffff"));
+    assertTrue(Pattern.compile("\\.product-update-link\\s*\\{[^}]*var\\(--topbar-active\\)",
+        Pattern.DOTALL).matcher(stylesheet).find());
   }
 
   @Test

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminUiThemeContractTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminUiThemeContractTest.java
@@ -19,7 +19,10 @@ class AdminUiThemeContractTest {
     int bootstrap = index.indexOf("/login/assets/ui-theme.js");
     int components = index.indexOf("./assets/admin.css");
     assertTrue(theme >= 0 && bootstrap > theme && components > bootstrap);
-    assertTrue(index.contains("/browse/assets/themes/default.css"));
+    assertTrue(index.contains(
+        "/browse/assets/themes/default.css?v=20260826-nexus-a11y-1"));
+    assertTrue(index.contains("/login/assets/ui-theme.js?v=20260826-nexus-a11y-1"));
+    assertTrue(index.contains("./assets/admin.css?v=20260826-nexus-a11y-1"));
     assertFalse(index.contains("/browse/assets/tokens.css"));
   }
 
@@ -49,7 +52,7 @@ class AdminUiThemeContractTest {
     assertTrue(javascript.contains("settings.supportedDefaultThemes"));
     assertTrue(javascript.contains("if (theme === \"jfrog\") return \"JFrog\""));
     assertTrue(i18n.contains("正在预览所选主题。保存界面设置后，它才会成为默认主题。"));
-    assertTrue(index.contains("./assets/admin.css?v=20260826-ui-theme-preview-1"));
+    assertTrue(index.contains("./assets/admin.css?v=20260826-nexus-a11y-1"));
     assertTrue(index.contains("/login/assets/ui-i18n.js?v=20260826-ui-theme-preview-1"));
     assertTrue(index.contains("./assets/admin.js?v=20260826-ui-theme-preview-1"));
     assertFalse(index.contains("id=\"ui-settings-status\""));

--- a/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminUiThemeContractTest.java
+++ b/admin-ui/src/test/java/com/github/klboke/kkrepo/admin/ui/AdminUiThemeContractTest.java
@@ -23,6 +23,14 @@ class AdminUiThemeContractTest {
   }
 
   @Test
+  void topbarFocusOutlineComesFromTheSelectedTheme() throws IOException {
+    String stylesheet = resource("/META-INF/resources/admin/assets/admin.css");
+
+    assertTrue(stylesheet.contains("outline: 2px solid var(--topbar-focus-outline)"));
+    assertFalse(stylesheet.contains("outline: 2px solid #ffffff"));
+  }
+
+  @Test
   void exposesDefaultThemeSelectionInUiSettings() throws IOException {
     String index = resource("/META-INF/resources/admin/index.html");
     String javascript = resource("/META-INF/resources/admin/assets/admin.js");

--- a/admin-ui/src/test/js/ui-theme.test.js
+++ b/admin-ui/src/test/js/ui-theme.test.js
@@ -45,7 +45,7 @@ test("boots with the current kkRepo CSS as the default theme", () => {
   assert.equal(view.rootAttributes.get("data-theme"), "default");
   assert.equal(
     view.stylesheetAttributes.get("href"),
-    "/browse/assets/themes/default.css?v=20260824-ui-themes-3",
+    "/browse/assets/themes/default.css?v=20260826-nexus-a11y-1",
   );
 });
 
@@ -61,7 +61,7 @@ test("loads every registered bundled theme template from cached UI settings", ()
     assert.equal(view.binding.currentTheme(), theme);
     assert.equal(
       view.stylesheetAttributes.get("href"),
-      `/browse/assets/themes/${theme}.css?v=20260824-ui-themes-3`,
+      `/browse/assets/themes/${theme}.css?v=20260826-nexus-a11y-1`,
     );
   }
 });
@@ -75,7 +75,7 @@ test("previews a selected theme without persisting browser settings", () => {
   assert.equal(view.rootAttributes.get("data-theme"), "jfrog");
   assert.equal(
     view.stylesheetAttributes.get("href"),
-    "/browse/assets/themes/jfrog.css?v=20260824-ui-themes-3",
+    "/browse/assets/themes/jfrog.css?v=20260826-nexus-a11y-1",
   );
   assert.deepEqual(view.storageWrites, []);
 });
@@ -100,6 +100,6 @@ test("falls back to the default template when a selected stylesheet is missing",
   assert.equal(view.binding.currentTheme(), "default");
   assert.equal(
     view.stylesheetAttributes.get("href"),
-    "/browse/assets/themes/default.css?v=20260824-ui-themes-3",
+    "/browse/assets/themes/default.css?v=20260826-nexus-a11y-1",
   );
 });

--- a/admin-ui/src/test/js/ui-theme.test.js
+++ b/admin-ui/src/test/js/ui-theme.test.js
@@ -50,7 +50,7 @@ test("boots with the current kkRepo CSS as the default theme", () => {
 });
 
 test("loads every registered bundled theme template from cached UI settings", () => {
-  const themes = ["indigo", "ocean", "sunset", "jfrog"];
+  const themes = ["indigo", "ocean", "sunset", "jfrog", "nexus"];
 
   for (const theme of themes) {
     const view = fixture({
@@ -67,7 +67,7 @@ test("loads every registered bundled theme template from cached UI settings", ()
 });
 
 test("previews a selected theme without persisting browser settings", () => {
-  const themes = ["default", "indigo", "ocean", "sunset", "jfrog"];
+  const themes = ["default", "indigo", "ocean", "sunset", "jfrog", "nexus"];
   const view = fixture({ defaultTheme: "default", supportedDefaultThemes: themes });
 
   assert.equal(view.binding.applyTheme("jfrog", themes), "jfrog");

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
@@ -85,7 +85,7 @@ select {
   place-items: center;
   margin-left: 3px;
   border-radius: var(--r-xs);
-  color: var(--brand-bright);
+  color: var(--topbar-active);
   font-size: 15px;
   line-height: 1;
   text-decoration: none;
@@ -257,7 +257,7 @@ select {
   width: 18px;
   height: 18px;
   flex: 0 0 18px;
-  color: var(--brand-bright);
+  color: var(--topbar-active);
 }
 
 .account-entry-title {

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/browse.css
@@ -99,7 +99,7 @@ select {
 }
 
 .product-update-link:focus-visible {
-  outline: 2px solid #ffffff;
+  outline: 2px solid var(--topbar-focus-outline);
   outline-offset: 1px;
 }
 
@@ -161,7 +161,7 @@ select {
 .product-link:focus-visible,
 .product-version:focus-visible {
   border-radius: 3px;
-  outline: 2px solid #ffffff;
+  outline: 2px solid var(--topbar-focus-outline);
   outline-offset: 2px;
 }
 

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/themes/default.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/themes/default.css
@@ -58,6 +58,7 @@
   --topbar-hover: rgba(255, 255, 255, 0.09);
   --topbar-active: var(--brand-bright);
   --topbar-selection: linear-gradient(180deg, rgba(20, 117, 107, 0.98), rgba(17, 96, 88, 0.98));
+  --topbar-focus-outline: #ffffff;
 
   /* ===== Signed-in account identity ===== */
   --account-focus-ring-color: rgba(47, 191, 164, 0.28);

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/themes/indigo.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/themes/indigo.css
@@ -54,6 +54,7 @@
   --topbar-hover: rgba(255, 255, 255, 0.08);
   --topbar-active: var(--brand-bright);
   --topbar-selection: linear-gradient(180deg, #4f46e5, #3730a3);
+  --topbar-focus-outline: #ffffff;
 
   /* ===== Signed-in account identity ===== */
   --account-focus-ring-color: rgba(129, 140, 248, 0.32);

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/themes/jfrog.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/themes/jfrog.css
@@ -53,6 +53,7 @@
   --topbar-hover: rgba(255, 255, 255, 0.09);
   --topbar-active: var(--brand-bright);
   --topbar-selection: linear-gradient(180deg, #16883b, #116b2d);
+  --topbar-focus-outline: #ffffff;
 
   /* ===== Signed-in account identity ===== */
   --account-focus-ring-color: rgba(64, 190, 70, 0.34);

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/themes/nexus.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/themes/nexus.css
@@ -10,8 +10,8 @@
   color-scheme: light;
 
   /* ===== Brand ===== */
-  --brand: #3f9665;
-  --brand-strong: #2f7650;
+  --brand: #2f7650;
+  --brand-strong: #286744;
   --brand-tint: #edf7f1;
   --brand-tint-strong: #dcefe4;
   --brand-bright: #70c795;
@@ -54,6 +54,7 @@
   --topbar-hover: #f1f3f4;
   --topbar-active: var(--brand);
   --topbar-selection: var(--brand);
+  --topbar-focus-outline: var(--brand-strong);
 
   /* ===== Signed-in account identity ===== */
   --account-focus-ring-color: rgba(112, 199, 149, 0.3);

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/themes/nexus.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/themes/nexus.css
@@ -57,7 +57,7 @@
   --topbar-focus-outline: var(--brand-strong);
 
   /* ===== Signed-in account identity ===== */
-  --account-focus-ring-color: rgba(112, 199, 149, 0.3);
+  --account-focus-ring-color: var(--brand);
   --account-avatar-background: linear-gradient(145deg, #4aa673, #2f6fa7);
   --account-avatar-border: rgba(31, 34, 38, 0.14);
   --account-avatar-highlight: inset 0 1px 0 rgba(255, 255, 255, 0.2);

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/themes/nexus.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/themes/nexus.css
@@ -1,10 +1,10 @@
 /*
  * kkRepo Nexus-inspired theme.
  *
- * A restrained repository-console palette with graphite navigation, Sonatype-
- * inspired green selection states, blue information accents and compact neutral
- * surfaces. It follows the complete semantic token contract in default.css
- * without copying Sonatype logos, product names or other branded assets.
+ * A restrained repository-console palette with a white application bar,
+ * Sonatype-inspired green selection states, blue information accents and
+ * compact neutral surfaces. It follows the complete semantic token contract in
+ * default.css without copying Sonatype logos, product names or branded assets.
  */
 :root {
   color-scheme: light;
@@ -46,19 +46,19 @@
   --info-bg: #eef5fb;
   --info-line: #bfd4e6;
 
-  /* ===== Graphite topbar ===== */
-  --topbar: #1b1d20;
-  --topbar-line: #34383d;
-  --topbar-ink: #f7f8f8;
-  --topbar-muted: #c3c8cd;
-  --topbar-hover: rgba(255, 255, 255, 0.09);
-  --topbar-active: var(--brand-bright);
-  --topbar-selection: linear-gradient(180deg, #438f63, #347a53);
+  /* ===== White application bar ===== */
+  --topbar: #ffffff;
+  --topbar-line: #d7dadd;
+  --topbar-ink: #1f2226;
+  --topbar-muted: #626970;
+  --topbar-hover: #f1f3f4;
+  --topbar-active: var(--brand);
+  --topbar-selection: var(--brand-tint-strong);
 
   /* ===== Signed-in account identity ===== */
   --account-focus-ring-color: rgba(112, 199, 149, 0.3);
   --account-avatar-background: linear-gradient(145deg, #4aa673, #2f6fa7);
-  --account-avatar-border: rgba(255, 255, 255, 0.2);
+  --account-avatar-border: rgba(31, 34, 38, 0.14);
   --account-avatar-highlight: inset 0 1px 0 rgba(255, 255, 255, 0.2);
   --account-avatar-ink: #ffffff;
   --account-avatar-presence: #70c795;
@@ -122,4 +122,31 @@
   --row-alt: var(--surface-muted);
   --header: var(--surface-sunken);
   --panel: var(--surface);
+}
+
+/* The shared shell defaults are tuned for dark topbars. Keep the light Nexus
+ * application bar self-contained in this theme without affecting other themes. */
+:root[data-theme="nexus"] .nx-topbar {
+  box-shadow: 0 1px 0 rgba(31, 34, 38, 0.06);
+}
+
+:root[data-theme="nexus"] .global-component-search input,
+:root[data-theme="nexus"] .user-menu-trigger,
+:root[data-theme="nexus"] .account-login {
+  border-color: var(--line);
+  background: var(--surface);
+}
+
+:root[data-theme="nexus"] .global-component-search input:hover,
+:root[data-theme="nexus"] .user-menu-trigger:hover,
+:root[data-theme="nexus"] .user-menu-trigger[aria-expanded="true"],
+:root[data-theme="nexus"] .account-login:hover {
+  border-color: var(--line-strong);
+  background: var(--topbar-hover);
+}
+
+:root[data-theme="nexus"] .global-component-search input:focus-visible,
+:root[data-theme="nexus"] .account-login:focus-visible {
+  border-color: var(--brand);
+  box-shadow: var(--focus-ring);
 }

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/themes/nexus.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/themes/nexus.css
@@ -1,0 +1,125 @@
+/*
+ * kkRepo Nexus-inspired theme.
+ *
+ * A restrained repository-console palette with graphite navigation, Sonatype-
+ * inspired green selection states, blue information accents and compact neutral
+ * surfaces. It follows the complete semantic token contract in default.css
+ * without copying Sonatype logos, product names or other branded assets.
+ */
+:root {
+  color-scheme: light;
+
+  /* ===== Brand ===== */
+  --brand: #3f9665;
+  --brand-strong: #2f7650;
+  --brand-tint: #edf7f1;
+  --brand-tint-strong: #dcefe4;
+  --brand-bright: #70c795;
+
+  /* ===== Signature accent ===== */
+  --accent: #2f6fa7;
+  --accent-soft: #eef5fb;
+
+  /* ===== Neutral ramp ===== */
+  --ink-1: #1f2226;
+  --ink-2: #34383d;
+  --ink-3: #626970;
+  --ink-4: #8b9198;
+  --line: #d7dadd;
+  --line-strong: #b9bec4;
+  --surface: #ffffff;
+  --surface-muted: #f8f9fa;
+  --surface-sunken: #eceeef;
+  --canvas: #f5f6f7;
+
+  /* ===== Semantic status ===== */
+  --success: #347a53;
+  --success-bg: #edf7f1;
+  --success-line: #b8ddc7;
+  --warning: #9a5b16;
+  --warning-bg: #fff6e8;
+  --warning-line: #ead09e;
+  --danger: #ad372f;
+  --danger-bg: #fff0ef;
+  --danger-line: #e8bab6;
+  --info: #2f6fa7;
+  --info-bg: #eef5fb;
+  --info-line: #bfd4e6;
+
+  /* ===== Graphite topbar ===== */
+  --topbar: #1b1d20;
+  --topbar-line: #34383d;
+  --topbar-ink: #f7f8f8;
+  --topbar-muted: #c3c8cd;
+  --topbar-hover: rgba(255, 255, 255, 0.09);
+  --topbar-active: var(--brand-bright);
+  --topbar-selection: linear-gradient(180deg, #438f63, #347a53);
+
+  /* ===== Signed-in account identity ===== */
+  --account-focus-ring-color: rgba(112, 199, 149, 0.3);
+  --account-avatar-background: linear-gradient(145deg, #4aa673, #2f6fa7);
+  --account-avatar-border: rgba(255, 255, 255, 0.2);
+  --account-avatar-highlight: inset 0 1px 0 rgba(255, 255, 255, 0.2);
+  --account-avatar-ink: #ffffff;
+  --account-avatar-presence: #70c795;
+
+  /* ===== Radius scale ===== */
+  --r-xs: 3px;
+  --r-sm: 4px;
+  --r-md: 6px;
+  --r-lg: 8px;
+  --r-pill: 999px;
+
+  /* ===== Elevation ===== */
+  --shadow-sm: 0 1px 2px rgba(31, 34, 38, 0.08);
+  --shadow-soft: 0 8px 22px rgba(31, 34, 38, 0.1);
+  --shadow-pop: 0 16px 38px rgba(31, 34, 38, 0.2);
+  --shadow-modal: 0 26px 72px rgba(22, 25, 29, 0.3);
+  --shadow-nav: 0 5px 14px rgba(63, 150, 101, 0.2);
+  --shadow-press: inset 0 1px 2px rgba(31, 34, 38, 0.18);
+
+  /* ===== Focus ===== */
+  --focus: rgba(63, 150, 101, 0.24);
+  --focus-ring: 0 0 0 3px var(--focus);
+
+  /* ===== Spacing scale ===== */
+  --s-1: 4px;
+  --s-2: 8px;
+  --s-3: 12px;
+  --s-4: 16px;
+  --s-5: 24px;
+  --s-6: 32px;
+
+  /* ===== Typography ===== */
+  --font-sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  --fs-xs: 12px;
+  --fs-sm: 13px;
+  --fs-base: 14px;
+  --fs-lg: 16px;
+  --fs-xl: 18px;
+  --fs-2xl: 22px;
+  --fs-3xl: 26px;
+  --fw-regular: 400;
+  --fw-medium: 500;
+  --fw-semibold: 600;
+  --fw-bold: 700;
+  --lh-tight: 1.25;
+  --lh-base: 1.5;
+
+  /* ===== Table ===== */
+  --row-hover: var(--brand-tint);
+  --table-head-ink: var(--ink-3);
+
+  /* ===== Legacy aliases ===== */
+  --active: var(--brand);
+  --active-ink: #ffffff;
+  --sidebar: var(--surface);
+  --sidebar-head: var(--surface);
+  --text: var(--ink-2);
+  --muted: var(--ink-3);
+  --row: var(--surface);
+  --row-alt: var(--surface-muted);
+  --header: var(--surface-sunken);
+  --panel: var(--surface);
+}

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/themes/nexus.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/themes/nexus.css
@@ -14,7 +14,7 @@
   --brand-strong: #286744;
   --brand-tint: #edf7f1;
   --brand-tint-strong: #dcefe4;
-  --brand-bright: #70c795;
+  --brand-bright: #347f56;
 
   /* ===== Signature accent ===== */
   --accent: #2f6fa7;
@@ -24,7 +24,7 @@
   --ink-1: #1f2226;
   --ink-2: #34383d;
   --ink-3: #626970;
-  --ink-4: #8b9198;
+  --ink-4: #6c7279;
   --line: #d7dadd;
   --line-strong: #b9bec4;
   --surface: #ffffff;
@@ -62,7 +62,7 @@
   --account-avatar-border: rgba(31, 34, 38, 0.14);
   --account-avatar-highlight: inset 0 1px 0 rgba(255, 255, 255, 0.2);
   --account-avatar-ink: #ffffff;
-  --account-avatar-presence: #70c795;
+  --account-avatar-presence: var(--brand-bright);
 
   /* ===== Radius scale ===== */
   --r-xs: 3px;
@@ -80,7 +80,7 @@
   --shadow-press: inset 0 1px 2px rgba(31, 34, 38, 0.18);
 
   /* ===== Focus ===== */
-  --focus: rgba(63, 150, 101, 0.24);
+  --focus: var(--brand);
   --focus-ring: 0 0 0 3px var(--focus);
 
   /* ===== Spacing scale ===== */

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/themes/nexus.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/themes/nexus.css
@@ -53,7 +53,7 @@
   --topbar-muted: #626970;
   --topbar-hover: #f1f3f4;
   --topbar-active: var(--brand);
-  --topbar-selection: var(--brand-tint-strong);
+  --topbar-selection: var(--brand);
 
   /* ===== Signed-in account identity ===== */
   --account-focus-ring-color: rgba(112, 199, 149, 0.3);
@@ -128,6 +128,10 @@
  * application bar self-contained in this theme without affecting other themes. */
 :root[data-theme="nexus"] .nx-topbar {
   box-shadow: 0 1px 0 rgba(31, 34, 38, 0.06);
+}
+
+:root[data-theme="nexus"] .workspace-tab.is-active {
+  color: #ffffff;
 }
 
 :root[data-theme="nexus"] .global-component-search input,

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/themes/ocean.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/themes/ocean.css
@@ -53,6 +53,7 @@
   --topbar-hover: rgba(255, 255, 255, 0.09);
   --topbar-active: var(--brand-bright);
   --topbar-selection: linear-gradient(180deg, #0284c7, #0369a1);
+  --topbar-focus-outline: #ffffff;
 
   /* ===== Signed-in account identity ===== */
   --account-focus-ring-color: rgba(56, 189, 248, 0.34);

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/themes/sunset.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/themes/sunset.css
@@ -53,6 +53,7 @@
   --topbar-hover: rgba(255, 255, 255, 0.09);
   --topbar-active: var(--brand-bright);
   --topbar-selection: linear-gradient(180deg, #e11d48, #9f1239);
+  --topbar-focus-outline: #ffffff;
 
   /* ===== Signed-in account identity ===== */
   --account-focus-ring-color: rgba(251, 113, 133, 0.34);

--- a/browse-ui/src/main/resources/META-INF/resources/browse/assets/tokens.css
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/assets/tokens.css
@@ -1,2 +1,2 @@
 /* Compatibility alias for cached pages from before selectable UI themes. */
-@import url("./themes/default.css?v=20260824-ui-themes-3");
+@import url("./themes/default.css?v=20260826-nexus-a11y-1");

--- a/browse-ui/src/main/resources/META-INF/resources/browse/index.html
+++ b/browse-ui/src/main/resources/META-INF/resources/browse/index.html
@@ -5,12 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>kkrepo browse</title>
     <link rel="icon" type="image/svg+xml" href="/browse/assets/favicon.svg?v=20260609-kl-logo-1">
-    <link id="kkrepo-theme-stylesheet" rel="stylesheet" href="/browse/assets/themes/default.css?v=20260824-ui-themes-3">
-    <script src="/login/assets/ui-theme.js?v=20260824-ui-themes-3"></script>
+    <link id="kkrepo-theme-stylesheet" rel="stylesheet" href="/browse/assets/themes/default.css?v=20260826-nexus-a11y-1">
+    <script src="/login/assets/ui-theme.js?v=20260826-nexus-a11y-1"></script>
   <link rel="stylesheet" href="/browse/assets/ui-scrollbars.css?v=20260826-shared-scrollbars-4">
     <link rel="stylesheet" href="/browse/assets/format-icons.css?v=20260811-conan-1">
     <link rel="stylesheet" href="/browse/assets/lucide-icons.css?v=20260818-user-round-1">
-    <link rel="stylesheet" href="/browse/assets/browse.css?v=20260826-search-menu-4">
+    <link rel="stylesheet" href="/browse/assets/browse.css?v=20260826-nexus-a11y-1">
     <link rel="stylesheet" href="/browse/assets/account-menu.css?v=20260824-ui-themes-3">
     <link rel="stylesheet" href="/browse/assets/global-component-search.css?v=20260819-topbar-control-height-1">
     <link rel="stylesheet" href="/login/assets/login-modal.css?v=20260818-login-icons-1">

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseUiThemeContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseUiThemeContractTest.java
@@ -23,7 +23,10 @@ class BrowseUiThemeContractTest {
     int bootstrap = index.indexOf("/login/assets/ui-theme.js");
     int components = index.indexOf("/browse/assets/browse.css");
     assertTrue(theme >= 0 && bootstrap > theme && components > bootstrap);
-    assertTrue(index.contains("/browse/assets/themes/default.css"));
+    assertTrue(index.contains(
+        "/browse/assets/themes/default.css?v=20260826-nexus-a11y-1"));
+    assertTrue(index.contains("/login/assets/ui-theme.js?v=20260826-nexus-a11y-1"));
+    assertTrue(index.contains("/browse/assets/browse.css?v=20260826-nexus-a11y-1"));
     assertFalse(index.contains("/browse/assets/tokens.css"));
   }
 
@@ -121,7 +124,7 @@ class BrowseUiThemeContractTest {
     assertTrue(nexusTheme.contains("color-scheme: light"));
     assertTrue(nexusTheme.contains("--brand: #2f7650"));
     assertTrue(nexusTheme.contains("--brand-strong: #286744"));
-    assertTrue(nexusTheme.contains("--brand-bright: #70c795"));
+    assertTrue(nexusTheme.contains("--brand-bright: #347f56"));
     assertTrue(nexusTheme.contains("--accent: #2f6fa7"));
     assertTrue(nexusTheme.contains("--canvas: #f5f6f7"));
     assertTrue(nexusTheme.contains("--topbar: #ffffff"));
@@ -129,6 +132,8 @@ class BrowseUiThemeContractTest {
     assertTrue(nexusTheme.contains("--topbar-selection: var(--brand)"));
     assertTrue(nexusTheme.contains("--topbar-focus-outline: var(--brand-strong)"));
     assertTrue(nexusTheme.contains("--account-focus-ring-color: var(--brand)"));
+    assertTrue(nexusTheme.contains("--ink-4: #6c7279"));
+    assertTrue(nexusTheme.contains("--focus: var(--brand)"));
     assertTrue(nexusTheme.contains(":root[data-theme=\"nexus\"] .workspace-tab.is-active"));
     assertTrue(nexusTheme.contains(":root[data-theme=\"nexus\"] .global-component-search input"));
     assertTrue(nexusTheme.contains(

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseUiThemeContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseUiThemeContractTest.java
@@ -42,6 +42,14 @@ class BrowseUiThemeContractTest {
   }
 
   @Test
+  void topbarFocusOutlineComesFromTheSelectedTheme() throws IOException {
+    String stylesheet = resource("/META-INF/resources/browse/assets/browse.css");
+
+    assertTrue(stylesheet.contains("outline: 2px solid var(--topbar-focus-outline)"));
+    assertFalse(stylesheet.contains("outline: 2px solid #ffffff"));
+  }
+
+  @Test
   void indigoThemeImplementsTheCompleteSharedTokenContract() throws IOException {
     String defaultTheme = resource("/META-INF/resources/browse/assets/themes/default.css");
     String indigoTheme = resource("/META-INF/resources/browse/assets/themes/indigo.css");
@@ -109,13 +117,15 @@ class BrowseUiThemeContractTest {
     String nexusTheme = resource("/META-INF/resources/browse/assets/themes/nexus.css");
 
     assertTrue(nexusTheme.contains("color-scheme: light"));
-    assertTrue(nexusTheme.contains("--brand: #3f9665"));
+    assertTrue(nexusTheme.contains("--brand: #2f7650"));
+    assertTrue(nexusTheme.contains("--brand-strong: #286744"));
     assertTrue(nexusTheme.contains("--brand-bright: #70c795"));
     assertTrue(nexusTheme.contains("--accent: #2f6fa7"));
     assertTrue(nexusTheme.contains("--canvas: #f5f6f7"));
     assertTrue(nexusTheme.contains("--topbar: #ffffff"));
     assertTrue(nexusTheme.contains("--topbar-ink: #1f2226"));
     assertTrue(nexusTheme.contains("--topbar-selection: var(--brand)"));
+    assertTrue(nexusTheme.contains("--topbar-focus-outline: var(--brand-strong)"));
     assertTrue(nexusTheme.contains(":root[data-theme=\"nexus\"] .workspace-tab.is-active"));
     assertTrue(nexusTheme.contains(":root[data-theme=\"nexus\"] .global-component-search input"));
     assertTrue(nexusTheme.contains(

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseUiThemeContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseUiThemeContractTest.java
@@ -103,6 +103,22 @@ class BrowseUiThemeContractTest {
     assertEquals(customPropertyNames(defaultTheme), customPropertyNames(jfrogTheme));
   }
 
+  @Test
+  void nexusThemeImplementsTheCompleteSharedTokenContract() throws IOException {
+    String defaultTheme = resource("/META-INF/resources/browse/assets/themes/default.css");
+    String nexusTheme = resource("/META-INF/resources/browse/assets/themes/nexus.css");
+
+    assertTrue(nexusTheme.contains("color-scheme: light"));
+    assertTrue(nexusTheme.contains("--brand: #3f9665"));
+    assertTrue(nexusTheme.contains("--brand-bright: #70c795"));
+    assertTrue(nexusTheme.contains("--accent: #2f6fa7"));
+    assertTrue(nexusTheme.contains("--canvas: #f5f6f7"));
+    assertTrue(nexusTheme.contains("--topbar: #1b1d20"));
+    assertTrue(nexusTheme.contains(
+        "--account-avatar-background: linear-gradient(145deg, #4aa673, #2f6fa7)"));
+    assertEquals(customPropertyNames(defaultTheme), customPropertyNames(nexusTheme));
+  }
+
   private Set<String> customPropertyNames(String css) {
     Set<String> names = new HashSet<>();
     Matcher matcher = Pattern.compile("(--[a-z0-9-]+)\\s*:").matcher(css);

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseUiThemeContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseUiThemeContractTest.java
@@ -47,6 +47,8 @@ class BrowseUiThemeContractTest {
 
     assertTrue(stylesheet.contains("outline: 2px solid var(--topbar-focus-outline)"));
     assertFalse(stylesheet.contains("outline: 2px solid #ffffff"));
+    assertTrue(componentUsesToken(stylesheet, ".product-update-link", "--topbar-active"));
+    assertTrue(componentUsesToken(stylesheet, ".account-login-icon", "--topbar-active"));
   }
 
   @Test
@@ -126,6 +128,7 @@ class BrowseUiThemeContractTest {
     assertTrue(nexusTheme.contains("--topbar-ink: #1f2226"));
     assertTrue(nexusTheme.contains("--topbar-selection: var(--brand)"));
     assertTrue(nexusTheme.contains("--topbar-focus-outline: var(--brand-strong)"));
+    assertTrue(nexusTheme.contains("--account-focus-ring-color: var(--brand)"));
     assertTrue(nexusTheme.contains(":root[data-theme=\"nexus\"] .workspace-tab.is-active"));
     assertTrue(nexusTheme.contains(":root[data-theme=\"nexus\"] .global-component-search input"));
     assertTrue(nexusTheme.contains(
@@ -140,6 +143,11 @@ class BrowseUiThemeContractTest {
       names.add(matcher.group(1));
     }
     return names;
+  }
+
+  private boolean componentUsesToken(String css, String selector, String token) {
+    return Pattern.compile(Pattern.quote(selector) + "\\s*\\{[^}]*var\\("
+        + Pattern.quote(token) + "\\)", Pattern.DOTALL).matcher(css).find();
   }
 
   private String resource(String path) throws IOException {

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseUiThemeContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseUiThemeContractTest.java
@@ -115,6 +115,8 @@ class BrowseUiThemeContractTest {
     assertTrue(nexusTheme.contains("--canvas: #f5f6f7"));
     assertTrue(nexusTheme.contains("--topbar: #ffffff"));
     assertTrue(nexusTheme.contains("--topbar-ink: #1f2226"));
+    assertTrue(nexusTheme.contains("--topbar-selection: var(--brand)"));
+    assertTrue(nexusTheme.contains(":root[data-theme=\"nexus\"] .workspace-tab.is-active"));
     assertTrue(nexusTheme.contains(":root[data-theme=\"nexus\"] .global-component-search input"));
     assertTrue(nexusTheme.contains(
         "--account-avatar-background: linear-gradient(145deg, #4aa673, #2f6fa7)"));

--- a/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseUiThemeContractTest.java
+++ b/browse-ui/src/test/java/com/github/klboke/kkrepo/browse/ui/BrowseUiThemeContractTest.java
@@ -113,7 +113,9 @@ class BrowseUiThemeContractTest {
     assertTrue(nexusTheme.contains("--brand-bright: #70c795"));
     assertTrue(nexusTheme.contains("--accent: #2f6fa7"));
     assertTrue(nexusTheme.contains("--canvas: #f5f6f7"));
-    assertTrue(nexusTheme.contains("--topbar: #1b1d20"));
+    assertTrue(nexusTheme.contains("--topbar: #ffffff"));
+    assertTrue(nexusTheme.contains("--topbar-ink: #1f2226"));
+    assertTrue(nexusTheme.contains(":root[data-theme=\"nexus\"] .global-component-search input"));
     assertTrue(nexusTheme.contains(
         "--account-avatar-background: linear-gradient(145deg, #4aa673, #2f6fa7)"));
     assertEquals(customPropertyNames(defaultTheme), customPropertyNames(nexusTheme));

--- a/browse-ui/src/test/js/browse-layout-scroll.test.js
+++ b/browse-ui/src/test/js/browse-layout-scroll.test.js
@@ -20,7 +20,7 @@ test("keeps the expanded navigation inside the sidebar scroll container", () => 
 test("cache-busts the current Browse assets", () => {
   const html = readFileSync(resolve(browseRoot, "index.html"), "utf8");
 
-  assert.match(html, /browse\.css\?v=20260826-search-menu-4/);
+  assert.match(html, /browse\.css\?v=20260826-nexus-a11y-1/);
   assert.match(html, /browse\.js\?v=20260826-search-menu-3/);
 });
 

--- a/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/api/UiSettingsDao.java
+++ b/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/api/UiSettingsDao.java
@@ -12,6 +12,7 @@ public interface UiSettingsDao {
   String THEME_OCEAN = "ocean";
   String THEME_SUNSET = "sunset";
   String THEME_JFROG = "jfrog";
+  String THEME_NEXUS = "nexus";
   String DEFAULT_THEME = THEME_DEFAULT;
 
   static String normalizeDefaultLanguage(String defaultLanguage) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/settings/UiSettingsController.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/settings/UiSettingsController.java
@@ -25,7 +25,8 @@ public class UiSettingsController {
       UiSettingsDao.THEME_INDIGO,
       UiSettingsDao.THEME_OCEAN,
       UiSettingsDao.THEME_SUNSET,
-      UiSettingsDao.THEME_JFROG);
+      UiSettingsDao.THEME_JFROG,
+      UiSettingsDao.THEME_NEXUS);
 
   private final UiSettingsDao uiSettingsDao;
 

--- a/server/src/test/java/com/github/klboke/kkrepo/server/settings/UiSettingsControllerTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/settings/UiSettingsControllerTest.java
@@ -24,7 +24,7 @@ class UiSettingsControllerTest {
     assertEquals(Instant.EPOCH, view.updatedAt());
     assertEquals(java.util.List.of("browser", "zh-CN", "en"), view.supportedDefaultLanguages());
     assertEquals(
-        java.util.List.of("default", "indigo", "ocean", "sunset", "jfrog"),
+        java.util.List.of("default", "indigo", "ocean", "sunset", "jfrog", "nexus"),
         view.supportedDefaultThemes());
   }
 
@@ -73,7 +73,7 @@ class UiSettingsControllerTest {
         new RecordingUiSettingsDao(new UiSettingsRecord("browser", "default", null));
     UiSettingsController controller = new UiSettingsController(dao);
 
-    for (String theme : java.util.List.of("ocean", "sunset", "jfrog")) {
+    for (String theme : java.util.List.of("ocean", "sunset", "jfrog", "nexus")) {
       UiSettingsController.UiSettingsView view =
           controller.update(new UiSettingsController.UiSettingsCommand(null, theme));
 


### PR DESCRIPTION
## Summary

- add a complete Nexus-inspired CSS theme with a white application bar, green selection states, blue information accents, compact radii, and themed account identity
- adapt the shared topbar search, account controls, hover states, focus rings, and shadows for the light Nexus application bar
- register Nexus as an optional Admin UI theme while keeping the current kkRepo design as the product default
- cover theme loading, preview selection, server validation, and the complete shared CSS token contract

## Validation

- node --test src/test/js/*.test.js
- mvn -pl admin-ui,browse-ui test
- mvn -pl browse-ui test
- mvn -pl server -am -Dtest=UiSettingsControllerTest -Dsurefire.failIfNoSpecifiedTests=false test
- built the executable Spring Boot JAR and visually verified the white application bar, search control, Admin and Browse workspaces, and the account menu on the 18090 preview instance