### PR TITLE
fix: prevent npm logout response truncation

### DIFF
--- a/server/src/main/java/com/github/klboke/kkrepo/server/routing/builtin/BuiltinRepositoryProtocolHandler.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/routing/builtin/BuiltinRepositoryProtocolHandler.java
@@ -711,7 +711,7 @@ public class BuiltinRepositoryProtocolHandler implements RepositoryProtocolHandl
     if (runtime.format() == RepositoryFormat.NPM) {
       String rawPath = extractRepositoryPath(name, request);
       if (NpmTokenService.isLogoutPath(rawPath)) {
-        return toStreamingResponse(npmToken.logout(request));
+        return toByteArrayResponse(npmToken.logout(request));
       }
       NpmPath path = npmParser.parse(rawPath);
       String userId = requestUserId(request);

--- a/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerNpmAuditTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/RepositoryContentControllerNpmAuditTest.java
@@ -63,6 +63,27 @@ class RepositoryContentControllerNpmAuditTest {
     assertLoginResponse("-/user/org.couchdb.user:alice");
   }
 
+  @Test
+  void npmLegacyLogoutReturnsMaterializedJson() throws Exception {
+    FakeRepositoryDao repositories = new FakeRepositoryDao();
+    repositories.repository(repository("npm-example", RepositoryFormat.NPM, RepositoryType.HOSTED));
+    byte[] logoutJson = "{\"ok\":\"true\"}".getBytes(StandardCharsets.UTF_8);
+    NpmTokenService tokenService = mock(NpmTokenService.class);
+    when(tokenService.logout(any()))
+        .thenReturn(MavenResponse.ok(
+            new ByteArrayInputStream(logoutJson), logoutJson.length, "application/json", null, null));
+    RepositoryProtocolController controller = controller(repositories, tokenService);
+    MockHttpServletRequest request = new MockHttpServletRequest(
+        "DELETE", "/repository/npm-example/-/user/token/NpmToken.generated-token");
+
+    ResponseEntity<?> response = controller.delete("npm-example", request);
+
+    assertEquals(200, response.getStatusCode().value());
+    assertEquals(logoutJson.length, response.getHeaders().getContentLength());
+    assertEquals("{\"ok\":\"true\"}",
+        new String((byte[]) response.getBody(), StandardCharsets.UTF_8));
+  }
+
   private static void assertLoginResponse(String path) throws Exception {
     FakeRepositoryDao repositories = new FakeRepositoryDao();
     repositories.repository(repository("npm-example", RepositoryFormat.NPM, RepositoryType.HOSTED));


### PR DESCRIPTION
## Summary

Follow-up to #270. The legacy npm logout endpoint used the same streaming response path from a generic `ResponseEntity<?>` handler, so its JSON body could be serialized incorrectly while retaining the original `Content-Length`.

## Changes

- Return legacy `DELETE /-/user/token/*` responses with the existing `toByteArrayResponse(...)` helper.
- Add a regression test asserting status, complete JSON bytes, and matching `Content-Length`.
- Leave all other streaming response paths unchanged.

## Verification

```text
mvn -pl server -am -Dtest=RepositoryContentControllerNpmAuditTest,NpmTokenServiceTest,RepositorySecurityFilterTest -Dsurefire.failIfNoSpecifiedTests=false test

75 tests passed, 0 failures, 0 errors
BUILD SUCCESS
```