### PR TITLE
Release kkRepo 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,42 @@
 
 All notable public changes to kkrepo are documented in this file.
 
-This project follows a pragmatic early-stage release process. Until a stable `1.0.0` release is announced, minor versions may include behavior changes, but releases should call out migration impact, compatibility changes, and operational notes.
+This project follows a pragmatic release process. Stable releases call out migration impact, compatibility changes, operational notes, and any known behavior changes in their release section.
+
+## 1.0.0 - 2026-08-27
+
+### Added
+
+- Nexus-compatible R / CRAN hosted, proxy, and group repositories with immutable source-package publication, deterministic indexes, snapshot-bound group resolution, migration, cleanup, security scanning, and real R client coverage. (#244)
+- Go hosted repositories with validated atomic `.mod`/`.info`/`.zip` publication, write policies, component upload, migration, cleanup, scanning, and complete hosted/proxy group behavior. (#256)
+- Database-backed UI theme selection across Admin, Browse, and sign-in, including the original kkRepo design plus Indigo, Ocean, Sunset, JFrog-inspired, and Nexus-inspired themes, with safe fallback and unsaved Admin preview. (#245, #261, #264)
+- Nexus-compatible configurable remote index paths for PyPI proxy repositories, including explicit root-index support for upstreams such as PyTorch. (#257)
+
+### Changed
+
+- Repository request routing now uses a fail-closed protocol-handler SPI with deterministic route precedence, while existing protocol behavior remains behind a compatible built-in handler; security-scan persistence responsibilities were split into focused collaborators. (#246)
+- Browse upload forms are driven by repository capabilities, adding Raw directory, per-file name, and multi-file controls while retaining strict single-file behavior for NuGet and RubyGems. (#258)
+- Browse search navigation, format selection, side-panel scrolling, package-detail layout stability, and shared Admin/Browse scrollbar styling were refined without changing protocol routes. (#260, #263)
+- Quickstart defaults, Dockerfile packaging, deployment documentation, Helm application version, runtime checks, and the optional scanner profile now use `1.0.0`.
+- Spring Boot, Guava, the AWS SDK, zstd-jni, and GraalVM Native Build Tools were refreshed. (#247, #248, #249, #250, #251)
+
+### Fixed
+
+- Browse deletion now derives Maven release, snapshot, timestamped-snapshot, and version-level metadata coordinates correctly before enqueueing GA/GAV metadata rebuilds. (#241, #242)
+- PyPI hosted uploads accept metadata-heavy Twine multipart requests through a bounded, configurable Tomcat part-count limit. (#254)
+- MySQL component search no longer loses valid matches when coordinates include InnoDB default stopwords such as `com`. (#259)
+
+### Compatibility And Validation
+
+- R / CRAN includes MySQL/PostgreSQL V49 persistence contracts, multi-replica leases and recovery, Nexus 3.94 black-box comparison, R 4.5/4.6 client E2E, million-row indexed-plan gates, and measured HTTP/client performance checks. (#244)
+- Go hosted/group behavior is covered by official Go module validation, live Nexus comparison, real Go client publication/resolution/cleanup flows, multi-replica-safe database transactions, and bounded archive inspection. (#256)
+- PyPI index-path behavior and upload limits, Maven browse deletion, repository upload specs, theme persistence, and UI behavior include targeted compatibility, database, contract, and executable JavaScript coverage. (#241, #242, #245, #254, #257, #258, #259, #260, #261, #263, #264)
+
+### Upgrade Notes
+
+- Existing `0.9.0` MySQL and PostgreSQL deployments can upgrade in place through Flyway V49-V50. Back up the relational database and blob store together, allow migrations to complete before serving traffic, and do not run mixed application versions after the new schema is applied.
+- V49 adds R / CRAN package, publication, snapshot, group-binding, proxy, tombstone, migration, and lease state. V50 adds the shared default UI theme setting and preserves the existing kkRepo design for upgraded installations.
+- New R / CRAN repositories are not created automatically. Existing PyPI proxies retain `/simple` when no remote index path is configured, and existing Go proxy/group repositories keep their current behavior until a hosted member is explicitly created or added.
 
 ## 0.9.0 - 2026-08-20
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:25-jre-jammy
 
 WORKDIR /app
 
-ARG JAR_FILE=server/target/kkrepo-server-0.9.0.jar
+ARG JAR_FILE=server/target/kkrepo-server-1.0.0.jar
 
 RUN groupadd --system kkrepo \
     && useradd --system --gid kkrepo --home-dir /app --shell /usr/sbin/nologin kkrepo

--- a/deploy/helm/kkrepo/Chart.yaml
+++ b/deploy/helm/kkrepo/Chart.yaml
@@ -3,5 +3,5 @@ name: kkrepo
 description: Multi-replica kkRepo artifact repository with an external MySQL or PostgreSQL database
 type: application
 version: 0.2.0
-appVersion: "0.9.0"
+appVersion: "1.0.0"
 kubeVersion: ">=1.27.0-0"

--- a/docker-compose.quickstart-postgresql.yml
+++ b/docker-compose.quickstart-postgresql.yml
@@ -41,7 +41,7 @@ services:
     network_mode: none
 
   kkrepo:
-    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.9.0}
+    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-1.0.0}
     depends_on:
       postgresql:
         condition: service_healthy
@@ -75,7 +75,7 @@ services:
     restart: unless-stopped
 
   scanner:
-    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.9.0}
+    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-1.0.0}
     profiles: ["security-scanning"]
     environment:
       KKREPO_SCANNER_SERVICE_CREDENTIAL: ${KKREPO_SECURITY_SCANNING_SERVICE_CREDENTIAL:-}
@@ -105,7 +105,7 @@ services:
     restart: unless-stopped
 
   scanner-database-updater:
-    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.9.0}
+    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-1.0.0}
     profiles: ["security-scanning"]
     entrypoint: ["/bin/sh", "-ec"]
     command:

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -42,7 +42,7 @@ services:
     network_mode: none
 
   kkrepo:
-    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-0.9.0}
+    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-1.0.0}
     depends_on:
       mysql:
         condition: service_healthy
@@ -76,7 +76,7 @@ services:
     restart: unless-stopped
 
   scanner:
-    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.9.0}
+    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-1.0.0}
     profiles: ["security-scanning"]
     environment:
       KKREPO_SCANNER_SERVICE_CREDENTIAL: ${KKREPO_SECURITY_SCANNING_SERVICE_CREDENTIAL:-}
@@ -106,7 +106,7 @@ services:
     restart: unless-stopped
 
   scanner-database-updater:
-    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-0.9.0}
+    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-1.0.0}
     profiles: ["security-scanning"]
     entrypoint: ["/bin/sh", "-ec"]
     command:

--- a/docs/en/build-deployment-guide.md
+++ b/docs/en/build-deployment-guide.md
@@ -40,7 +40,7 @@ curl -fsSL https://raw.githubusercontent.com/klboke/kkrepo/main/scripts/quicksta
   | KKREPO_RUNTIME=native KKREPO_DATABASE_TYPE=postgresql bash
 ```
 
-`KKREPO_RUNTIME=jvm` selects `ghcr.io/klboke/kkrepo:0.9.0`, while `KKREPO_RUNTIME=native` selects `ghcr.io/klboke/kkrepo:0.9.0-native`. Both are published for Linux `amd64` and `arm64`. An explicit `KKREPO_IMAGE_TAG` overrides the runtime's default tag.
+`KKREPO_RUNTIME=jvm` selects `ghcr.io/klboke/kkrepo:1.0.0`, while `KKREPO_RUNTIME=native` selects `ghcr.io/klboke/kkrepo:1.0.0-native`. Both are published for Linux `amd64` and `arm64`. An explicit `KKREPO_IMAGE_TAG` overrides the runtime's default tag.
 
 The script prints each step and:
 
@@ -61,7 +61,7 @@ bash quickstart.sh
 
 By default, it starts:
 
-- The JVM runtime from `ghcr.io/klboke/kkrepo:0.9.0`
+- The JVM runtime from `ghcr.io/klboke/kkrepo:1.0.0`
 - MySQL 8.0
 - Persistent MySQL and File blob storage volumes for local trials
 
@@ -153,7 +153,7 @@ Note: a normal `server` module jar does not contain a Spring Boot executable ent
 Pull the latest public release image:
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:0.9.0
+docker pull ghcr.io/klboke/kkrepo:1.0.0
 ```
 
 You can also use `latest` to follow the latest public release:
@@ -165,7 +165,7 @@ docker pull ghcr.io/klboke/kkrepo:latest
 The Native image is published separately:
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:0.9.0-native
+docker pull ghcr.io/klboke/kkrepo:1.0.0-native
 docker pull ghcr.io/klboke/kkrepo:native-latest
 ```
 

--- a/docs/zh/build-deployment-guide.md
+++ b/docs/zh/build-deployment-guide.md
@@ -40,7 +40,7 @@ curl -fsSL https://raw.githubusercontent.com/klboke/kkrepo/main/scripts/quicksta
   | KKREPO_RUNTIME=native KKREPO_DATABASE_TYPE=postgresql bash
 ```
 
-`KKREPO_RUNTIME=jvm` 选择 `ghcr.io/klboke/kkrepo:0.9.0`，`KKREPO_RUNTIME=native` 选择 `ghcr.io/klboke/kkrepo:0.9.0-native`。两种镜像均发布 Linux `amd64` 和 `arm64` 架构。显式设置 `KKREPO_IMAGE_TAG` 时，会覆盖对应运行时的默认 tag。
+`KKREPO_RUNTIME=jvm` 选择 `ghcr.io/klboke/kkrepo:1.0.0`，`KKREPO_RUNTIME=native` 选择 `ghcr.io/klboke/kkrepo:1.0.0-native`。两种镜像均发布 Linux `amd64` 和 `arm64` 架构。显式设置 `KKREPO_IMAGE_TAG` 时，会覆盖对应运行时的默认 tag。
 
 该脚本会逐步打印日志并执行：
 
@@ -61,7 +61,7 @@ bash quickstart.sh
 
 默认会启动：
 
-- `ghcr.io/klboke/kkrepo:0.9.0` 中的 JVM 运行时
+- `ghcr.io/klboke/kkrepo:1.0.0` 中的 JVM 运行时
 - MySQL 8.0
 - 用于本地试用的持久化 MySQL volume 和 File blob storage volume
 
@@ -153,7 +153,7 @@ server/target/kkrepo-server-<version>.jar
 拉取最新公开发行镜像：
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:0.9.0
+docker pull ghcr.io/klboke/kkrepo:1.0.0
 ```
 
 也可以使用 `latest` 跟随最新公开发行版本：
@@ -165,7 +165,7 @@ docker pull ghcr.io/klboke/kkrepo:latest
 Native 镜像使用独立 tag：
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:0.9.0-native
+docker pull ghcr.io/klboke/kkrepo:1.0.0-native
 docker pull ghcr.io/klboke/kkrepo:native-latest
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
   </modules>
 
   <properties>
-    <revision>0.9.0</revision>
+    <revision>1.0.0</revision>
     <java.version>25</java.version>
     <spring.boot.version>4.1.1</spring.boot.version>
     <native-build-tools-plugin.version>1.1.10</native-build-tools-plugin.version>

--- a/scripts/ci/test-quickstart-runtime.sh
+++ b/scripts/ci/test-quickstart-runtime.sh
@@ -58,13 +58,13 @@ run_quickstart() {
 
 run_quickstart default-jvm
 grep -qx 'KKREPO_RUNTIME=jvm' "$TMP_ROOT/default-jvm/.env"
-grep -qx 'KKREPO_IMAGE_TAG=0.9.0' "$TMP_ROOT/default-jvm/.env"
-grep -qx 'jvm|0.9.0' "$TMP_ROOT/default-jvm.log"
+grep -qx 'KKREPO_IMAGE_TAG=1.0.0' "$TMP_ROOT/default-jvm/.env"
+grep -qx 'jvm|1.0.0' "$TMP_ROOT/default-jvm.log"
 
 run_quickstart native KKREPO_RUNTIME=native
 grep -qx 'KKREPO_RUNTIME=native' "$TMP_ROOT/native/.env"
-grep -qx 'KKREPO_IMAGE_TAG=0.9.0-native' "$TMP_ROOT/native/.env"
-grep -qx 'native|0.9.0-native' "$TMP_ROOT/native.log"
+grep -qx 'KKREPO_IMAGE_TAG=1.0.0-native' "$TMP_ROOT/native/.env"
+grep -qx 'native|1.0.0-native' "$TMP_ROOT/native.log"
 
 mkdir -p "$TMP_ROOT/existing-jvm"
 # Simulate a persisted v0.8.0 JVM quickstart before explicitly switching runtimes.
@@ -73,7 +73,7 @@ KKREPO_RUNTIME=jvm
 KKREPO_IMAGE_TAG=0.8.0
 EOF
 run_quickstart existing-jvm KKREPO_RUNTIME=native
-grep -qx 'native|0.9.0-native' "$TMP_ROOT/existing-jvm.log"
+grep -qx 'native|1.0.0-native' "$TMP_ROOT/existing-jvm.log"
 
 run_quickstart custom-native \
   KKREPO_RUNTIME=native \

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -186,10 +186,10 @@ fi
 KKREPO_RUNTIME="${KKREPO_RUNTIME:-jvm}"
 case "$KKREPO_RUNTIME" in
   jvm)
-    DEFAULT_IMAGE_TAG="0.9.0"
+    DEFAULT_IMAGE_TAG="1.0.0"
     ;;
   native)
-    DEFAULT_IMAGE_TAG="0.9.0-native"
+    DEFAULT_IMAGE_TAG="1.0.0-native"
     ;;
   *)
     fail "KKREPO_RUNTIME must be jvm or native, got: $KKREPO_RUNTIME"


### PR DESCRIPTION
## Summary

- release kkRepo 1.0.0 from the current `main` baseline
- update Maven, Docker, Helm, Quickstart JVM/Native/scanner defaults, runtime regression expectations, and bilingual deployment documentation
- document the 0.9.0-to-1.0.0 changes, compatibility evidence, and Flyway V49-V50 upgrade path

## Release highlights

- R / CRAN hosted, proxy, and group repositories
- Go hosted repositories and complete hosted/proxy group behavior
- database-backed UI themes, including Nexus-inspired styling and Admin preview
- configurable PyPI proxy remote index paths
- Maven snapshot deletion, Twine multipart upload, MySQL search, Browse upload, and UI fixes

## Validation

- `mvn -B -ntp -N validate`
- `helm lint deploy/helm/kkrepo`
- both Quickstart Compose files, with and without the `security-scanning` profile
- `bash scripts/ci/test-quickstart-runtime.sh`
- `bash scripts/ci/test-quickstart-data-permissions.sh`
- `bash scripts/ci/check-flyway-parity.sh`
- `bash scripts/ci/check-compose-scanner-isolation.sh`
- shell syntax checks and `git diff --check`

Flyway parity is verified at V50. The release is intended to pass the repository's label-gated Full E2E workflow before merge.
