### PR TITLE
feat(deploy): add quickstart readiness health checks

### DIFF
--- a/docker-compose.quickstart-postgresql.yml
+++ b/docker-compose.quickstart-postgresql.yml
@@ -74,6 +74,24 @@ services:
       - application-egress
     restart: unless-stopped
 
+  # Keep probes outside the application image so JVM and shell-less Native both work.
+  # Compose reports application readiness on this service, not on kkrepo itself.
+  kkrepo-health:
+    image: alpine:3.20
+    init: true
+    depends_on:
+      - kkrepo
+    command: ["sleep", "infinity"]
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://kkrepo:8081/actuator/health/readiness >/dev/null"]
+      interval: 15s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+    networks:
+      - application-egress
+    restart: unless-stopped
+
   scanner:
     image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-1.0.0}
     profiles: ["security-scanning"]

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -75,6 +75,24 @@ services:
       - application-egress
     restart: unless-stopped
 
+  # Keep probes outside the application image so JVM and shell-less Native both work.
+  # Compose reports application readiness on this service, not on kkrepo itself.
+  kkrepo-health:
+    image: alpine:3.20
+    init: true
+    depends_on:
+      - kkrepo
+    command: ["sleep", "infinity"]
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://kkrepo:8081/actuator/health/readiness >/dev/null"]
+      interval: 15s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+    networks:
+      - application-egress
+    restart: unless-stopped
+
   scanner:
     image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-1.0.0}
     profiles: ["security-scanning"]

--- a/docs/en/build-deployment-guide.md
+++ b/docs/en/build-deployment-guide.md
@@ -63,6 +63,7 @@ By default, it starts:
 
 - The JVM runtime from `ghcr.io/klboke/kkrepo:1.0.0`
 - MySQL 8.0
+- A `kkrepo-health` sidecar that continuously probes application readiness
 - Persistent MySQL and File blob storage volumes for local trials
 
 After startup, open:
@@ -73,6 +74,16 @@ After startup, open:
 - Prometheus metrics: `http://127.0.0.1:19091/actuator/prometheus`
 
 On the first visit, create the initial `Local/admin` administrator password in the UI. After entering the admin console, create a blob store named `default`. File is fine for local trials; OSS/S3 is recommended for production.
+
+Both quickstart Compose files include `kkrepo-health`, which checks `http://kkrepo:8081/actuator/health/readiness` every 15 seconds. The probe runs in an Alpine sidecar, so it works with both JVM and shell-less Native images. The container port stays `8081` when you change the published host port with `KKREPO_MANAGEMENT_PORT`.
+
+From the quickstart directory, inspect readiness with:
+
+```bash
+docker compose -f docker-compose.quickstart.yml ps kkrepo-health
+```
+
+Use `docker-compose.quickstart-postgresql.yml` for PostgreSQL. The `healthy` / `unhealthy` status belongs to `kkrepo-health`; the application container itself remains `running`. To wait for readiness when starting the full stack, use `docker compose -f docker-compose.quickstart.yml up -d --wait`. Additional services that need to wait for kkRepo should depend on `kkrepo-health` with `condition: service_healthy`. This health check reports readiness; an unhealthy result does not automatically restart kkRepo.
 
 Stop the trial environment:
 

--- a/docs/zh/build-deployment-guide.md
+++ b/docs/zh/build-deployment-guide.md
@@ -63,6 +63,7 @@ bash quickstart.sh
 
 - `ghcr.io/klboke/kkrepo:1.0.0` 中的 JVM 运行时
 - MySQL 8.0
+- 持续探测应用就绪状态的 `kkrepo-health` sidecar
 - 用于本地试用的持久化 MySQL volume 和 File blob storage volume
 
 启动后访问：
@@ -73,6 +74,16 @@ bash quickstart.sh
 - Prometheus 指标：`http://127.0.0.1:19091/actuator/prometheus`
 
 首次进入页面时，在 UI 中创建初始 `Local/admin` 管理员密码。进入管理控制台后，先创建名为 `default` 的 blob store；本地试用可以选择 File，生产环境建议使用 OSS/S3。
+
+两份 quickstart Compose 文件均包含 `kkrepo-health`，每 15 秒检查一次 `http://kkrepo:8081/actuator/health/readiness`。探测在 Alpine sidecar 中执行，因此同时兼容 JVM 和无 shell 的 Native 镜像。通过 `KKREPO_MANAGEMENT_PORT` 修改宿主机映射端口时，容器内端口仍为 `8081`。
+
+在 quickstart 目录中查看就绪状态：
+
+```bash
+docker compose -f docker-compose.quickstart.yml ps kkrepo-health
+```
+
+PostgreSQL 请使用 `docker-compose.quickstart-postgresql.yml`。`healthy` / `unhealthy` 状态属于 `kkrepo-health`，应用容器本身仍显示 `running`。启动完整环境并等待就绪，可执行 `docker compose -f docker-compose.quickstart.yml up -d --wait`。需要等待 kkRepo 就绪的其他服务，应使用 `condition: service_healthy` 依赖 `kkrepo-health`。此健康检查用于报告就绪状态，检查失败不会自动重启 kkRepo。
 
 停止试用环境：
 


### PR DESCRIPTION
## Summary

Add a `kkrepo-health` sidecar to both MySQL and PostgreSQL quickstart Compose files. It probes `/actuator/health/readiness` on the internal management port, providing continuous readiness status and allowing `docker compose up --wait` to wait for the application with both JVM and shell-less Native images.

Use `init: true` for normal signal forwarding and document the sidecar's health status, dependency semantics, and host-port overrides in both deployment guides.

Closes #284.

## Validation

- [x] `docker compose config --quiet` for both quickstart files.
- [x] `bash scripts/ci/check-compose-scanner-isolation.sh`.
- [x] `bash scripts/ci/test-quickstart-runtime.sh`.
- [x] `git diff --check`.
- [x] Live validation with published `1.0.0` / `1.0.0-native` images across MySQL and PostgreSQL (all four combinations): default `up --wait` startup, readiness endpoint, unhealthy detection, recovery, and sidecar SIGTERM exit `143`.
- Initial startup used the committed healthcheck timings and random host ports. Failure/recovery checks used a temporary Compose override with shorter probe timings; all temporary containers and volumes were removed afterward.
- Server and compatibility tests run in standard CI. Additional protocol/client E2E labels are not applicable to this Compose/documentation-only change.

## Compatibility and design checklist

- [x] No protocol behavior changes; official-protocol/Nexus comparison and new `compat-test` cases are not applicable.
- [x] No changes to application state, caches, locking, sessions, metadata, permissions, or migrations.

## Notes for reviewers

Docker reports health on `kkrepo-health`, not on the application container. The sidecar reports readiness and does not automatically restart kkRepo. The probe retains the existing network isolation and does not require tools inside either application image.
