### PR TITLE
fix: prevent npm 10 legacy login response truncation

### DIFF
--- a/server/src/main/java/com/github/klboke/kkrepo/server/routing/builtin/BuiltinRepositoryProtocolHandler.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/routing/builtin/BuiltinRepositoryProtocolHandler.java
@@ -501,7 +501,7 @@ public class BuiltinRepositoryProtocolHandler implements RepositoryProtocolHandl
       String rawPath = extractRepositoryPath(name, request);
       if (NpmTokenService.isLoginPath(rawPath)) {
         try (InputStream body = request.getInputStream()) {
-          return toStreamingResponse(npmToken.login(body));
+          return toByteArrayResponse(npmToken.login(body));
         }
       }
       NpmPath path = npmParser.parse(rawPath);

--- a/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerNpmAuditTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerNpmAuditTest.java
@@ -1,14 +1,21 @@
 package com.github.klboke.kkrepo.server;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.klboke.kkrepo.core.RepositoryFormat;
 import com.github.klboke.kkrepo.core.RepositoryType;
 import com.github.klboke.kkrepo.persistence.jdbc.api.RepositoryDao;
 import com.github.klboke.kkrepo.persistence.jdbc.api.model.RepositoryRecord;
+import com.github.klboke.kkrepo.server.maven.MavenResponse;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
+import com.github.klboke.kkrepo.server.npm.NpmTokenService;
 import com.github.klboke.kkrepo.server.support.dao.RepositoryDaoAdapter;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -51,7 +58,41 @@ class RepositoryContentControllerNpmAuditTest {
     assertEquals(0, ((Map<String, Object>) body.get("metadata")).get("totalDependencies"));
   }
 
+  @Test
+  void npmLegacyLoginReturnsMaterializedTokenJson() throws Exception {
+    assertLoginResponse("-/user/org.couchdb.user:alice");
+  }
+
+  private static void assertLoginResponse(String path) throws Exception {
+    FakeRepositoryDao repositories = new FakeRepositoryDao();
+    repositories.repository(repository("npm-example", RepositoryFormat.NPM, RepositoryType.HOSTED));
+    byte[] tokenJson = "{\"token\":\"NpmToken.generated-token\"}"
+        .getBytes(StandardCharsets.UTF_8);
+    NpmTokenService tokenService = mock(NpmTokenService.class);
+    when(tokenService.login(any()))
+        .thenReturn(MavenResponse.ok(
+            new ByteArrayInputStream(tokenJson), tokenJson.length, "application/json", null, null)
+            .withStatus(201));
+    RepositoryProtocolController controller = controller(repositories, tokenService);
+    MockHttpServletRequest request = new MockHttpServletRequest(
+        "PUT", "/repository/npm-example/" + path);
+    request.setContent("{\"name\":\"alice\",\"password\":\"secret\"}"
+        .getBytes(StandardCharsets.UTF_8));
+
+    ResponseEntity<?> response = controller.put("npm-example", request);
+
+    assertEquals(201, response.getStatusCode().value());
+    assertEquals(tokenJson.length, response.getHeaders().getContentLength());
+    assertEquals("{\"token\":\"NpmToken.generated-token\"}",
+        new String((byte[]) response.getBody(), StandardCharsets.UTF_8));
+  }
+
   private static RepositoryProtocolController controller(FakeRepositoryDao repositories) {
+    return controller(repositories, null);
+  }
+
+  private static RepositoryProtocolController controller(
+      FakeRepositoryDao repositories, NpmTokenService tokenService) {
     return RepositoryProtocolControllerTestSupport.controller(
         new RepositoryRuntimeRegistry(repositories, 0),
         null, null, null,
@@ -59,7 +100,7 @@ class RepositoryContentControllerNpmAuditTest {
         null, null,
         null,
         null, null, null,
-        null, null,
+        null, tokenService,
         null, null, null,
         null, null, null,
         null, null, null,


### PR DESCRIPTION
## Summary

Fixes #269.

The legacy npm login endpoint returned the generated token through the streaming response path. In the generic `ResponseEntity<?>` path, the streaming body was not materialized as response bytes, producing an incomplete response while the declared `Content-Length` could still describe the full token JSON. npm then reported `ECONNRESET` after the server or proxy closed the connection early.

## Changes

- Return the legacy npm login result with the existing `toByteArrayResponse(...)` helper.
- Add a regression test covering the legacy CouchDB-compatible `PUT` login path.
- Assert HTTP `201`, complete token JSON, byte-array response body, and matching `Content-Length`.

The change is limited to legacy response handling. It does not add an incomplete implementation of npm's separate `POST /-/v1/login` web-login handshake.

## Verification

Local targeted tests:

```text
RepositoryContentControllerNpmAuditTest
NpmTokenServiceTest
RepositorySecurityFilterTest

74 tests passed, 0 failures, 0 errors
```

Server verification:

- Built all 34 Maven reactor modules with JDK 25: `BUILD SUCCESS`.
- Started the built application against an isolated MySQL 8 container.
- Completed database migrations through version 50.
- Bootstrapped an isolated npm hosted repository.
- Ran real npm `10.9.3` login from the client machine through an SSH tunnel using `--auth-type=legacy`.
- `npm login` completed successfully.
- `npm whoami` returned `ids`.
- `npm ping` returned `PONG`.
- Server log contained no `ECONNRESET`, connection reset, broken pipe, or client-abort errors.

The temporary server database, container, blob data, tunnel, and npm user configuration were removed after verification.