### PR TITLE
Update kkscaner limits in values.yaml to string format

### DIFF
--- a/deploy/helm/kkrepo/values.yaml
+++ b/deploy/helm/kkrepo/values.yaml
@@ -136,15 +136,15 @@ securityScanning:
     delay: 1h
     initialDelay: 5m
   limits:
-    maxOciRequestBytes: 65536
-    maxInputBytes: 2147483648
-    maxOutputBytes: 16777216
-    maxResponseBytes: 67108864
-    maxResponseTokens: 262144
-    responseMemoryBudgetBytes: 268435456
-    maxStderrBytes: 262144
+    maxOciRequestBytes: '65536'
+    maxInputBytes: '2147483648'
+    maxOutputBytes: '16777216'
+    maxResponseBytes: '67108864'
+    maxResponseTokens: '262144'
+    responseMemoryBudgetBytes: '268435456'
+    maxStderrBytes: '262144'
     # Shared admission budget across concurrent scans. Keep this below scratchVolumeSize.
-    maxScratchBytes: 7516192768
+    maxScratchBytes: '7516192768'
     scratchVolumeSize: 8Gi
     maxConcurrentScans: 2
     maxQueuedScans: 4


### PR DESCRIPTION
Changed kkrepo.scanner numeric limits to string format in values.yaml to fix the env convert bug when deploy the kkrepo.scanner.

## BUG Logs
when deployed the helm chart without the quote:
```
 2026-08-28T10:27:37.506370657+08:00 Description:

  2026-08-28T10:27:37.506389144+08:00

  2026-08-28T10:27:37.506407691+08:00 Failed to bind properties under 'kkrepo.scanner.max-input-bytes' to long:

  2026-08-28T10:27:37.506420464+08:00

  2026-08-28T10:27:37.506432181+08:00     Property: kkrepo.scanner.max-input-bytes

  2026-08-28T10:27:37.506442498+08:00     Value: "2.147483648e+09"

  2026-08-28T10:27:37.506452901+08:00     Origin: System Environment Property "KKREPO_SCANNER_MAX_INPUT_BYTES"

  2026-08-28T10:27:37.506463374+08:00     Reason: failed to convert java.lang.String to long (caused by java.lang.NumberFormatException: For input
  string: "2.147483648e+09")

  2026-08-28T10:27:37.506473365+08:00

  2026-08-28T10:27:37.506484045+08:00 Action:

  2026-08-28T10:27:37.506493815+08:00

  2026-08-28T10:27:37.506504042+08:00 Update your application's configuration
```
