### PR TITLE
[codex] Support ES256 OIDC tokens and improve PyPI diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           docker compose -f docker-compose.quickstart-postgresql.yml config
 
       - name: Run server tests
-        run: mvn -B -ntp -pl server,scanner-adapter -am -Dsurefire.failIfNoSpecifiedTests=false verify
+        run: mvn -B -ntp -T 4 -pl server,scanner-adapter -am '-Dsurefire.excludes=**/DatabaseServerSmokeTest.java' -Dsurefire.failIfNoSpecifiedTests=false verify
 
       - name: Run non-live compatibility tests
         run: mvn -B -ntp -pl compat-test -am -Dtest=MavenMetadataMergeCompatibilityTest,MavenWritePolicyCompatibilityTest,NpmProtocolCompatibilityTest -Dsurefire.failIfNoSpecifiedTests=false verify
@@ -108,6 +108,13 @@ jobs:
           java-version: "25"
           cache: maven
       - run: mvn -B -ntp -pl server -am -Dtest=DatabaseServerSmokeTest#${{ matrix.method }} -Dsurefire.failIfNoSpecifiedTests=false test
+      - name: Upload smoke coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          directory: .
+          fail_ci_if_error: true
+          flags: server-smoke-${{ matrix.database }}
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   mysql-v29-upgrade-compatibility:
     name: mysql-v29-upgrade-compatibility

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
           distribution: temurin
           java-version: "25"
           cache: maven
-      - run: mvn -B -ntp -pl server -am -Dtest=DatabaseServerSmokeTest#${{ matrix.method }} -Dsurefire.failIfNoSpecifiedTests=false test
+      - run: mvn -B -ntp -pl server -am -Dtest=DatabaseServerSmokeTest#${{ matrix.method }} -Dsurefire.failIfNoSpecifiedTests=false verify
       - name: Upload smoke coverage to Codecov
         uses: codecov/codecov-action@v7
         with:

--- a/server/src/main/java/com/github/klboke/kkrepo/server/pypi/PypiProxyService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/pypi/PypiProxyService.java
@@ -371,7 +371,7 @@ public class PypiProxyService {
     Optional<ProxyStateDao.ProxyRemoteState> state = proxyStateDao.loadState(runtime.id());
     if (state.isPresent()) {
       ProxyStateDao.ProxyRemoteState blocked = state.orElseThrow();
-      log.warn(
+      log.debug(
           "PyPI proxy request skipped while upstream is blocked: repository={} path={} "
               + "failCount={} blockedUntil={} lastFailureAt={} lastError={}",
           runtime.name(),
@@ -381,7 +381,7 @@ public class PypiProxyService {
           blocked.lastFailureAt(),
           proxyLogValue(blocked.lastError()));
     } else {
-      log.warn(
+      log.debug(
           "PyPI proxy request skipped while upstream is blocked: repository={} path={} state=unavailable",
           runtime.name(), proxyLogValue(path));
     }

--- a/server/src/main/java/com/github/klboke/kkrepo/server/pypi/PypiProxyService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/pypi/PypiProxyService.java
@@ -368,22 +368,24 @@ public class PypiProxyService {
 
   private PypiExceptions.BadUpstreamException temporarilyBlocked(
       RepositoryRuntime runtime, String path) {
-    Optional<ProxyStateDao.ProxyRemoteState> state = proxyStateDao.loadState(runtime.id());
-    if (state.isPresent()) {
-      ProxyStateDao.ProxyRemoteState blocked = state.orElseThrow();
-      log.debug(
-          "PyPI proxy request skipped while upstream is blocked: repository={} path={} "
-              + "failCount={} blockedUntil={} lastFailureAt={} lastError={}",
-          runtime.name(),
-          proxyLogValue(path),
-          blocked.failCount(),
-          blocked.blockedUntil(),
-          blocked.lastFailureAt(),
-          proxyLogValue(blocked.lastError()));
-    } else {
-      log.debug(
-          "PyPI proxy request skipped while upstream is blocked: repository={} path={} state=unavailable",
-          runtime.name(), proxyLogValue(path));
+    if (log.isDebugEnabled()) {
+      Optional<ProxyStateDao.ProxyRemoteState> state = proxyStateDao.loadState(runtime.id());
+      if (state.isPresent()) {
+        ProxyStateDao.ProxyRemoteState blocked = state.orElseThrow();
+        log.debug(
+            "PyPI proxy request skipped while upstream is blocked: repository={} path={} "
+                + "failCount={} blockedUntil={} lastFailureAt={} lastError={}",
+            runtime.name(),
+            proxyLogValue(path),
+            blocked.failCount(),
+            blocked.blockedUntil(),
+            blocked.lastFailureAt(),
+            proxyLogValue(blocked.lastError()));
+      } else {
+        log.debug(
+            "PyPI proxy request skipped while upstream is blocked: repository={} path={} state=unavailable",
+            runtime.name(), proxyLogValue(path));
+      }
     }
     return new PypiExceptions.BadUpstreamException(
         "Upstream temporarily blocked: " + runtime.proxyRemoteUrl());

--- a/server/src/main/java/com/github/klboke/kkrepo/server/pypi/PypiProxyService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/pypi/PypiProxyService.java
@@ -25,10 +25,13 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 @Service
 public class PypiProxyService {
+  private static final Logger log = LoggerFactory.getLogger(PypiProxyService.class);
   private static final long[] BACKOFF_SECONDS = {30, 60, 120, 300, 600, 1800};
 
   private final AssetDao assetDao;
@@ -88,7 +91,7 @@ public class PypiProxyService {
     }
     if (proxyStateDao.isBlocked(runtime.id(), now)) {
       if (cached.isPresent()) return reader.serveSnapshot(cached.get(), headOnly, path);
-      throw new PypiExceptions.BadUpstreamException("Upstream temporarily blocked: " + runtime.proxyRemoteUrl());
+      throw temporarilyBlocked(runtime, path);
     }
 
     String projectName = PypiPaths.packageNameFromPath(path);
@@ -126,7 +129,7 @@ public class PypiProxyService {
     }
     if (proxyStateDao.isBlocked(runtime.id(), now)) {
       if (cached.isPresent()) return reader.serveSnapshot(cached.get(), headOnly, path);
-      throw new PypiExceptions.BadUpstreamException("Upstream temporarily blocked: " + runtime.proxyRemoteUrl());
+      throw temporarilyBlocked(runtime, path);
     }
 
     String url = upstreamIndexUrl(runtime, projectName);
@@ -355,9 +358,41 @@ public class PypiProxyService {
     long block = runtime.autoBlockOrDefault()
         ? BACKOFF_SECONDS[Math.min(failCount, BACKOFF_SECONDS.length - 1)]
         : 0;
+    log.warn(
+        "PyPI proxy upstream request failed: repository={} path={} failCount={} blockSeconds={} error={}",
+        runtime.name(), proxyLogValue(path), failCount + 1, block, proxyLogValue(error));
     proxyStateDao.recordFailure(runtime.id(), block, error, now);
     if (cached.isPresent()) return reader.serveSnapshot(cached.get(), headOnly, path);
     throw new PypiExceptions.BadUpstreamException(error);
+  }
+
+  private PypiExceptions.BadUpstreamException temporarilyBlocked(
+      RepositoryRuntime runtime, String path) {
+    Optional<ProxyStateDao.ProxyRemoteState> state = proxyStateDao.loadState(runtime.id());
+    if (state.isPresent()) {
+      ProxyStateDao.ProxyRemoteState blocked = state.orElseThrow();
+      log.warn(
+          "PyPI proxy request skipped while upstream is blocked: repository={} path={} "
+              + "failCount={} blockedUntil={} lastFailureAt={} lastError={}",
+          runtime.name(),
+          proxyLogValue(path),
+          blocked.failCount(),
+          blocked.blockedUntil(),
+          blocked.lastFailureAt(),
+          proxyLogValue(blocked.lastError()));
+    } else {
+      log.warn(
+          "PyPI proxy request skipped while upstream is blocked: repository={} path={} state=unavailable",
+          runtime.name(), proxyLogValue(path));
+    }
+    return new PypiExceptions.BadUpstreamException(
+        "Upstream temporarily blocked: " + runtime.proxyRemoteUrl());
+  }
+
+  private static String proxyLogValue(String value) {
+    if (value == null || value.isBlank()) return "-";
+    String normalized = value.replaceAll("[\\p{Cntrl}]", " ");
+    return normalized.length() <= 1024 ? normalized : normalized.substring(0, 1024);
   }
 
   private boolean isFresh(

--- a/server/src/main/java/com/github/klboke/kkrepo/server/security/SecurityAuthenticationService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/security/SecurityAuthenticationService.java
@@ -901,7 +901,7 @@ public class SecurityAuthenticationService {
           roles,
           claims));
     } catch (SecurityValidationException e) {
-      log.warn(
+      log.debug(
           "OIDC token validation rejected: realm={} alg={} kid={} reason={}",
           realm.realmId(), oidcLogValue(alg), oidcLogValue(kid), oidcLogValue(e.getMessage()));
       return Optional.empty();

--- a/server/src/main/java/com/github/klboke/kkrepo/server/security/SecurityAuthenticationService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/security/SecurityAuthenticationService.java
@@ -16,9 +16,14 @@ import jakarta.servlet.http.HttpSession;
 import java.io.Serializable;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.security.AlgorithmParameters;
 import java.security.KeyFactory;
+import java.security.PublicKey;
 import java.security.Signature;
-import java.security.interfaces.RSAPublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.security.spec.ECPublicKeySpec;
 import java.security.spec.RSAPublicKeySpec;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -44,6 +49,8 @@ import javax.naming.directory.Attributes;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
 import javax.naming.ldap.InitialLdapContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.session.FindByIndexNameSessionRepository;
@@ -55,6 +62,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
 public class SecurityAuthenticationService {
+  private static final Logger log = LoggerFactory.getLogger(SecurityAuthenticationService.class);
   private static final String DEFAULT_SOURCE = "Local";
   private static final String DEFAULT_ANONYMOUS_USER_ID = "anonymous";
   private static final String DEFAULT_ANONYMOUS_REALM_NAME = "NexusAuthorizingRealm";
@@ -839,20 +847,32 @@ public class SecurityAuthenticationService {
   }
 
   private Optional<OidcProfile> validateOidcToken(SecurityRealmRecord realm, String token) {
+    String alg = null;
+    String kid = null;
     try {
       String[] parts = token.split("\\.", -1);
       Map<String, Object> header = readJwtJson(parts[0]);
       Map<String, Object> claims = readJwtJson(parts[1]);
-      String alg = asString(header.get("alg"));
+      alg = asString(header.get("alg"));
+      kid = asString(header.get("kid"));
       if (alg == null || "none".equalsIgnoreCase(alg)) {
+        log.debug(
+            "OIDC token validation rejected: realm={} alg={} kid={} reason=missing or unsigned algorithm",
+            realm.realmId(), oidcLogValue(alg), oidcLogValue(kid));
         return Optional.empty();
       }
       Map<String, Object> config = attributes(realm);
-      RSAPublicKey key = oidcSigningKey(config, asString(header.get("kid")));
+      PublicKey key = oidcSigningKey(config, kid, alg);
       if (!verifyJwt(parts, alg, key)) {
+        log.debug(
+            "OIDC token validation rejected: realm={} alg={} kid={} reason=signature verification failed",
+            realm.realmId(), oidcLogValue(alg), oidcLogValue(kid));
         return Optional.empty();
       }
       if (!validClaims(config, claims)) {
+        log.debug(
+            "OIDC token validation rejected: realm={} alg={} kid={} reason=claims validation failed",
+            realm.realmId(), oidcLogValue(alg), oidcLogValue(kid));
         return Optional.empty();
       }
       String userId = claimString(claims, defaultString(stringConfig(config, "userIdClaim", "usernameClaim"), "preferred_username"));
@@ -860,6 +880,9 @@ public class SecurityAuthenticationService {
         userId = claimString(claims, "sub");
       }
       if (userId == null) {
+        log.debug(
+            "OIDC token validation rejected: realm={} alg={} kid={} reason=user identifier claim is missing",
+            realm.realmId(), oidcLogValue(alg), oidcLogValue(kid));
         return Optional.empty();
       }
       Set<String> roles = new LinkedHashSet<>();
@@ -877,7 +900,19 @@ public class SecurityAuthenticationService {
           claimString(claims, "sub"),
           roles,
           claims));
+    } catch (SecurityValidationException e) {
+      log.warn(
+          "OIDC token validation rejected: realm={} alg={} kid={} reason={}",
+          realm.realmId(), oidcLogValue(alg), oidcLogValue(kid), oidcLogValue(e.getMessage()));
+      return Optional.empty();
     } catch (Exception e) {
+      log.debug(
+          "OIDC token validation failed: realm={} alg={} kid={} cause={} reason={}",
+          realm.realmId(),
+          oidcLogValue(alg),
+          oidcLogValue(kid),
+          e.getClass().getSimpleName(),
+          oidcLogValue(e.getMessage()));
       return Optional.empty();
     }
   }
@@ -887,11 +922,15 @@ public class SecurityAuthenticationService {
     return objectMapper.readValue(decoded, JSON_MAP);
   }
 
-  private boolean verifyJwt(String[] parts, String alg, RSAPublicKey key) throws Exception {
+  private boolean verifyJwt(String[] parts, String alg, PublicKey key) throws Exception {
+    byte[] signature = Base64.getUrlDecoder().decode(parts[2]);
+    if ("ES256".equals(alg) && signature.length != 64) {
+      return false;
+    }
     Signature verifier = Signature.getInstance(signatureAlgorithm(alg));
     verifier.initVerify(key);
     verifier.update((parts[0] + "." + parts[1]).getBytes(StandardCharsets.US_ASCII));
-    return verifier.verify(Base64.getUrlDecoder().decode(parts[2]));
+    return verifier.verify(signature);
   }
 
   private String signatureAlgorithm(String alg) {
@@ -899,12 +938,15 @@ public class SecurityAuthenticationService {
       case "RS256" -> "SHA256withRSA";
       case "RS384" -> "SHA384withRSA";
       case "RS512" -> "SHA512withRSA";
+      case "ES256" -> "SHA256withECDSAinP1363Format";
       default -> throw new SecurityValidationException("Unsupported OIDC JWT alg: " + alg);
     };
   }
 
   @SuppressWarnings("unchecked")
-  private RSAPublicKey oidcSigningKey(Map<String, Object> config, String kid) throws Exception {
+  private PublicKey oidcSigningKey(Map<String, Object> config, String kid, String alg) throws Exception {
+    String expectedKeyType = expectedJwkKeyType(alg);
+    String expectedCurve = expectedJwkCurve(alg);
     String jwksUri = required(config, "jwksUri", "jwks_url", "jwkSetUri");
     long cacheSeconds = intConfig(config, 300, "jwksCacheSeconds");
     Map<String, Object> jwks = sharedCache == null
@@ -938,18 +980,86 @@ public class SecurityAuthenticationService {
         continue;
       }
       Map<String, Object> key = (Map<String, Object>) rawKey;
-      if (!"RSA".equals(asString(key.get("kty")))) {
+      if (!expectedKeyType.equals(asString(key.get("kty")))) {
         continue;
       }
       String keyId = asString(key.get("kid"));
       if (kid != null && !kid.equals(keyId)) {
         continue;
       }
-      BigInteger modulus = new BigInteger(1, Base64.getUrlDecoder().decode(asString(key.get("n"))));
-      BigInteger exponent = new BigInteger(1, Base64.getUrlDecoder().decode(asString(key.get("e"))));
-      return (RSAPublicKey) KeyFactory.getInstance("RSA").generatePublic(new RSAPublicKeySpec(modulus, exponent));
+      String keyAlgorithm = asString(key.get("alg"));
+      if (keyAlgorithm != null && !alg.equals(keyAlgorithm)) {
+        continue;
+      }
+      String use = asString(key.get("use"));
+      if (use != null && !"sig".equals(use)) {
+        continue;
+      }
+      if (expectedCurve != null && !expectedCurve.equals(asString(key.get("crv")))) {
+        continue;
+      }
+      try {
+        return "RSA".equals(expectedKeyType)
+            ? rsaPublicKey(key)
+            : ecPublicKey(key, alg);
+      } catch (Exception e) {
+        throw new SecurityValidationException(
+            "OIDC signing key is invalid for kid: " + kid, e);
+      }
     }
-    throw new SecurityValidationException("OIDC signing key not found for kid: " + kid);
+    throw new SecurityValidationException(
+        "OIDC signing key not found for kid " + kid + " and alg " + alg);
+  }
+
+  private PublicKey rsaPublicKey(Map<String, Object> key) throws Exception {
+    BigInteger modulus = unsignedJwkInteger(key, "n");
+    BigInteger exponent = unsignedJwkInteger(key, "e");
+    return KeyFactory.getInstance("RSA").generatePublic(new RSAPublicKeySpec(modulus, exponent));
+  }
+
+  private PublicKey ecPublicKey(Map<String, Object> key, String alg) throws Exception {
+    AlgorithmParameters parameters = AlgorithmParameters.getInstance("EC");
+    parameters.init(new ECGenParameterSpec(jcaCurveName(alg)));
+    ECParameterSpec curve = parameters.getParameterSpec(ECParameterSpec.class);
+    ECPoint point = new ECPoint(unsignedJwkInteger(key, "x"), unsignedJwkInteger(key, "y"));
+    return KeyFactory.getInstance("EC").generatePublic(new ECPublicKeySpec(point, curve));
+  }
+
+  private BigInteger unsignedJwkInteger(Map<String, Object> key, String name) {
+    String encoded = asString(key.get(name));
+    if (encoded == null || encoded.isBlank()) {
+      throw new SecurityValidationException("OIDC JWK is missing " + name);
+    }
+    return new BigInteger(1, Base64.getUrlDecoder().decode(encoded));
+  }
+
+  private String expectedJwkKeyType(String alg) {
+    return switch (alg) {
+      case "RS256", "RS384", "RS512" -> "RSA";
+      case "ES256" -> "EC";
+      default -> throw new SecurityValidationException("Unsupported OIDC JWT alg: " + alg);
+    };
+  }
+
+  private String expectedJwkCurve(String alg) {
+    return switch (alg) {
+      case "RS256", "RS384", "RS512" -> null;
+      case "ES256" -> "P-256";
+      default -> throw new SecurityValidationException("Unsupported OIDC JWT alg: " + alg);
+    };
+  }
+
+  private String jcaCurveName(String alg) {
+    return switch (alg) {
+      case "ES256" -> "secp256r1";
+      default -> throw new SecurityValidationException("Unsupported OIDC EC JWT alg: " + alg);
+    };
+  }
+
+  private static String oidcLogValue(String value) {
+    if (value == null || value.isBlank()) return "-";
+    String normalized = value.replaceAll("[\\p{Cntrl}]", " ");
+    return normalized.length() <= 256 ? normalized : normalized.substring(0, 256);
   }
 
   private boolean validClaims(Map<String, Object> config, Map<String, Object> claims) {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/architecture/RepositoryRoutingArchitectureTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/architecture/RepositoryRoutingArchitectureTest.java
@@ -5,6 +5,7 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
 import com.github.klboke.kkrepo.server.RepositoryProtocolController;
 import com.github.klboke.kkrepo.server.routing.RepositoryProtocolHandler;
+import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.lang.ArchRule;
@@ -12,6 +13,9 @@ import org.junit.jupiter.api.Test;
 
 class RepositoryRoutingArchitectureTest {
   private static final String ROOT = "com.github.klboke.kkrepo";
+  private static final JavaClasses ALL_PROJECT_CLASSES = new ClassFileImporter()
+      .withImportOption(new ImportOption.DoNotIncludeTests())
+      .importPackages(ROOT);
 
   @Test
   void repositoryProtocolControllerDependsOnlyOnTheRoutingBoundary() {
@@ -24,7 +28,7 @@ class RepositoryRoutingArchitectureTest {
             "com.github.klboke.kkrepo.server",
             "com.github.klboke.kkrepo.server.routing");
 
-    rule.check(serverClasses());
+    rule.check(ALL_PROJECT_CLASSES);
   }
 
   @Test
@@ -55,7 +59,7 @@ class RepositoryRoutingArchitectureTest {
             "..server.yum..")
         .should().dependOnClassesThat().resideInAnyPackage("..server.routing..");
 
-    rule.check(serverClasses());
+    rule.check(ALL_PROJECT_CLASSES);
   }
 
   @Test
@@ -64,7 +68,7 @@ class RepositoryRoutingArchitectureTest {
         .that().resideInAnyPackage("..protocol..")
         .should().dependOnClassesThat().resideInAnyPackage("..server..");
 
-    rule.check(allProjectClasses());
+    rule.check(ALL_PROJECT_CLASSES);
   }
 
   @Test
@@ -73,18 +77,6 @@ class RepositoryRoutingArchitectureTest {
         .that().implement(RepositoryProtocolHandler.class)
         .should().resideInAPackage("..server.routing..");
 
-    rule.check(serverClasses());
-  }
-
-  private static com.tngtech.archunit.core.domain.JavaClasses serverClasses() {
-    return new ClassFileImporter()
-        .withImportOption(new ImportOption.DoNotIncludeTests())
-        .importPackages(ROOT + ".server");
-  }
-
-  private static com.tngtech.archunit.core.domain.JavaClasses allProjectClasses() {
-    return new ClassFileImporter()
-        .withImportOption(new ImportOption.DoNotIncludeTests())
-        .importPackages(ROOT);
+    rule.check(ALL_PROJECT_CLASSES);
   }
 }

--- a/server/src/test/java/com/github/klboke/kkrepo/server/config/DatabaseServerSmokeTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/config/DatabaseServerSmokeTest.java
@@ -60,12 +60,14 @@ class DatabaseServerSmokeTest {
   private static final MySQLContainer MYSQL = new MySQLContainer("mysql:8.0")
       .withDatabaseName("kkrepo")
       .withUsername("kkrepo")
-      .withPassword("kkrepo");
+      .withPassword("kkrepo")
+      .withTmpFs(Map.of("/var/lib/mysql", "rw"));
   private static final PostgreSQLContainer POSTGRESQL = new PostgreSQLContainer(
       System.getProperty("kkrepo.test.postgresql.image", "postgres:12"))
       .withDatabaseName("kkrepo")
       .withUsername("kkrepo")
-      .withPassword("kkrepo");
+      .withPassword("kkrepo")
+      .withTmpFs(Map.of("/var/lib/postgresql/data", "rw"));
 
   @AfterAll
   static void stopDatabases() {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiProxyServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiProxyServiceTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
@@ -80,7 +81,7 @@ class PypiProxyServiceTest {
             null,
             now,
             "Upstream IO error:\nconnection reset")));
-    ListAppender<ILoggingEvent> appender = attachAppender();
+    LogCapture capture = attachAppender();
 
     try {
       PypiExceptions.BadUpstreamException failure = assertThrows(
@@ -88,11 +89,12 @@ class PypiProxyServiceTest {
           () -> fixture.service.getIndex(runtime, "certifi", false));
       assertTrue(failure.getMessage().contains("Upstream temporarily blocked"));
     } finally {
-      detachAppender(appender);
+      detachAppender(capture);
     }
 
-    assertEquals(1, appender.list.size());
-    String message = appender.list.get(0).getFormattedMessage();
+    assertEquals(1, capture.appender().list.size());
+    assertEquals(Level.DEBUG, capture.appender().list.get(0).getLevel());
+    String message = capture.appender().list.get(0).getFormattedMessage();
     assertTrue(message.contains("repository=pypi"));
     assertTrue(message.contains("path=simple/certifi/"));
     assertTrue(message.contains("failCount=4"));
@@ -109,18 +111,19 @@ class PypiProxyServiceTest {
         .thenReturn(Optional.empty());
     when(fixture.proxyStateDao.isBlocked(eq(10L), any())).thenReturn(true);
     when(fixture.proxyStateDao.loadState(10L)).thenReturn(Optional.empty());
-    ListAppender<ILoggingEvent> appender = attachAppender();
+    LogCapture capture = attachAppender();
 
     try {
       assertThrows(
           PypiExceptions.BadUpstreamException.class,
           () -> fixture.service.getIndex(runtime, "certifi", false));
     } finally {
-      detachAppender(appender);
+      detachAppender(capture);
     }
 
-    assertEquals(1, appender.list.size());
-    assertTrue(appender.list.get(0).getFormattedMessage().contains("state=unavailable"));
+    assertEquals(1, capture.appender().list.size());
+    assertEquals(Level.DEBUG, capture.appender().list.get(0).getLevel());
+    assertTrue(capture.appender().list.get(0).getFormattedMessage().contains("state=unavailable"));
   }
 
   @Test
@@ -335,18 +338,22 @@ class PypiProxyServiceTest {
     }).when(fetcher).fetchWithBodyRetry(any(), anyString(), any());
   }
 
-  private static ListAppender<ILoggingEvent> attachAppender() {
+  private static LogCapture attachAppender() {
     Logger logger = (Logger) LoggerFactory.getLogger(PypiProxyService.class);
+    Level priorLevel = logger.getLevel();
+    logger.setLevel(Level.DEBUG);
     ListAppender<ILoggingEvent> appender = new ListAppender<>();
     appender.start();
     logger.addAppender(appender);
-    return appender;
+    return new LogCapture(logger, priorLevel, appender);
   }
 
-  private static void detachAppender(ListAppender<ILoggingEvent> appender) {
-    Logger logger = (Logger) LoggerFactory.getLogger(PypiProxyService.class);
-    logger.detachAppender(appender);
+  private static void detachAppender(LogCapture capture) {
+    capture.logger().detachAppender(capture.appender());
+    capture.logger().setLevel(capture.priorLevel());
   }
+
+  private record LogCapture(Logger logger, Level priorLevel, ListAppender<ILoggingEvent> appender) {}
 
   private static Fixture fixture() {
     AssetDao assetDao = mock(AssetDao.class);

--- a/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiProxyServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiProxyServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -124,6 +125,28 @@ class PypiProxyServiceTest {
     assertEquals(1, capture.appender().list.size());
     assertEquals(Level.DEBUG, capture.appender().list.get(0).getLevel());
     assertTrue(capture.appender().list.get(0).getFormattedMessage().contains("state=unavailable"));
+  }
+
+  @Test
+  void blockedCacheMissDoesNotLoadDiagnosticStateWhenDebugLoggingIsDisabled() {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(1, 7L);
+    when(fixture.cache.find(eq(10L), eq("simple/certifi/"), any()))
+        .thenReturn(Optional.empty());
+    when(fixture.proxyStateDao.isBlocked(eq(10L), any())).thenReturn(true);
+    Logger logger = (Logger) LoggerFactory.getLogger(PypiProxyService.class);
+    Level priorLevel = logger.getLevel();
+    logger.setLevel(Level.INFO);
+
+    try {
+      assertThrows(
+          PypiExceptions.BadUpstreamException.class,
+          () -> fixture.service.getIndex(runtime, "certifi", false));
+    } finally {
+      logger.setLevel(priorLevel);
+    }
+
+    verify(fixture.proxyStateDao, never()).loadState(anyLong());
   }
 
   @Test

--- a/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiProxyServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiProxyServiceTest.java
@@ -1,6 +1,7 @@
 package com.github.klboke.kkrepo.server.pypi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -14,6 +15,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.github.klboke.kkrepo.core.BlobStorage;
 import com.github.klboke.kkrepo.core.RepositoryFormat;
 import com.github.klboke.kkrepo.core.RepositoryType;
@@ -36,6 +40,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 class PypiProxyServiceTest {
   @Test
@@ -57,6 +62,65 @@ class PypiProxyServiceTest {
     when(fixture.proxyStateDao.isBlocked(eq(10L), any())).thenReturn(true);
     when(fixture.reader.serveSnapshot(stale, false, "simple/demo/")).thenReturn(expected);
     assertSame(expected, fixture.service.getIndex(runtime(1, 7L), "demo", false));
+  }
+
+  @Test
+  void blockedCacheMissLogsStoredUpstreamFailure() throws Exception {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(1, 7L);
+    Instant now = Instant.now();
+    when(fixture.cache.find(eq(10L), eq("simple/certifi/"), any()))
+        .thenReturn(Optional.empty());
+    when(fixture.proxyStateDao.isBlocked(eq(10L), any())).thenReturn(true);
+    when(fixture.proxyStateDao.loadState(10L)).thenReturn(Optional.of(
+        new ProxyStateDao.ProxyRemoteState(
+            10L,
+            now.plusSeconds(300),
+            4,
+            null,
+            now,
+            "Upstream IO error:\nconnection reset")));
+    ListAppender<ILoggingEvent> appender = attachAppender();
+
+    try {
+      PypiExceptions.BadUpstreamException failure = assertThrows(
+          PypiExceptions.BadUpstreamException.class,
+          () -> fixture.service.getIndex(runtime, "certifi", false));
+      assertTrue(failure.getMessage().contains("Upstream temporarily blocked"));
+    } finally {
+      detachAppender(appender);
+    }
+
+    assertEquals(1, appender.list.size());
+    String message = appender.list.get(0).getFormattedMessage();
+    assertTrue(message.contains("repository=pypi"));
+    assertTrue(message.contains("path=simple/certifi/"));
+    assertTrue(message.contains("failCount=4"));
+    assertTrue(message.contains("lastError=Upstream IO error: connection reset"));
+    assertFalse(message.contains("\n"));
+    verify(fixture.fetcher, never()).fetchWithBodyRetry(any(), anyString(), any());
+  }
+
+  @Test
+  void blockedCacheMissLogsWhenSharedStateDisappearsConcurrently() {
+    Fixture fixture = fixture();
+    RepositoryRuntime runtime = runtime(1, 7L);
+    when(fixture.cache.find(eq(10L), eq("simple/certifi/"), any()))
+        .thenReturn(Optional.empty());
+    when(fixture.proxyStateDao.isBlocked(eq(10L), any())).thenReturn(true);
+    when(fixture.proxyStateDao.loadState(10L)).thenReturn(Optional.empty());
+    ListAppender<ILoggingEvent> appender = attachAppender();
+
+    try {
+      assertThrows(
+          PypiExceptions.BadUpstreamException.class,
+          () -> fixture.service.getIndex(runtime, "certifi", false));
+    } finally {
+      detachAppender(appender);
+    }
+
+    assertEquals(1, appender.list.size());
+    assertTrue(appender.list.get(0).getFormattedMessage().contains("state=unavailable"));
   }
 
   @Test
@@ -269,6 +333,19 @@ class PypiProxyServiceTest {
       HttpRemoteFetcher.ResultHandler<PypiResponse> handler = invocation.getArgument(2);
       return handler.handle(result);
     }).when(fetcher).fetchWithBodyRetry(any(), anyString(), any());
+  }
+
+  private static ListAppender<ILoggingEvent> attachAppender() {
+    Logger logger = (Logger) LoggerFactory.getLogger(PypiProxyService.class);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+    return appender;
+  }
+
+  private static void detachAppender(ListAppender<ILoggingEvent> appender) {
+    Logger logger = (Logger) LoggerFactory.getLogger(PypiProxyService.class);
+    logger.detachAppender(appender);
   }
 
   private static Fixture fixture() {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiProxyServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/pypi/PypiProxyServiceTest.java
@@ -131,7 +131,7 @@ class PypiProxyServiceTest {
   void blockedCacheMissDoesNotLoadDiagnosticStateWhenDebugLoggingIsDisabled() {
     Fixture fixture = fixture();
     RepositoryRuntime runtime = runtime(1, 7L);
-    when(fixture.cache.find(eq(10L), eq("simple/certifi/"), any()))
+    when(fixture.cache.find(eq(10L), eq("packages/certifi.whl"), any()))
         .thenReturn(Optional.empty());
     when(fixture.proxyStateDao.isBlocked(eq(10L), any())).thenReturn(true);
     Logger logger = (Logger) LoggerFactory.getLogger(PypiProxyService.class);
@@ -141,7 +141,7 @@ class PypiProxyServiceTest {
     try {
       assertThrows(
           PypiExceptions.BadUpstreamException.class,
-          () -> fixture.service.getIndex(runtime, "certifi", false));
+          () -> fixture.service.getPackage(runtime, "packages/certifi.whl", false));
     } finally {
       logger.setLevel(priorLevel);
     }

--- a/server/src/test/java/com/github/klboke/kkrepo/server/security/SecurityAuthenticationServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/security/SecurityAuthenticationServiceTest.java
@@ -800,6 +800,121 @@ class SecurityAuthenticationServiceTest {
   }
 
   @Test
+  void logsOidcRejectionReasonsForUnsignedInvalidClaimsMissingUserAndMalformedTokens()
+      throws Exception {
+    KeyPair keyPair = rsaKeyPair();
+    String kid = "validation-key";
+    HttpServer jwks = jwksServer(jwksJson(keyPair, kid));
+    jwks.start();
+    try {
+      FakeSecurityDao dao = new FakeSecurityDao();
+      dao.realm(new SecurityRealmRecord(
+          1L,
+          "oidc",
+          "OIDC",
+          "OIDC",
+          true,
+          0,
+          Map.of(
+              "source", "OIDC",
+              "issuer", "https://issuer.example.com",
+              "audience", "kkrepo",
+              "jwksUri", "http://127.0.0.1:" + jwks.getAddress().getPort() + "/jwks")));
+      SecurityAuthenticationService service = service(dao);
+      String unsigned = jwt(
+          "{\"alg\":\"none\",\"kid\":\"unsigned-key\"}",
+          "{\"sub\":\"sensitive-unsigned-user\"}",
+          "sensitive-unsigned-signature");
+      String expired = signedJwt(
+          keyPair,
+          kid,
+          Map.of(
+              "iss", "https://issuer.example.com",
+              "aud", List.of("kkrepo"),
+              "sub", "expired-user",
+              "exp", 1));
+      String missingUser = signedJwt(
+          keyPair,
+          kid,
+          Map.of(
+              "iss", "https://issuer.example.com",
+              "aud", List.of("kkrepo"),
+              "exp", Instant.now().plusSeconds(300).getEpochSecond()));
+      LogCapture capture = attachAuthenticationAppender();
+
+      try {
+        assertFalse(service.authenticate(request(Map.of(
+            "Authorization", "Bearer " + unsigned))).isPresent());
+        assertFalse(service.authenticate(request(Map.of(
+            "Authorization", "Bearer " + expired))).isPresent());
+        assertFalse(service.authenticate(request(Map.of(
+            "Authorization", "Bearer " + missingUser))).isPresent());
+        assertFalse(service.authenticate(request(Map.of(
+            "Authorization", "Bearer not-a-jwt.payload.signature"))).isPresent());
+      } finally {
+        detachAuthenticationAppender(capture);
+      }
+
+      List<String> messages = capture.appender().list.stream()
+          .map(ILoggingEvent::getFormattedMessage)
+          .toList();
+      assertEquals(4, messages.size());
+      assertTrue(messages.stream().anyMatch(message ->
+          message.contains("reason=missing or unsigned algorithm")));
+      assertTrue(messages.stream().anyMatch(message ->
+          message.contains("reason=claims validation failed")));
+      assertTrue(messages.stream().anyMatch(message ->
+          message.contains("reason=user identifier claim is missing")));
+      assertTrue(messages.stream().anyMatch(message ->
+          message.contains("OIDC token validation failed")
+              && message.contains("cause=")));
+      assertFalse(String.join("\n", messages).contains("sensitive-unsigned-user"));
+      assertFalse(String.join("\n", messages).contains("sensitive-unsigned-signature"));
+    } finally {
+      jwks.stop(0);
+    }
+  }
+
+  @Test
+  void rejectsMatchingEcJwkWhenRequiredCoordinateIsMissing() throws Exception {
+    String kid = "broken-ec";
+    String body = OBJECT_MAPPER.writeValueAsString(Map.of(
+        "keys",
+        List.of(Map.of(
+            "kty", "EC",
+            "kid", kid,
+            "alg", "ES256",
+            "use", "sig",
+            "crv", "P-256",
+            "y", "AQ"))));
+    HttpServer jwks = jwksServer(body);
+    jwks.start();
+    try {
+      FakeSecurityDao dao = new FakeSecurityDao();
+      dao.realm(new SecurityRealmRecord(
+          1L,
+          "oidc",
+          "OIDC",
+          "OIDC",
+          true,
+          0,
+          Map.of(
+              "source", "OIDC",
+              "jwksUri", "http://127.0.0.1:" + jwks.getAddress().getPort() + "/jwks")));
+      SecurityAuthenticationService service = service(dao);
+      String token = jwt(
+          "{\"alg\":\"ES256\",\"kid\":\"broken-ec\"}",
+          "{\"sub\":\"alice\",\"exp\":4102444800}",
+          "signature");
+
+      assertFalse(service.authenticate(request(Map.of(
+          "Authorization", "Bearer " + token))).isPresent());
+    } finally {
+      jwks.stop(0);
+    }
+  }
+
+  @Test
   void logsUnsupportedOidcAlgorithmWithoutTokenOrClaims() {
     FakeSecurityDao dao = new FakeSecurityDao();
     dao.realm(new SecurityRealmRecord(
@@ -1158,6 +1273,21 @@ class SecurityAuthenticationServiceTest {
                 "use", "sig",
                 "n", base64UrlUnsigned(rsaPublicKey.getModulus()),
                 "e", base64UrlUnsigned(rsaPublicKey.getPublicExponent())),
+            Map.of(
+                "kty", "EC",
+                "kid", ecKid,
+                "alg", "RS256"),
+            Map.of(
+                "kty", "EC",
+                "kid", ecKid,
+                "alg", "ES256",
+                "use", "enc"),
+            Map.of(
+                "kty", "EC",
+                "kid", ecKid,
+                "alg", "ES256",
+                "use", "sig",
+                "crv", "P-384"),
             Map.of(
                 "kty", "EC",
                 "kid", ecKid,

--- a/server/src/test/java/com/github/klboke/kkrepo/server/security/SecurityAuthenticationServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/security/SecurityAuthenticationServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
@@ -808,17 +809,18 @@ class SecurityAuthenticationServiceTest {
         "{\"alg\":\"HS256\",\"kid\":\"unsupported-key\"}",
         "{\"sub\":\"sensitive-user\",\"exp\":4102444800}",
         "sensitive-signature");
-    ListAppender<ILoggingEvent> appender = attachAuthenticationAppender();
+    LogCapture capture = attachAuthenticationAppender();
 
     try {
       assertFalse(service.authenticate(request(Map.of(
           "Authorization", "Bearer " + token))).isPresent());
     } finally {
-      detachAuthenticationAppender(appender);
+      detachAuthenticationAppender(capture);
     }
 
-    assertEquals(1, appender.list.size());
-    String message = appender.list.get(0).getFormattedMessage();
+    assertEquals(1, capture.appender().list.size());
+    assertEquals(Level.DEBUG, capture.appender().list.get(0).getLevel());
+    String message = capture.appender().list.get(0).getFormattedMessage();
     assertTrue(message.contains("alg=HS256"));
     assertTrue(message.contains("kid=unsupported-key"));
     assertTrue(message.contains("Unsupported OIDC JWT alg: HS256"));
@@ -1205,18 +1207,22 @@ class SecurityAuthenticationServiceTest {
     return base64Url(fixed);
   }
 
-  private static ListAppender<ILoggingEvent> attachAuthenticationAppender() {
+  private static LogCapture attachAuthenticationAppender() {
     Logger logger = (Logger) LoggerFactory.getLogger(SecurityAuthenticationService.class);
+    Level priorLevel = logger.getLevel();
+    logger.setLevel(Level.DEBUG);
     ListAppender<ILoggingEvent> appender = new ListAppender<>();
     appender.start();
     logger.addAppender(appender);
-    return appender;
+    return new LogCapture(logger, priorLevel, appender);
   }
 
-  private static void detachAuthenticationAppender(ListAppender<ILoggingEvent> appender) {
-    Logger logger = (Logger) LoggerFactory.getLogger(SecurityAuthenticationService.class);
-    logger.detachAppender(appender);
+  private static void detachAuthenticationAppender(LogCapture capture) {
+    capture.logger().detachAppender(capture.appender());
+    capture.logger().setLevel(capture.priorLevel());
   }
+
+  private record LogCapture(Logger logger, Level priorLevel, ListAppender<ILoggingEvent> appender) {}
 
   private static String base64Url(byte[] bytes) {
     return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);

--- a/server/src/test/java/com/github/klboke/kkrepo/server/security/SecurityAuthenticationServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/security/SecurityAuthenticationServiceTest.java
@@ -6,6 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.klboke.kkrepo.persistence.jdbc.api.SecurityDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.ApiKeyRecord;
@@ -28,7 +31,9 @@ import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.Signature;
+import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
+import java.security.spec.ECGenParameterSpec;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -42,6 +47,7 @@ import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 import org.springframework.session.FindByIndexNameSessionRepository;
 import org.springframework.transaction.PlatformTransactionManager;
 
@@ -722,6 +728,105 @@ class SecurityAuthenticationServiceTest {
   }
 
   @Test
+  void authenticatesEs256OidcBearerJwtAgainstMatchingEcJwkAlongsideRsaKey() throws Exception {
+    KeyPair rsaKeyPair = rsaKeyPair();
+    KeyPair ecKeyPair = ecKeyPair("secp256r1");
+    String ecKid = "authelia-es256";
+    HttpServer jwks = jwksServer(mixedRsaAndEcJwksJson(
+        rsaKeyPair, "authelia-rsa256", ecKeyPair, ecKid));
+    jwks.start();
+    try {
+      FakeSecurityDao dao = new FakeSecurityDao();
+      dao.realm(new SecurityRealmRecord(
+          1L,
+          "oidc",
+          "OIDC",
+          "OIDC",
+          true,
+          0,
+          Map.of(
+              "source", "OIDC",
+              "issuer", "https://issuer.example.com",
+              "audience", "kkrepo",
+              "jwksUri", "http://jwks.rebind.invalid:" + jwks.getAddress().getPort() + "/jwks",
+              "userIdClaim", "preferred_username",
+              "groupsClaim", "groups")));
+      OutboundRequestPolicy pinnedPolicy = new OutboundRequestPolicy(
+          true,
+          "",
+          host -> new InetAddress[] {InetAddress.getByAddress(
+              host, new byte[] {127, 0, 0, 1})});
+      SecurityAuthenticationService service = service(dao, "nx-anonymous", pinnedPolicy);
+      String token = signedJwt(
+          ecKeyPair,
+          ecKid,
+          "ES256",
+          "SHA256withECDSAinP1363Format",
+          Map.of(
+              "iss", "https://issuer.example.com",
+              "aud", List.of("kkrepo"),
+              "sub", "subject-es256",
+              "preferred_username", "alice-es256",
+              "groups", List.of("admins"),
+              "exp", Instant.now().plusSeconds(300).getEpochSecond()));
+
+      Optional<AuthenticatedSubject> authenticated = service.authenticate(request(Map.of(
+          "Authorization", "Bearer " + token)));
+
+      assertTrue(authenticated.isPresent());
+      assertEquals("alice-es256", authenticated.get().userId());
+      assertTrue(authenticated.get().permissionSubject().groupIds().contains("admins"));
+      assertEquals(
+          "subject-es256",
+          dao.findUser("OIDC", "alice-es256").orElseThrow().externalId());
+
+      String derEncodedSignatureToken = signedJwt(
+          ecKeyPair,
+          ecKid,
+          "ES256",
+          "SHA256withECDSA",
+          Map.of(
+              "iss", "https://issuer.example.com",
+              "aud", List.of("kkrepo"),
+              "sub", "subject-invalid-signature-encoding",
+              "preferred_username", "invalid-signature-encoding",
+              "exp", Instant.now().plusSeconds(300).getEpochSecond()));
+      assertFalse(service.authenticate(request(Map.of(
+          "Authorization", "Bearer " + derEncodedSignatureToken))).isPresent());
+    } finally {
+      jwks.stop(0);
+    }
+  }
+
+  @Test
+  void logsUnsupportedOidcAlgorithmWithoutTokenOrClaims() {
+    FakeSecurityDao dao = new FakeSecurityDao();
+    dao.realm(new SecurityRealmRecord(
+        1L, "oidc", "OIDC", "OIDC", true, 0, Map.of("source", "OIDC")));
+    SecurityAuthenticationService service = service(dao);
+    String token = jwt(
+        "{\"alg\":\"HS256\",\"kid\":\"unsupported-key\"}",
+        "{\"sub\":\"sensitive-user\",\"exp\":4102444800}",
+        "sensitive-signature");
+    ListAppender<ILoggingEvent> appender = attachAuthenticationAppender();
+
+    try {
+      assertFalse(service.authenticate(request(Map.of(
+          "Authorization", "Bearer " + token))).isPresent());
+    } finally {
+      detachAuthenticationAppender(appender);
+    }
+
+    assertEquals(1, appender.list.size());
+    String message = appender.list.get(0).getFormattedMessage();
+    assertTrue(message.contains("alg=HS256"));
+    assertTrue(message.contains("kid=unsupported-key"));
+    assertTrue(message.contains("Unsupported OIDC JWT alg: HS256"));
+    assertFalse(message.contains("sensitive-user"));
+    assertFalse(message.contains("sensitive-signature"));
+  }
+
+  @Test
   void authenticatesAnonymousUserThroughConfiguredRealmAndAssignedRoles() {
     FakeSecurityDao dao = new FakeSecurityDao();
     dao.anonymous(new SecurityAnonymousConfigRecord(
@@ -1006,6 +1111,12 @@ class SecurityAuthenticationServiceTest {
     return generator.generateKeyPair();
   }
 
+  private static KeyPair ecKeyPair(String curve) throws Exception {
+    KeyPairGenerator generator = KeyPairGenerator.getInstance("EC");
+    generator.initialize(new ECGenParameterSpec(curve));
+    return generator.generateKeyPair();
+  }
+
   private static HttpServer jwksServer(String jwksJson) throws Exception {
     HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
     server.createContext("/jwks", exchange -> {
@@ -1031,10 +1142,43 @@ class SecurityAuthenticationServiceTest {
             "e", base64UrlUnsigned(publicKey.getPublicExponent())))));
   }
 
+  private static String mixedRsaAndEcJwksJson(
+      KeyPair rsaKeyPair, String rsaKid, KeyPair ecKeyPair, String ecKid) throws Exception {
+    RSAPublicKey rsaPublicKey = (RSAPublicKey) rsaKeyPair.getPublic();
+    ECPublicKey ecPublicKey = (ECPublicKey) ecKeyPair.getPublic();
+    return OBJECT_MAPPER.writeValueAsString(Map.of(
+        "keys",
+        List.of(
+            Map.of(
+                "kty", "RSA",
+                "kid", rsaKid,
+                "alg", "RS256",
+                "use", "sig",
+                "n", base64UrlUnsigned(rsaPublicKey.getModulus()),
+                "e", base64UrlUnsigned(rsaPublicKey.getPublicExponent())),
+            Map.of(
+                "kty", "EC",
+                "kid", ecKid,
+                "alg", "ES256",
+                "use", "sig",
+                "crv", "P-256",
+                "x", base64UrlUnsigned(ecPublicKey.getW().getAffineX(), 32),
+                "y", base64UrlUnsigned(ecPublicKey.getW().getAffineY(), 32)))));
+  }
+
   private static String signedJwt(KeyPair keyPair, String kid, Map<String, Object> claims) throws Exception {
-    String header = base64UrlJson(Map.of("alg", "RS256", "kid", kid, "typ", "JWT"));
+    return signedJwt(keyPair, kid, "RS256", "SHA256withRSA", claims);
+  }
+
+  private static String signedJwt(
+      KeyPair keyPair,
+      String kid,
+      String algorithm,
+      String signatureAlgorithm,
+      Map<String, Object> claims) throws Exception {
+    String header = base64UrlJson(Map.of("alg", algorithm, "kid", kid, "typ", "JWT"));
     String payload = base64UrlJson(claims);
-    Signature signature = Signature.getInstance("SHA256withRSA");
+    Signature signature = Signature.getInstance(signatureAlgorithm);
     signature.initSign(keyPair.getPrivate());
     signature.update((header + "." + payload).getBytes(StandardCharsets.US_ASCII));
     return header + "." + payload + "." + base64Url(signature.sign());
@@ -1050,6 +1194,28 @@ class SecurityAuthenticationServiceTest {
       bytes = Arrays.copyOfRange(bytes, 1, bytes.length);
     }
     return base64Url(bytes);
+  }
+
+  private static String base64UrlUnsigned(BigInteger value, int length) {
+    byte[] bytes = value.toByteArray();
+    byte[] fixed = new byte[length];
+    int sourceOffset = Math.max(0, bytes.length - length);
+    int copied = Math.min(bytes.length, length);
+    System.arraycopy(bytes, sourceOffset, fixed, length - copied, copied);
+    return base64Url(fixed);
+  }
+
+  private static ListAppender<ILoggingEvent> attachAuthenticationAppender() {
+    Logger logger = (Logger) LoggerFactory.getLogger(SecurityAuthenticationService.class);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+    return appender;
+  }
+
+  private static void detachAuthenticationAppender(ListAppender<ILoggingEvent> appender) {
+    Logger logger = (Logger) LoggerFactory.getLogger(SecurityAuthenticationService.class);
+    logger.detachAppender(appender);
   }
 
   private static String base64Url(byte[] bytes) {


### PR DESCRIPTION
## Summary

- Add OIDC ID-token verification for `ES256` using EC P-256 JWKs and JOSE-compatible raw signatures.
- Enforce `alg`, `kid`, `kty`, `crv`, and JWK `use` compatibility while preserving the existing RSA verification path.
- Add sanitized OIDC validation diagnostics without logging tokens or claims.
- Preserve the existing PyPI Auto Block behavior, but log the original upstream failure once at WARN and repeated blocked requests at DEBUG. Diagnostic circuit-state reads are skipped entirely when DEBUG logging is disabled.
- Speed up the JUnit/CI path by running the Maven reactor with four threads, avoiding duplicate database smoke execution in the main job, reusing one ArchUnit class import, and placing smoke-test database data on tmpfs.
- Keep the dedicated MySQL and PostgreSQL smoke jobs as the single owners of those scenarios and upload their coverage separately.

## Root cause

kkRepo v1.0.0 only constructed RSA public keys and supported the `RS256`, `RS384`, and `RS512` verification algorithms. A valid ID token signed by Authelia with `ES256` therefore reached kkRepo but could never pass signature verification.

The PyPI report in the same discussion is a separate observability problem: pip's version check requests `/simple/pip/`; an upstream `403` opens the existing circuit breaker, and later package requests return `502` while it is open. This PR does not change those circuit-breaker semantics.

The database persistence suites already reuse one static Testcontainers instance per database module and Surefire JVM, and the scanner module has only one cached Spring test context. The database server smoke deliberately creates two application contexts per database because it verifies repeated startup and cross-replica sessions. Sharing containers across jobs or modules would be unsafe because the suites truncate shared state and run independently. The remaining safe optimization is therefore to avoid executing the smoke class in both the main job and the dedicated matrix, while retaining one isolated owner for each database.

Context: https://github.com/klboke/kkRepo/discussions/255

## Verification

- `mvn -T 4 -pl server -am -Dtest=PypiProxyServiceTest,RepositoryRoutingArchitectureTest -Dsurefire.failIfNoSpecifiedTests=false test` — 14 tests passed; the ArchUnit suite dropped from about 15.0s to 10.68s.
- `mvn -T 4 -pl server -am -Dtest=DatabaseServerSmokeTest -Dsurefire.failIfNoSpecifiedTests=false test` — both database scenarios passed in 80.97s (PostgreSQL 42.75s, MySQL 37.03s), down from about 114.87s before the tmpfs changes.
- `mvn -T 4 -pl server -am -Dtest=SecurityAuthenticationServiceTest,PypiProxyServiceTest -Dsurefire.failIfNoSpecifiedTests=false verify` — 46 focused OIDC and PyPI tests passed with 0 failures and 0 errors.
- Local full main-job command — all 35 reactor modules passed in 4:31.
- GitHub Actions main test command — all 35 reactor modules passed in 3:53 wall-clock time; the server module ran 2,801 tests with 0 failures and 0 errors in 1:26. The complete `unit-and-protocol-tests` job finished in 4:18.
- Dedicated PostgreSQL and MySQL server smoke jobs passed in 1:39 and 2:20, including separate Codecov uploads.
- Codecov passed with 96.87% patch coverage and 85.35% project coverage (+0.02%); CodeQL reported no new alerts.
