### PR TITLE
fix: support Docker image deletion from Browse

### DIFF
--- a/compat-test/docker-browse-delete-mapping.md
+++ b/compat-test/docker-browse-delete-mapping.md
@@ -27,13 +27,21 @@ and compares the remaining tag/digest reads through Registry V2.
 
 The reference test follows the actual Nexus node lookup, asset lookup, and administrative
 delete calls for both a tag and a digest. Tag deletion preserves another tag and the
-digest on both systems. Nexus 3.94 administrative digest deletion removes the digest
-asset but retains tag assets; kkRepo retains its existing OCI behavior that removes
-the digest and its tag aliases. This reference difference is asserted explicitly.
+digest on both systems. Administrative digest deletion removes the selected digest
+entry and preserves tag assets on both systems. The test compares the retained tag's
+status and manifest bytes, verifies that the deleted digest entry cannot be opened
+or deleted again, and deletes the final tag through both administrative APIs.
 The test confirms Nexus asset removal by calling `readAsset` again and checking its
 `success: false` / `HTTP 404 Not Found` result. Registry digest reads can remain
 available after the administrative asset deletion, so they are not used as proof
 that the selected Nexus asset was removed.
+
+kkRepo persists digest-reference deletion in the manifest's database attributes,
+separately from the body still owned by its tags. Browse listing and detail lookup
+omit the deleted reference across replicas. Deletion locks the manifest row and
+releases the asset/blob reference only after both the digest entry and all tags
+are gone. A subsequent manifest push restores the digest entry. The Registry V2
+DELETE operation continues to remove the manifest and all associated tags.
 
 This fix accepts tag/digest leaves only. Docker directory deletion is not exposed in
 kkRepo Browse and directory requests are rejected. In particular, `team/manifests`

--- a/compat-test/docker-browse-delete-mapping.md
+++ b/compat-test/docker-browse-delete-mapping.md
@@ -1,0 +1,46 @@
+# Docker Browse administrative deletion reference
+
+Captured from a running Nexus Repository Community 3.94.0-12 instance. The browser loads
+`/static/rapture/nexus-coreui-plugin-prod.js` and `/static/rapture/extdirect-prod.js`.
+`NX.coreui.store.ComponentAssetTree` calls `NX.direct.coreui_Browse.read`; the Browse
+controller opens `ComponentAssetInfo` for an `asset` node. Its Delete button calls
+`NX.direct.coreui_Component.deleteAsset(asset.getId(), asset.get("repositoryName"))`.
+The ExtDirect provider sends these calls to `POST /service/extdirect`.
+
+| UI step | ExtDirect action / method | `data` arguments |
+| --- | --- | --- |
+| List tag leaves | `coreui_Browse.read` | `[{"repositoryName":"<repo>","node":"v2/<image>/tags"}]` |
+| List digest leaves | `coreui_Browse.read` | `[{"repositoryName":"<repo>","node":"v2/<image>/manifests"}]` |
+| Open selected leaf | `coreui_Component.readAsset` | `["<node.assetId>","<repo>"]` |
+| Delete selected asset | `coreui_Component.deleteAsset` | `["<asset.id>","<asset.repositoryName>"]` |
+
+Each request includes `type: "rpc"` and a transaction `tid`. Successful calls return
+HTTP 200 with `result.success: true`. Deletion returns the affected asset paths in
+`result.data`, such as `["/v2/<image>/manifests/latest"]`. The asset model supplies the
+source repository; deletion does not guess it from the displayed group name.
+
+kkRepo's existing Browse leaves use `<image>/manifests/<tag-or-digest>` and send
+`DELETE /internal/browse/<repo>?path=<leaf>&source=<source-repo>`. Success is HTTP 200
+with `repository`, `sourceRepository`, `path`, and `deletedAssets`. These transport
+envelopes are intentionally different; the black-box test validates both contracts
+and compares the remaining tag/digest reads through Registry V2.
+
+The reference test follows the actual Nexus node lookup, asset lookup, and administrative
+delete calls for both a tag and a digest. Tag deletion preserves another tag and the
+digest on both systems. Nexus 3.94 administrative digest deletion removes the digest
+asset but retains tag assets; kkRepo retains its existing OCI behavior that removes
+the digest and its tag aliases. This reference difference is asserted explicitly.
+The test confirms Nexus asset removal by calling `readAsset` again and checking its
+`success: false` / `HTTP 404 Not Found` result. Registry digest reads can remain
+available after the administrative asset deletion, so they are not used as proof
+that the selected Nexus asset was removed.
+
+This fix accepts tag/digest leaves only. Docker directory deletion is not exposed in
+kkRepo Browse and directory requests are rejected. In particular, `team/manifests`
+must never be inferred to mean deletion of the separate image `team`.
+
+Run `DockerRegistryBlackBoxCompatibilityTest#browseDeletionUsesNexusAdministrativeAssetMappingWhenConfigured`
+with writable Docker endpoints and `NEXUS_COMPAT_BASE_URL` / `KKREPO_COMPAT_BASE_URL`
+pointing to their administrative application URLs. Docker connector endpoint overrides
+remain available through `DOCKER_NEXUS_COMPAT_BASE_URL` and
+`DOCKER_NEXUS_PLUS_COMPAT_BASE_URL`.

--- a/compat-test/src/test/java/com/github/klboke/kkrepo/compat/DockerRegistryBlackBoxCompatibilityTest.java
+++ b/compat-test/src/test/java/com/github/klboke/kkrepo/compat/DockerRegistryBlackBoxCompatibilityTest.java
@@ -1,5 +1,6 @@
 package com.github.klboke.kkrepo.compat;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -183,19 +184,37 @@ class DockerRegistryBlackBoxCompatibilityTest {
       assertEquals(expected.status(), actual.status(), "reference after tag deletion " + reference);
     }
 
-    // Nexus's administrative digest deletion removes the digest asset but retains tag assets.
-    // Keep kkrepo's existing OCI contract that also removes aliases; this PR only connects Browse.
+    // Both administrative APIs delete the selected digest entry while preserving tag assets.
     deleteNexusBrowseAsset(nexusUi, config.repository(), imagePath, digest, true);
-    assertEquals(200, get(config.nexus(), config.nexus().v2(imagePath + "/manifests/1.0.0"),
-        dockerAccept(), true).status());
     assertEquals(200, delete(browse,
         browse.resolve(browseUrl + encode(image + "/manifests/" + digest)), true).status());
-    for (String reference : List.of("latest", "1.0.0", digest)) {
+    for (String reference : List.of("latest", "1.0.0")) {
+      Exchange expected = get(config.nexus(), config.nexus().v2(imagePath + "/manifests/" + reference),
+          dockerAccept(), true);
       Exchange actual = get(config.nexusPlus(), config.nexusPlus().v2(imagePath + "/manifests/" + reference),
           dockerAccept(), true);
-      assertEquals(404, actual.status(), "deleted reference " + reference);
+      assertEquals(reference.equals("latest") ? 404 : 200, expected.status());
+      assertEquals(expected.status(), actual.status(), "reference after digest deletion " + reference);
+      if (expected.status() == 200) {
+        assertArrayEquals(expected.body(), actual.body(), "retained tag manifest bytes");
+      }
     }
+    Exchange remaining = get(browse, browse.resolve(browseUrl + encode(image + "/manifests")),
+        "application/json", true);
+    assertEquals(200, remaining.status());
+    assertTrue(new String(remaining.body(), StandardCharsets.UTF_8).contains(image + "/manifests/1.0.0"));
+    assertFalse(new String(remaining.body(), StandardCharsets.UTF_8).contains(digest));
+    assertEquals(404, get(browse, browse.resolve("/internal/browse/" + encode(config.repository())
+        + "/attributes?path=" + encode(image + "/manifests/" + digest)), "application/json", true).status());
+    assertEquals(404, delete(browse,
+        browse.resolve(browseUrl + encode(image + "/manifests/" + digest)), true).status());
     deleteNexusBrowseAsset(nexusUi, config.repository(), imagePath, "1.0.0", false);
+    assertEquals(200, delete(browse,
+        browse.resolve(browseUrl + encode(image + "/manifests/1.0.0")), true).status());
+    for (Endpoint endpoint : List.of(config.nexus(), config.nexusPlus())) {
+      assertEquals(404, get(endpoint, endpoint.v2(imagePath + "/manifests/1.0.0"),
+          dockerAccept(), true).status());
+    }
   }
 
   // Captured from Nexus 3.94's ComponentAssetTree and Browse controllers; see

--- a/compat-test/src/test/java/com/github/klboke/kkrepo/compat/DockerRegistryBlackBoxCompatibilityTest.java
+++ b/compat-test/src/test/java/com/github/klboke/kkrepo/compat/DockerRegistryBlackBoxCompatibilityTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.klboke.kkrepo.protocol.docker.DockerConstants;
 import java.net.URI;
 import java.net.URLEncoder;
@@ -24,6 +26,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class DockerRegistryBlackBoxCompatibilityTest {
+  private static final ObjectMapper JSON = new ObjectMapper();
   private static final HttpClient HTTP = HttpClient.newBuilder()
       .connectTimeout(Duration.ofSeconds(20))
       .followRedirects(HttpClient.Redirect.NEVER)
@@ -136,11 +139,13 @@ class DockerRegistryBlackBoxCompatibilityTest {
   }
 
   @Test
-  void browseDeletionMatchesNexusTagsAndRemovesDigestAliasesWhenConfigured() throws Exception {
+  void browseDeletionUsesNexusAdministrativeAssetMappingWhenConfigured() throws Exception {
     CompatConfig config = CompatConfig.load();
     assumeTrue(config.enabled() && config.configured() && config.writeEnabled(),
         "Configure writable Nexus and kkrepo Docker endpoints to compare administrative deletion");
     assumeTrue(CompatDefaults.nexusPlusBaseUrl().isPresent(), "Configure the kkrepo application URL");
+    Endpoint nexusUi = new Endpoint("nexus-ui", CompatDefaults.nexusBaseUrl(),
+        CompatDefaults.nexusUsername(), CompatDefaults.nexusPassword());
     Endpoint browse = new Endpoint("kkrepo-browse", CompatDefaults.nexusPlusBaseUrl(),
         CompatDefaults.nexusPlusUsername(), CompatDefaults.nexusPlusPassword());
     String image = config.uploadImage() + "/browse-delete-" + System.nanoTime();
@@ -158,12 +163,17 @@ class DockerRegistryBlackBoxCompatibilityTest {
       }
     }
 
-    // The portal's internal API must preserve the registry's tag-vs-manifest deletion semantics.
+    // Follow Nexus Browse's node -> readAsset -> deleteAsset mapping, not Registry V2 DELETE.
+    deleteNexusBrowseAsset(nexusUi, config.repository(), imagePath, "latest", false);
     String browseUrl = "/internal/browse/" + encode(config.repository()) + "?path=";
-    assertEquals(202, delete(config.nexus(),
-        config.nexus().v2(imagePath + "/manifests/latest"), true).status());
-    assertEquals(200, delete(browse,
-        browse.resolve(browseUrl + encode(image + "/manifests/latest")), true).status());
+    Exchange deletedTag = delete(browse,
+        browse.resolve(browseUrl + encode(image + "/manifests/latest")), true);
+    assertEquals(200, deletedTag.status());
+    JsonNode deleted = JSON.readTree(deletedTag.body());
+    assertEquals(config.repository(), deleted.path("repository").asText());
+    assertEquals(config.repository(), deleted.path("sourceRepository").asText());
+    assertEquals(image + "/manifests/latest", deleted.path("path").asText());
+    assertEquals(1, deleted.path("deletedAssets").asInt());
     for (String reference : List.of("latest", "1.0.0", digest)) {
       Exchange expected = get(config.nexus(), config.nexus().v2(imagePath + "/manifests/" + reference),
           dockerAccept(), true);
@@ -173,8 +183,11 @@ class DockerRegistryBlackBoxCompatibilityTest {
       assertEquals(expected.status(), actual.status(), "reference after tag deletion " + reference);
     }
 
-    // Preserve kkrepo's existing OCI digest-delete contract. Nexus 3.94 can retain tag aliases
-    // after digest deletion, so that known reference behavior is not a tag-deletion oracle.
+    // Nexus's administrative digest deletion removes the digest asset but retains tag assets.
+    // Keep kkrepo's existing OCI contract that also removes aliases; this PR only connects Browse.
+    deleteNexusBrowseAsset(nexusUi, config.repository(), imagePath, digest, true);
+    assertEquals(200, get(config.nexus(), config.nexus().v2(imagePath + "/manifests/1.0.0"),
+        dockerAccept(), true).status());
     assertEquals(200, delete(browse,
         browse.resolve(browseUrl + encode(image + "/manifests/" + digest)), true).status());
     for (String reference : List.of("latest", "1.0.0", digest)) {
@@ -182,10 +195,64 @@ class DockerRegistryBlackBoxCompatibilityTest {
           dockerAccept(), true);
       assertEquals(404, actual.status(), "deleted reference " + reference);
     }
-    assertEquals(202, delete(config.nexus(),
-        config.nexus().v2(imagePath + "/manifests/1.0.0"), true).status());
-    assertEquals(202, delete(config.nexus(),
-        config.nexus().v2(imagePath + "/manifests/" + digest), true).status());
+    deleteNexusBrowseAsset(nexusUi, config.repository(), imagePath, "1.0.0", false);
+  }
+
+  // Captured from Nexus 3.94's ComponentAssetTree and Browse controllers; see
+  // compat-test/docker-browse-delete-mapping.md for the source bundle and request contracts.
+  private static void deleteNexusBrowseAsset(Endpoint endpoint, String repository,
+      String imagePath, String reference, boolean digest) throws Exception {
+    String nodePath = "v2/" + imagePath + (digest ? "/manifests" : "/tags");
+    JsonNode selected = null;
+    long deadline = System.nanoTime() + Duration.ofSeconds(20).toNanos();
+    do {
+      JsonNode rows = nexusUi(endpoint, "coreui_Browse", "read",
+          List.of(Map.of("repositoryName", repository, "node", nodePath))).path("data");
+      for (JsonNode row : rows) {
+        if (reference.equals(row.path("text").asText())) {
+          selected = row;
+          break;
+        }
+      }
+      if (selected == null) Thread.sleep(100);
+    } while (selected == null && System.nanoTime() < deadline);
+    assertTrue(selected != null, "Nexus Browse did not expose " + nodePath + "/" + reference);
+    assertEquals("asset", selected.path("type").asText());
+    JsonNode asset = nexusUi(endpoint, "coreui_Component", "readAsset",
+        List.of(selected.path("assetId").asText(), repository)).path("data");
+    String assetPath = "/v2/" + imagePath + "/manifests/" + reference;
+    assertEquals(assetPath, asset.path("name").asText());
+    assertEquals(repository, asset.path("repositoryName").asText());
+    JsonNode result = nexusUi(endpoint, "coreui_Component", "deleteAsset",
+        List.of(asset.path("id").asText(), asset.path("repositoryName").asText()));
+    assertEquals(JSON.valueToTree(List.of(assetPath)), result.path("data"),
+        "Nexus UI response must identify the selected deleted asset");
+    JsonNode missing = nexusUi(endpoint, "coreui_Component", "readAsset",
+        List.of(asset.path("id").asText(), repository), false);
+    assertEquals("HTTP 404 Not Found", missing.path("message").asText(),
+        "The selected Nexus asset must be absent after administrative deletion");
+  }
+
+  private static JsonNode nexusUi(Endpoint endpoint, String action, String method, List<?> data)
+      throws Exception {
+    return nexusUi(endpoint, action, method, data, true);
+  }
+
+  private static JsonNode nexusUi(Endpoint endpoint, String action, String method, List<?> data,
+      boolean expectedSuccess)
+      throws Exception {
+    byte[] payload = JSON.writeValueAsBytes(Map.of(
+        "action", action, "method", method, "type", "rpc", "tid", 1, "data", data));
+    Exchange response = send(auth(endpoint, true,
+        HttpRequest.newBuilder(endpoint.resolve("/service/extdirect"))
+            .timeout(Duration.ofSeconds(30))
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofByteArray(payload))));
+    assertEquals(200, response.status(), "Nexus UI " + action + "." + method);
+    JsonNode envelope = JSON.readTree(response.body());
+    JsonNode result = (envelope.isArray() ? envelope.path(0) : envelope).path("result");
+    assertEquals(expectedSuccess, result.path("success").asBoolean(), result.toString());
+    return result;
   }
 
   @Test

--- a/compat-test/src/test/java/com/github/klboke/kkrepo/compat/DockerRegistryBlackBoxCompatibilityTest.java
+++ b/compat-test/src/test/java/com/github/klboke/kkrepo/compat/DockerRegistryBlackBoxCompatibilityTest.java
@@ -136,6 +136,55 @@ class DockerRegistryBlackBoxCompatibilityTest {
   }
 
   @Test
+  void browseDeletionPreservesTagsAndMatchesNexusManifestDeletionWhenConfigured() throws Exception {
+    CompatConfig config = CompatConfig.load();
+    assumeTrue(config.enabled() && config.configured() && config.writeEnabled(),
+        "Configure writable Nexus and kkrepo Docker endpoints to compare administrative deletion");
+    assumeTrue(CompatDefaults.nexusPlusBaseUrl().isPresent(), "Configure the kkrepo application URL");
+    Endpoint browse = new Endpoint("kkrepo-browse", CompatDefaults.nexusPlusBaseUrl(),
+        CompatDefaults.nexusPlusUsername(), CompatDefaults.nexusPlusPassword());
+    String image = config.uploadImage() + "/browse-delete-" + System.nanoTime();
+    byte[] layer = image.getBytes(StandardCharsets.UTF_8);
+    String layerDigest = "sha256:" + sha256(layer);
+    byte[] manifest = singleLayerManifest(layerDigest, layer.length).getBytes(StandardCharsets.UTF_8);
+    String digest = "sha256:" + sha256(manifest);
+    String imagePath = config.repositoryPath(image);
+    for (Endpoint endpoint : List.of(config.nexus(), config.nexusPlus())) {
+      pushBlob(endpoint, imagePath, "sha256:" + sha256(new byte[0]), new byte[0], true);
+      pushBlob(endpoint, imagePath, layerDigest, layer, true);
+      for (String tag : List.of("latest", "1.0.0")) {
+        assertEquals(201, put(endpoint, endpoint.v2(imagePath + "/manifests/" + tag),
+            DockerConstants.MEDIA_TYPE_OCI_MANIFEST, manifest, true).status());
+      }
+    }
+
+    // The portal's internal API must preserve the registry's tag-vs-manifest deletion semantics.
+    String browseUrl = "/internal/browse/" + encode(config.repository()) + "?path=";
+    assertEquals(200, delete(browse,
+        browse.resolve(browseUrl + encode(image + "/manifests/latest")), true).status());
+    assertEquals(404, get(config.nexusPlus(), config.nexusPlus().v2(imagePath + "/manifests/latest"),
+        dockerAccept(), true).status());
+    assertEquals(200, get(config.nexusPlus(), config.nexusPlus().v2(imagePath + "/manifests/1.0.0"),
+        dockerAccept(), true).status());
+    assertEquals(200, get(config.nexusPlus(), config.nexusPlus().v2(imagePath + "/manifests/" + digest),
+        dockerAccept(), true).status());
+
+    // Nexus's Registry V2 digest deletion is the reference for the resulting registry state.
+    assertEquals(202, delete(config.nexus(),
+        config.nexus().v2(imagePath + "/manifests/" + digest), true).status());
+    assertEquals(200, delete(browse,
+        browse.resolve(browseUrl + encode(image + "/manifests/" + digest)), true).status());
+    for (String reference : List.of("latest", "1.0.0", digest)) {
+      Exchange expected = get(config.nexus(), config.nexus().v2(imagePath + "/manifests/" + reference),
+          dockerAccept(), true);
+      Exchange actual = get(config.nexusPlus(), config.nexusPlus().v2(imagePath + "/manifests/" + reference),
+          dockerAccept(), true);
+      assertEquals(404, expected.status());
+      assertEquals(expected.status(), actual.status(), "deleted reference " + reference);
+    }
+  }
+
+  @Test
   void pathBasedRoutingMatchesConnectorWhenConfigured() throws Exception {
     CompatConfig config = CompatConfig.load();
     assumeTrue(config.enabled(),

--- a/compat-test/src/test/java/com/github/klboke/kkrepo/compat/DockerRegistryBlackBoxCompatibilityTest.java
+++ b/compat-test/src/test/java/com/github/klboke/kkrepo/compat/DockerRegistryBlackBoxCompatibilityTest.java
@@ -136,7 +136,7 @@ class DockerRegistryBlackBoxCompatibilityTest {
   }
 
   @Test
-  void browseDeletionPreservesTagsAndMatchesNexusManifestDeletionWhenConfigured() throws Exception {
+  void browseDeletionMatchesNexusTagsAndRemovesDigestAliasesWhenConfigured() throws Exception {
     CompatConfig config = CompatConfig.load();
     assumeTrue(config.enabled() && config.configured() && config.writeEnabled(),
         "Configure writable Nexus and kkrepo Docker endpoints to compare administrative deletion");
@@ -160,28 +160,32 @@ class DockerRegistryBlackBoxCompatibilityTest {
 
     // The portal's internal API must preserve the registry's tag-vs-manifest deletion semantics.
     String browseUrl = "/internal/browse/" + encode(config.repository()) + "?path=";
+    assertEquals(202, delete(config.nexus(),
+        config.nexus().v2(imagePath + "/manifests/latest"), true).status());
     assertEquals(200, delete(browse,
         browse.resolve(browseUrl + encode(image + "/manifests/latest")), true).status());
-    assertEquals(404, get(config.nexusPlus(), config.nexusPlus().v2(imagePath + "/manifests/latest"),
-        dockerAccept(), true).status());
-    assertEquals(200, get(config.nexusPlus(), config.nexusPlus().v2(imagePath + "/manifests/1.0.0"),
-        dockerAccept(), true).status());
-    assertEquals(200, get(config.nexusPlus(), config.nexusPlus().v2(imagePath + "/manifests/" + digest),
-        dockerAccept(), true).status());
-
-    // Nexus's Registry V2 digest deletion is the reference for the resulting registry state.
-    assertEquals(202, delete(config.nexus(),
-        config.nexus().v2(imagePath + "/manifests/" + digest), true).status());
-    assertEquals(200, delete(browse,
-        browse.resolve(browseUrl + encode(image + "/manifests/" + digest)), true).status());
     for (String reference : List.of("latest", "1.0.0", digest)) {
       Exchange expected = get(config.nexus(), config.nexus().v2(imagePath + "/manifests/" + reference),
           dockerAccept(), true);
       Exchange actual = get(config.nexusPlus(), config.nexusPlus().v2(imagePath + "/manifests/" + reference),
           dockerAccept(), true);
-      assertEquals(404, expected.status());
-      assertEquals(expected.status(), actual.status(), "deleted reference " + reference);
+      assertEquals(reference.equals("latest") ? 404 : 200, expected.status());
+      assertEquals(expected.status(), actual.status(), "reference after tag deletion " + reference);
     }
+
+    // Preserve kkrepo's existing OCI digest-delete contract. Nexus 3.94 can retain tag aliases
+    // after digest deletion, so that known reference behavior is not a tag-deletion oracle.
+    assertEquals(200, delete(browse,
+        browse.resolve(browseUrl + encode(image + "/manifests/" + digest)), true).status());
+    for (String reference : List.of("latest", "1.0.0", digest)) {
+      Exchange actual = get(config.nexusPlus(), config.nexusPlus().v2(imagePath + "/manifests/" + reference),
+          dockerAccept(), true);
+      assertEquals(404, actual.status(), "deleted reference " + reference);
+    }
+    assertEquals(202, delete(config.nexus(),
+        config.nexus().v2(imagePath + "/manifests/1.0.0"), true).status());
+    assertEquals(202, delete(config.nexus(),
+        config.nexus().v2(imagePath + "/manifests/" + digest), true).status());
   }
 
   @Test

--- a/docs/en/repository-guides/docker-oci.md
+++ b/docs/en/repository-guides/docker-oci.md
@@ -59,6 +59,13 @@ Push only to hosted. Proxy and group are read endpoints even when the caller is 
 
 ## Cleanup And Security
 
+Administrators can delete tags, manifest digests, and image directories from Browse. Deleting a tag
+removes only that tag; deleting a digest removes that manifest and all of its tags in the image.
+Directory deletion removes the selected image subtree in the source repository. From a group,
+deletion affects the selected member only; proxy deletion removes local cached content, which can
+be fetched again from upstream. Administrative Browse deletion follows the portal's administrator
+permission rules, independently of the Registry V2 write policy.
+
 Delete and cleanup logic distinguishes tags, manifests, and shared blob references; do not delete
 objects directly from blob storage. Run cleanup preview and allow reference accounting to determine
 when a blob is unreferenced. Security scanning should target the committed manifest and layer set,

--- a/docs/en/repository-guides/docker-oci.md
+++ b/docs/en/repository-guides/docker-oci.md
@@ -59,8 +59,11 @@ Push only to hosted. Proxy and group are read endpoints even when the caller is 
 
 ## Cleanup And Security
 
-Administrators can select a tag or manifest digest in Browse and delete it. Deleting a tag removes
-only that tag; deleting a digest removes that manifest and all of its tags in the image. Docker
+Administrators can select a tag or manifest digest in Browse and delete it. Each operation removes
+only the selected reference: deleting a digest entry preserves existing tags and their downloadable
+manifest content, matching Nexus administrative asset deletion. Content is released when no tag or
+digest entry retains it; shared blobs remain protected. A subsequent push restores the digest entry.
+Registry V2 digest deletion still removes the manifest and all its tags. Docker
 image and namespace directories are not deletion targets; the API rejects directory paths.
 From a group, deletion affects the selected member only; proxy deletion removes local cached
 content, which can be fetched again from upstream. Administrative Browse deletion follows the

--- a/docs/en/repository-guides/docker-oci.md
+++ b/docs/en/repository-guides/docker-oci.md
@@ -59,12 +59,12 @@ Push only to hosted. Proxy and group are read endpoints even when the caller is 
 
 ## Cleanup And Security
 
-Administrators can delete tags, manifest digests, and image directories from Browse. Deleting a tag
-removes only that tag; deleting a digest removes that manifest and all of its tags in the image.
-Directory deletion removes the selected image subtree in the source repository. From a group,
-deletion affects the selected member only; proxy deletion removes local cached content, which can
-be fetched again from upstream. Administrative Browse deletion follows the portal's administrator
-permission rules, independently of the Registry V2 write policy.
+Administrators can select a tag or manifest digest in Browse and delete it. Deleting a tag removes
+only that tag; deleting a digest removes that manifest and all of its tags in the image. Docker
+image and namespace directories are not deletion targets; the API rejects directory paths.
+From a group, deletion affects the selected member only; proxy deletion removes local cached
+content, which can be fetched again from upstream. Administrative Browse deletion follows the
+portal's administrator permission rules, independently of the Registry V2 write policy.
 
 Delete and cleanup logic distinguishes tags, manifests, and shared blob references; do not delete
 objects directly from blob storage. Run cleanup preview and allow reference accounting to determine

--- a/docs/zh/repository-guides/docker-oci.md
+++ b/docs/zh/repository-guides/docker-oci.md
@@ -57,11 +57,11 @@ docker pull nexus.example.com/docker-group/team/alpine:3.20
 
 ## 清理与安全
 
-管理员可以在 Browse 中删除 tag、manifest digest 和镜像目录。删除 tag 只移除该标签；
-删除 digest 会移除该镜像中的对应 manifest 及其全部标签。删除目录会清理来源仓库中的
-对应镜像子树。从 group 发起删除时只影响选中的成员；删除 proxy 内容只清理本地缓存，
-后续仍可从上游重新获取。Browse 管理删除遵循门户的管理员权限规则，独立于 Registry V2
-写入策略。
+管理员可以在 Browse 中选中 tag 或 manifest digest 并删除。删除 tag 只移除该标签；
+删除 digest 会移除该镜像中的对应 manifest 及其全部标签。Docker 镜像和命名空间目录
+不是删除目标，API 会拒绝目录路径。从 group 发起删除时只影响选中的成员；删除 proxy
+内容只清理本地缓存，后续仍可从上游重新获取。Browse 管理删除遵循门户的管理员权限规则，
+独立于 Registry V2 写入策略。
 
 删除和 cleanup 会区分 tag、manifest 与共享 blob reference，不能直接从 blob storage 删除
 对象。先执行 cleanup preview，并由引用计数判断 blob 何时不再被引用。安全扫描应面向已提交

--- a/docs/zh/repository-guides/docker-oci.md
+++ b/docs/zh/repository-guides/docker-oci.md
@@ -57,6 +57,12 @@ docker pull nexus.example.com/docker-group/team/alpine:3.20
 
 ## 清理与安全
 
+管理员可以在 Browse 中删除 tag、manifest digest 和镜像目录。删除 tag 只移除该标签；
+删除 digest 会移除该镜像中的对应 manifest 及其全部标签。删除目录会清理来源仓库中的
+对应镜像子树。从 group 发起删除时只影响选中的成员；删除 proxy 内容只清理本地缓存，
+后续仍可从上游重新获取。Browse 管理删除遵循门户的管理员权限规则，独立于 Registry V2
+写入策略。
+
 删除和 cleanup 会区分 tag、manifest 与共享 blob reference，不能直接从 blob storage 删除
 对象。先执行 cleanup preview，并由引用计数判断 blob 何时不再被引用。安全扫描应面向已提交
 manifest 与 layer 集合，而不是未完成的 upload session。

--- a/docs/zh/repository-guides/docker-oci.md
+++ b/docs/zh/repository-guides/docker-oci.md
@@ -57,8 +57,10 @@ docker pull nexus.example.com/docker-group/team/alpine:3.20
 
 ## 清理与安全
 
-管理员可以在 Browse 中选中 tag 或 manifest digest 并删除。删除 tag 只移除该标签；
-删除 digest 会移除该镜像中的对应 manifest 及其全部标签。Docker 镜像和命名空间目录
+管理员可以在 Browse 中选中 tag 或 manifest digest 并删除，每次只移除选中的引用。
+删除 digest 条目会保留已有 tag 及其可下载的 manifest 内容，与 Nexus 管理界面的资产删除行为一致。
+没有 tag 或 digest 条目引用内容后才释放内容，共享 blob 仍受保护；重新推送会恢复 digest 条目。
+Registry V2 的 digest 删除仍会移除 manifest 及其全部标签。Docker 镜像和命名空间目录
 不是删除目标，API 会拒绝目录路径。从 group 发起删除时只影响选中的成员；删除 proxy
 内容只清理本地缓存，后续仍可从上游重新获取。Browse 管理删除遵循门户的管理员权限规则，
 独立于 Registry V2 写入策略。

--- a/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/api/DockerRegistryDao.java
+++ b/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/api/DockerRegistryDao.java
@@ -70,6 +70,12 @@ public interface DockerRegistryDao {
 
   DeletedManifest deleteManifest(long repositoryId, String imageName, String digest);
 
+  /**
+   * Deletes only the selected administrative reference. Returned asset IDs are populated only
+   * when neither the digest reference nor any tags retain the manifest body. Requires a transaction.
+   */
+  DeletedManifest deleteBrowseReference(long repositoryId, String imageName, String reference);
+
   boolean referencedDigestExists(long repositoryId, String imageName, String digest);
 
   boolean imageReferencesDigest(long repositoryId, String imageName, String digest);

--- a/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/api/model/docker/DockerManifestRecord.java
+++ b/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/api/model/docker/DockerManifestRecord.java
@@ -23,4 +23,10 @@ public record DockerManifestRecord(
     Map<String, Object> attributes,
     Instant createdAt,
     Instant updatedAt) {
+  public static final String DIGEST_REFERENCE_DELETED = "digestReferenceDeleted";
+
+  /** The manifest body may still be owned by tags after its Browse digest reference is deleted. */
+  public boolean hasDigestReference() {
+    return attributes == null || !Boolean.TRUE.equals(attributes.get(DIGEST_REFERENCE_DELETED));
+  }
 }

--- a/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/JdbcDockerRegistryDao.java
+++ b/persistence-jdbc/src/main/java/com/github/klboke/kkrepo/persistence/jdbc/internal/JdbcDockerRegistryDao.java
@@ -428,13 +428,13 @@ public class JdbcDockerRegistryDao implements com.github.klboke.kkrepo.persisten
 
   @Transactional(propagation = Propagation.MANDATORY)
   public DeletedManifest deleteManifest(long repositoryId, String imageName, String digest) {
-    Optional<DockerManifestRecord> manifest = findManifestByDigest(repositoryId, imageName, digest);
+    Optional<DockerManifestRecord> manifest = findManifestByDigestForUpdate(repositoryId, imageName, digest);
     if (manifest.isEmpty()) {
       return DeletedManifest.notFound();
     }
     long id = manifest.get().id();
     Long assetBlobId = jdbcTemplate.queryForObject(
-        "SELECT asset_blob_id FROM asset WHERE id = ?",
+        "SELECT asset_blob_id FROM asset WHERE id = ? FOR UPDATE",
         (rs, rowNum) -> nullableLong(rs, "asset_blob_id"),
         manifest.get().assetId());
     jdbcTemplate.update("DELETE FROM docker_tag WHERE manifest_id = ?", id);
@@ -444,6 +444,41 @@ public class JdbcDockerRegistryDao implements com.github.klboke.kkrepo.persisten
         WHERE id = ?
         """, id);
     return new DeletedManifest(deleted, manifest.get().assetId(), assetBlobId);
+  }
+
+  @Override
+  @Transactional(propagation = Propagation.MANDATORY)
+  public DeletedManifest deleteBrowseReference(long repositoryId, String imageName, String reference) {
+    boolean digestReference = reference.contains(":");
+    Optional<DockerManifestRecord> selected = findManifestByReference(repositoryId, imageName, reference);
+    if (selected.isEmpty()) return DeletedManifest.notFound();
+    // Serialize with manifest upserts and other Browse deletes on every replica. Tag deletion also
+    // checks manifest_id so a concurrent retag cannot make us delete a different manifest's pointer.
+    Optional<DockerManifestRecord> locked = findManifestByDigestForUpdate(
+        repositoryId, imageName, selected.get().digest());
+    if (locked.isEmpty()) return DeletedManifest.notFound();
+    DockerManifestRecord manifest = locked.get();
+    if (digestReference) {
+      if (!manifest.hasDigestReference()) return DeletedManifest.notFound();
+      if (listTagsForManifestForUpdate(manifest.id()).isEmpty()) {
+        return deleteManifest(repositoryId, imageName, manifest.digest());
+      }
+      // Persist reference deletion separately from the shared manifest body. A subsequent push
+      // restores the digest reference through upsertManifest's replacement attributes.
+      jdbcTemplate.update("UPDATE docker_manifest SET attributes_json = "
+          + jsonColumns.setBoolean("attributes_json", true, DockerManifestRecord.DIGEST_REFERENCE_DELETED)
+          + " WHERE id = ?", manifest.id());
+    } else {
+      int deleted = jdbcTemplate.update("""
+          DELETE FROM docker_tag
+          WHERE repository_id = ? AND image_name_hash = ? AND tag_hash = ? AND manifest_id = ?
+          """, repositoryId, hash(imageName), hash(reference), manifest.id());
+      if (deleted == 0) return DeletedManifest.notFound();
+      if (!manifest.hasDigestReference() && listTagsForManifestForUpdate(manifest.id()).isEmpty()) {
+        return deleteManifest(repositoryId, imageName, manifest.digest());
+      }
+    }
+    return new DeletedManifest(1, null, null);
   }
 
   public boolean referencedDigestExists(long repositoryId, String imageName, String digest) {
@@ -752,8 +787,11 @@ public class JdbcDockerRegistryDao implements com.github.klboke.kkrepo.persisten
         WHERE m.repository_id = ?
           AND m.image_name_hash = ?
           AND m.deleted_at IS NULL
+          AND COALESCE(%s, 'false') <> 'true'
         ORDER BY reference
-        """, (rs, rowNum) -> new BrowseReferenceRow(
+        """.formatted(jsonColumns.extractText(
+            "m.attributes_json", DockerManifestRecord.DIGEST_REFERENCE_DELETED)),
+        (rs, rowNum) -> new BrowseReferenceRow(
             rs.getString("reference"),
             rs.getString("digest"),
             rs.getLong("asset_id"),
@@ -769,7 +807,8 @@ public class JdbcDockerRegistryDao implements com.github.klboke.kkrepo.persisten
     if (ref == null) {
       return Optional.empty();
     }
-    return findManifestByReference(repositoryId, ref.imageName(), ref.reference());
+    return findManifestByReference(repositoryId, ref.imageName(), ref.reference())
+        .filter(manifest -> !ref.reference().contains(":") || manifest.hasDigestReference());
   }
 
   public static byte[] hash(String value) {

--- a/persistence-jdbc/src/test/java/com/github/klboke/kkrepo/persistence/jdbc/contract/PersistenceApiContract.java
+++ b/persistence-jdbc/src/test/java/com/github/klboke/kkrepo/persistence/jdbc/contract/PersistenceApiContract.java
@@ -4951,6 +4951,151 @@ public abstract class PersistenceApiContract {
   }
 
   @Test
+  void dockerBrowseDeletionPreservesTagsUntilTheLastReferenceAndCanBeRepushed() {
+    DockerManifestRecord manifest = dockerBrowseFixture("docker-browse-delete");
+    DockerRegistryDao registry = stores().dockerRegistry();
+    long repo = manifest.repositoryId();
+    String image = manifest.imageName();
+    String digest = manifest.digest();
+    assertEquals(0, inTransaction(() -> registry.deleteBrowseReference(repo, image, "missing")).deleted());
+    assertThrows(IllegalStateException.class, () -> inTransaction(() -> {
+      registry.deleteBrowseReference(repo, image, digest);
+      throw new IllegalStateException("rollback administrative deletion");
+    }));
+    assertTrue(registry.findBrowseManifestByReferencePath(repo, image + "/manifests/" + digest).isPresent());
+
+    var deleted = inTransaction(() -> registry.deleteBrowseReference(repo, image, digest));
+    assertEquals(1, deleted.deleted());
+    assertNull(deleted.assetId(), "tag-owned manifest content must not be released");
+    assertNull(deleted.assetBlobId());
+    assertFalse(registry.findManifestByDigest(repo, image, digest).orElseThrow().hasDigestReference());
+    assertEquals(List.of("1.0.0", "latest"), registry.listBrowseReferences(repo, image).stream()
+        .map(DockerRegistryDao.BrowseReferenceRow::reference).toList());
+    assertTrue(registry.findBrowseManifestByReferencePath(repo, image + "/manifests/" + digest).isEmpty());
+    assertTrue(registry.findBrowseManifestByReferencePath(repo, image + "/manifests/1.0.0").isPresent());
+    assertEquals(0, inTransaction(() -> registry.deleteBrowseReference(repo, image, digest)).deleted());
+    assertNull(inTransaction(() -> registry.deleteBrowseReference(repo, image, "latest")).assetId());
+    assertTrue(registry.findManifestByTag(repo, image, "1.0.0").isPresent());
+    var last = inTransaction(() -> registry.deleteBrowseReference(repo, image, "1.0.0"));
+    assertEquals(1, last.deleted());
+    assertEquals(manifest.assetId(), last.assetId());
+    assertNotNull(last.assetBlobId());
+    assertTrue(registry.findManifestByDigest(repo, image, digest).isEmpty());
+    assertTrue(registry.listBrowseReferences(repo, image).isEmpty());
+
+    inTransaction(() -> registry.upsertManifest(manifest));
+    assertTrue(registry.findBrowseManifestByReferencePath(repo, image + "/manifests/" + digest).isPresent());
+    assertEquals(List.of(digest), registry.listBrowseReferences(repo, image).stream()
+        .map(DockerRegistryDao.BrowseReferenceRow::reference).toList());
+    assertEquals(manifest.assetId(), inTransaction(() ->
+        registry.deleteBrowseReference(repo, image, digest)).assetId(), "untagged digest can be released");
+  }
+
+  @Test
+  void dockerBrowseDigestDeletionSerializesAcrossReplicas() throws Exception {
+    DockerManifestRecord manifest = dockerBrowseFixture("docker-browse-concurrent");
+    DockerRegistryDao registry = stores().dockerRegistry();
+    CountDownLatch locked = new CountDownLatch(1);
+    CountDownLatch release = new CountDownLatch(1);
+    try (var executor = Executors.newFixedThreadPool(2)) {
+      var first = executor.submit(() -> inTransaction(() -> {
+        var deleted = registry.deleteBrowseReference(
+            manifest.repositoryId(), manifest.imageName(), manifest.digest());
+        locked.countDown();
+        await(release);
+        return deleted.deleted();
+      }));
+      assertTrue(locked.await(30, java.util.concurrent.TimeUnit.SECONDS));
+      var second = executor.submit(() -> inTransaction(() -> registry.deleteBrowseReference(
+          manifest.repositoryId(), manifest.imageName(), manifest.digest()).deleted()));
+      try {
+        assertThrows(java.util.concurrent.TimeoutException.class,
+            () -> second.get(250, java.util.concurrent.TimeUnit.MILLISECONDS));
+      } finally {
+        release.countDown();
+      }
+      assertEquals(1, first.get(30, java.util.concurrent.TimeUnit.SECONDS));
+      assertEquals(0, second.get(30, java.util.concurrent.TimeUnit.SECONDS));
+    } finally {
+      release.countDown();
+    }
+    assertEquals(List.of("1.0.0", "latest"), registry.listTags(
+        manifest.repositoryId(), manifest.imageName(), null, 10));
+  }
+
+  @Test
+  void dockerBrowseDeleteUsesTheCurrentAssetAfterWaitingForRepublish() throws Exception {
+    DockerManifestRecord manifest = dockerBrowseFixture("docker-browse-republish");
+    DockerRegistryDao registry = stores().dockerRegistry();
+    long repo = manifest.repositoryId();
+    inTransaction(() -> {
+      registry.deleteTag(repo, manifest.imageName(), "latest");
+      registry.deleteTag(repo, manifest.imageName(), "1.0.0");
+      return null;
+    });
+    AssetRecord prior = stores().assets().findAssetById(manifest.assetId()).orElseThrow();
+    CountDownLatch publishing = new CountDownLatch(1);
+    CountDownLatch release = new CountDownLatch(1);
+    try (var executor = Executors.newFixedThreadPool(2)) {
+      var writer = executor.submit(() -> inTransaction(() -> {
+        registry.findManifestByDigestForUpdate(repo, manifest.imageName(), manifest.digest()).orElseThrow();
+        String path = prior.path() + "/replacement";
+        long assetId = stores().assets().insertAsset(new AssetRecord(null, repo, null, prior.assetBlobId(),
+            prior.format(), path, PersistenceHashes.pathHash(path), prior.name(), prior.kind(),
+            prior.contentType(), prior.size(), null, Instant.now(), prior.attributes()));
+        registry.upsertManifest(new DockerManifestRecord(manifest.id(), repo, manifest.imageName(),
+            manifest.imageNameHash(), manifest.digestAlgorithm(), manifest.digest(), manifest.digestHash(),
+            manifest.mediaType(), null, null, null, assetId, manifest.size(), "publisher", "127.0.0.1",
+            null, Map.of(), manifest.createdAt(), Instant.now()));
+        publishing.countDown();
+        await(release);
+        return assetId;
+      }));
+      assertTrue(publishing.await(30, java.util.concurrent.TimeUnit.SECONDS));
+      var deleting = executor.submit(() -> inTransaction(() -> registry.deleteBrowseReference(
+          repo, manifest.imageName(), manifest.digest())));
+      try {
+        assertThrows(java.util.concurrent.TimeoutException.class,
+            () -> deleting.get(250, java.util.concurrent.TimeUnit.MILLISECONDS));
+      } finally {
+        release.countDown();
+      }
+      long publishedAsset = writer.get(30, java.util.concurrent.TimeUnit.SECONDS);
+      var deleted = deleting.get(30, java.util.concurrent.TimeUnit.SECONDS);
+      assertEquals(publishedAsset, deleted.assetId());
+      assertEquals(prior.assetBlobId(), deleted.assetBlobId());
+    } finally {
+      release.countDown();
+    }
+  }
+
+  private DockerManifestRecord dockerBrowseFixture(String repositoryName) {
+    long repositoryId = createRepository(repositoryName, RepositoryFormat.DOCKER);
+    long blobStoreId = stores().repositories().findById(repositoryId).orElseThrow().blobStoreId();
+    Instant now = Instant.now();
+    long blobId = stores().assets().insertBlob(
+        blob(blobStoreId, "docker/manifests/acme/app/v1", repositoryName + "-manifest"));
+    String image = "acme/app";
+    String digest = "sha256:" + "a".repeat(64);
+    String path = "docker/manifests/acme/app/sha256/" + "a".repeat(64);
+    long assetId = stores().assets().insertAsset(new AssetRecord(
+        null, repositoryId, null, blobId, RepositoryFormat.DOCKER,
+        path, PersistenceHashes.sha256(path), "manifest.json", "MANIFEST",
+        "application/vnd.oci.image.manifest.v1+json", 42L, null, now, Map.of()));
+    return inTransaction(() -> {
+      DockerManifestRecord manifest = stores().dockerRegistry().upsertManifest(new DockerManifestRecord(
+          null, repositoryId, image, PersistenceHashes.sha256(image), "sha256", digest, PersistenceHashes.sha256(digest),
+          "application/vnd.oci.image.manifest.v1+json", null, null, null, assetId, 42L,
+          "contract", "127.0.0.1", null, Map.of(), now, now));
+      for (String tag : List.of("latest", "1.0.0")) {
+        stores().dockerRegistry().upsertTag(new DockerTagRecord(null, repositoryId, image, PersistenceHashes.sha256(image),
+            tag, PersistenceHashes.sha256(tag), manifest.id(), digest, "contract", "127.0.0.1", now, now));
+      }
+      return manifest;
+    });
+  }
+
+  @Test
   void dockerCleanupBatchReadsAndLocksArePortable() {
     long repositoryId = createRepository("docker-cleanup-batches", RepositoryFormat.DOCKER);
     long blobStoreId = stores().repositories().findById(repositoryId).orElseThrow().blobStoreId();

--- a/server/src/main/java/com/github/klboke/kkrepo/server/browse/BrowseContentDeleteController.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/browse/BrowseContentDeleteController.java
@@ -100,6 +100,7 @@ public class BrowseContentDeleteController {
   private RService rService;
   private CondaService condaService;
   private HelmGroupIndexCache helmGroupIndexCache;
+  private DockerBrowseDeleteService dockerDeleteService;
 
   public BrowseContentDeleteController(
       RepositoryDao repositoryDao,
@@ -176,6 +177,11 @@ public class BrowseContentDeleteController {
   @Autowired
   void setHelmDeleteSupport(HelmGroupIndexCache helmGroupIndexCache) {
     this.helmGroupIndexCache = helmGroupIndexCache;
+  }
+
+  @Autowired
+  void setDockerDeleteSupport(DockerBrowseDeleteService dockerDeleteService) {
+    this.dockerDeleteService = dockerDeleteService;
   }
 
   @DeleteMapping("/{repository}")
@@ -329,6 +335,9 @@ public class BrowseContentDeleteController {
     String publicPath = normalize(path);
     if (publicPath.isEmpty()) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "path is required");
+    }
+    if (requested.format() == RepositoryFormat.DOCKER) {
+      return dockerDeleteService.delete(requested, publicPath, sourceRepository);
     }
     AnsibleCoordinate ansibleCoordinate = requested.format() == RepositoryFormat.ANSIBLEGALAXY
         ? ansibleCoordinate(publicPath)

--- a/server/src/main/java/com/github/klboke/kkrepo/server/browse/DockerBrowseDeleteService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/browse/DockerBrowseDeleteService.java
@@ -46,12 +46,14 @@ public class DockerBrowseDeleteService {
       RepositoryRecord requested, String path, String sourceRepository) {
     Reference reference = reference(path);
     for (RepositoryRecord source : sources(requested, sourceRepository)) {
-      if (dockerDao.findManifestByReference(source.id(), reference.image(), reference.value()).isEmpty()) {
+      var manifest = dockerDao.findManifestByReference(source.id(), reference.image(), reference.value());
+      if (manifest.isEmpty() || (DockerPathParser.isDigestReference(reference.value())
+          && !manifest.get().hasDigestReference())) {
         continue;
       }
       var runtime = runtimes.resolveById(source.id()).orElseThrow(() ->
           new ResponseStatusException(HttpStatus.CONFLICT, "Repository runtime is unavailable"));
-      int deleted = manifests.deleteReference(runtime, reference.image(), reference.value());
+      int deleted = manifests.deleteBrowseReference(runtime, reference.image(), reference.value());
       if (deleted == 0) {
         throw notFound(path);
       }

--- a/server/src/main/java/com/github/klboke/kkrepo/server/browse/DockerBrowseDeleteService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/browse/DockerBrowseDeleteService.java
@@ -1,0 +1,136 @@
+package com.github.klboke.kkrepo.server.browse;
+
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.jdbc.api.DockerRegistryDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.RepositoryDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.model.RepositoryRecord;
+import com.github.klboke.kkrepo.protocol.docker.DockerPathParser;
+import com.github.klboke.kkrepo.protocol.docker.DockerProtocolException;
+import com.github.klboke.kkrepo.server.docker.DockerManifestStore;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
+import java.util.LinkedHashSet;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Administrative deletion of Docker browse entries, including locally cached proxy content. */
+@Service
+public class DockerBrowseDeleteService {
+  private static final String MANIFESTS = "/manifests";
+
+  private final RepositoryDao repositoryDao;
+  private final DockerRegistryDao dockerDao;
+  private final RepositoryRuntimeRegistry runtimes;
+  private final DockerManifestStore manifests;
+
+  public DockerBrowseDeleteService(
+      RepositoryDao repositoryDao,
+      DockerRegistryDao dockerDao,
+      RepositoryRuntimeRegistry runtimes,
+      DockerManifestStore manifests) {
+    this.repositoryDao = repositoryDao;
+    this.dockerDao = dockerDao;
+    this.runtimes = runtimes;
+    this.manifests = manifests;
+  }
+
+  /**
+   * Uses database-backed Docker identities, never generic asset path deletion. The transaction
+   * covers the selected references; concurrent uploads after the directory snapshot may remain.
+   * DockerManifestStore maintains tag/manifest/blob state and shared cache versions after commit,
+   * so sibling replicas observe the deletion without depending on this node's browse state.
+   */
+  @Transactional
+  public BrowseContentDeleteController.BrowseDeleteResult delete(
+      RepositoryRecord requested, String path, String sourceRepository) {
+    for (RepositoryRecord source : sources(requested, sourceRepository)) {
+      List<Reference> references = references(source, path);
+      if (references.isEmpty()) {
+        continue;
+      }
+      var runtime = runtimes.resolveById(source.id()).orElseThrow(() ->
+          new ResponseStatusException(HttpStatus.CONFLICT, "Repository runtime is unavailable"));
+      int deleted = 0;
+      for (Reference reference : references) {
+        deleted += manifests.deleteReference(runtime, reference.image(), reference.value());
+      }
+      if (deleted == 0) {
+        throw notFound(path);
+      }
+      return new BrowseContentDeleteController.BrowseDeleteResult(
+          requested.name(), source.name(), path, deleted);
+    }
+    throw notFound(path);
+  }
+
+  private List<RepositoryRecord> sources(RepositoryRecord requested, String sourceRepository) {
+    if (sourceRepository == null || sourceRepository.isBlank()) {
+      return requested.type() == RepositoryType.GROUP
+          ? repositoryDao.listMembers(requested.id()) : List.of(requested);
+    }
+    RepositoryRecord source = repositoryDao.findByName(sourceRepository.trim())
+        .orElseThrow(() -> new ResponseStatusException(
+            HttpStatus.NOT_FOUND, "Repository not found: " + sourceRepository));
+    if (!source.id().equals(requested.id())) {
+      if (requested.type() != RepositoryType.GROUP) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "source must match repository");
+      }
+      if (repositoryDao.listMembers(requested.id()).stream()
+          .noneMatch(member -> member.id().equals(source.id()))) {
+        throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST, "source is not a member of " + requested.name());
+      }
+    }
+    return List.of(source);
+  }
+
+  private List<Reference> references(RepositoryRecord source, String path) {
+    int marker = path.lastIndexOf(MANIFESTS + "/");
+    if (marker > 0) {
+      String value = path.substring(marker + MANIFESTS.length() + 1);
+      if (!value.contains("/")) {
+        String image = path.substring(0, marker);
+        validate(image, value);
+        return dockerDao.findManifestByReference(source.id(), image, value).isPresent()
+            ? List.of(new Reference(image, value)) : List.of();
+      }
+    }
+    boolean manifestDirectory = path.endsWith(MANIFESTS);
+    String parent = manifestDirectory
+        ? path.substring(0, path.length() - MANIFESTS.length()) : path;
+    validate(parent, null);
+    List<String> images = manifestDirectory
+        ? dockerDao.imageExists(source.id(), parent) ? List.of(parent) : List.of()
+        : dockerDao.listBrowseImages(source.id(), parent).stream()
+            .map(DockerRegistryDao.BrowseImageRow::imageName)
+            // SQL LIKE can also match wildcard characters in names; deletion must stay literal.
+            .filter(image -> image.equals(parent) || image.startsWith(parent + "/"))
+            .toList();
+    LinkedHashSet<Reference> references = new LinkedHashSet<>();
+    for (String image : images) {
+      for (DockerRegistryDao.BrowseReferenceRow row : dockerDao.listBrowseReferences(source.id(), image)) {
+        references.add(new Reference(image, row.digest()));
+      }
+    }
+    return List.copyOf(references);
+  }
+
+  private static void validate(String image, String reference) {
+    try {
+      DockerPathParser.validateImageName(image);
+      if (reference != null && !DockerPathParser.isDigestReference(reference)) {
+        DockerPathParser.validateTag(reference);
+      }
+    } catch (DockerProtocolException invalid) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, invalid.getMessage(), invalid);
+    }
+  }
+
+  private static ResponseStatusException notFound(String path) {
+    return new ResponseStatusException(HttpStatus.NOT_FOUND, "Browse path not found: " + path);
+  }
+
+  private record Reference(String image, String value) {}
+}

--- a/server/src/main/java/com/github/klboke/kkrepo/server/browse/DockerBrowseDeleteService.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/browse/DockerBrowseDeleteService.java
@@ -8,7 +8,6 @@ import com.github.klboke.kkrepo.protocol.docker.DockerPathParser;
 import com.github.klboke.kkrepo.protocol.docker.DockerProtocolException;
 import com.github.klboke.kkrepo.server.docker.DockerManifestStore;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
-import java.util.LinkedHashSet;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -37,25 +36,22 @@ public class DockerBrowseDeleteService {
   }
 
   /**
-   * Uses database-backed Docker identities, never generic asset path deletion. The transaction
-   * covers the selected references; concurrent uploads after the directory snapshot may remain.
+   * Uses database-backed Docker identities, never generic asset path deletion. Only tag/digest
+   * leaves are accepted; directory paths do not carry enough information to identify a selection.
    * DockerManifestStore maintains tag/manifest/blob state and shared cache versions after commit,
    * so sibling replicas observe the deletion without depending on this node's browse state.
    */
   @Transactional
   public BrowseContentDeleteController.BrowseDeleteResult delete(
       RepositoryRecord requested, String path, String sourceRepository) {
+    Reference reference = reference(path);
     for (RepositoryRecord source : sources(requested, sourceRepository)) {
-      List<Reference> references = references(source, path);
-      if (references.isEmpty()) {
+      if (dockerDao.findManifestByReference(source.id(), reference.image(), reference.value()).isEmpty()) {
         continue;
       }
       var runtime = runtimes.resolveById(source.id()).orElseThrow(() ->
           new ResponseStatusException(HttpStatus.CONFLICT, "Repository runtime is unavailable"));
-      int deleted = 0;
-      for (Reference reference : references) {
-        deleted += manifests.deleteReference(runtime, reference.image(), reference.value());
-      }
+      int deleted = manifests.deleteReference(runtime, reference.image(), reference.value());
       if (deleted == 0) {
         throw notFound(path);
       }
@@ -86,46 +82,30 @@ public class DockerBrowseDeleteService {
     return List.of(source);
   }
 
-  private List<Reference> references(RepositoryRecord source, String path) {
+  private static Reference reference(String path) {
     int marker = path.lastIndexOf(MANIFESTS + "/");
-    if (marker > 0) {
-      String value = path.substring(marker + MANIFESTS.length() + 1);
-      if (!value.contains("/")) {
-        String image = path.substring(0, marker);
-        validate(image, value);
-        return dockerDao.findManifestByReference(source.id(), image, value).isPresent()
-            ? List.of(new Reference(image, value)) : List.of();
-      }
+    if (marker <= 0) {
+      throw invalidPath();
     }
-    boolean manifestDirectory = path.endsWith(MANIFESTS);
-    String parent = manifestDirectory
-        ? path.substring(0, path.length() - MANIFESTS.length()) : path;
-    validate(parent, null);
-    List<String> images = manifestDirectory
-        ? dockerDao.imageExists(source.id(), parent) ? List.of(parent) : List.of()
-        : dockerDao.listBrowseImages(source.id(), parent).stream()
-            .map(DockerRegistryDao.BrowseImageRow::imageName)
-            // SQL LIKE can also match wildcard characters in names; deletion must stay literal.
-            .filter(image -> image.equals(parent) || image.startsWith(parent + "/"))
-            .toList();
-    LinkedHashSet<Reference> references = new LinkedHashSet<>();
-    for (String image : images) {
-      for (DockerRegistryDao.BrowseReferenceRow row : dockerDao.listBrowseReferences(source.id(), image)) {
-        references.add(new Reference(image, row.digest()));
-      }
+    String image = path.substring(0, marker);
+    String value = path.substring(marker + MANIFESTS.length() + 1);
+    if (value.isEmpty() || value.contains("/")) {
+      throw invalidPath();
     }
-    return List.copyOf(references);
-  }
-
-  private static void validate(String image, String reference) {
     try {
       DockerPathParser.validateImageName(image);
-      if (reference != null && !DockerPathParser.isDigestReference(reference)) {
-        DockerPathParser.validateTag(reference);
+      if (!DockerPathParser.isDigestReference(value)) {
+        DockerPathParser.validateTag(value);
       }
     } catch (DockerProtocolException invalid) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, invalid.getMessage(), invalid);
     }
+    return new Reference(image, value);
+  }
+
+  private static ResponseStatusException invalidPath() {
+    return new ResponseStatusException(
+        HttpStatus.BAD_REQUEST, "Docker deletion requires a tag or digest browse path");
   }
 
   private static ResponseStatusException notFound(String path) {

--- a/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerManifestStore.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/docker/DockerManifestStore.java
@@ -307,17 +307,7 @@ public class DockerManifestStore {
   public int deleteReference(RepositoryRuntime runtime, String imageName, String reference) {
     if (DockerPathParser.isDigestReference(reference)) {
       DockerRegistryDao.DeletedManifest deleted = dockerDao.deleteManifest(runtime.id(), imageName, reference);
-      if (deleted.deleted() > 0) {
-        if (deleted.assetId() != null) {
-          assetDao.deleteAssetById(deleted.assetId());
-        }
-        if (deleted.assetBlobId() != null) {
-          assetDao.markBlobDeletedIfUnreferenced(
-              deleted.assetBlobId(), "docker manifest deleted");
-        }
-        invalidateGroupMemberCaches(runtime);
-      }
-      return deleted.deleted();
+      return completeReferenceDeletion(runtime, deleted);
     }
     DockerPathParser.validateTag(reference);
     int deleted = dockerDao.deleteTag(runtime.id(), imageName, reference);
@@ -325,6 +315,26 @@ public class DockerManifestStore {
       invalidateGroupMemberCaches(runtime);
     }
     return deleted;
+  }
+
+  /** Nexus Browse removes an individual asset reference, preserving tags that share its body. */
+  @Transactional
+  public int deleteBrowseReference(RepositoryRuntime runtime, String imageName, String reference) {
+    return completeReferenceDeletion(
+        runtime, dockerDao.deleteBrowseReference(runtime.id(), imageName, reference));
+  }
+
+  private int completeReferenceDeletion(RepositoryRuntime runtime, DockerRegistryDao.DeletedManifest deleted) {
+    if (deleted.deleted() > 0) {
+      if (deleted.assetId() != null) {
+        assetDao.deleteAssetById(deleted.assetId());
+      }
+      if (deleted.assetBlobId() != null) {
+        assetDao.markBlobDeletedIfUnreferenced(deleted.assetBlobId(), "docker manifest deleted");
+      }
+      invalidateGroupMemberCaches(runtime);
+    }
+    return deleted.deleted();
   }
 
   public List<DockerManifestRecord> referrers(

--- a/server/src/test/java/com/github/klboke/kkrepo/server/browse/BrowseContentDeleteControllerTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/browse/BrowseContentDeleteControllerTest.java
@@ -60,6 +60,22 @@ import org.springframework.web.server.ResponseStatusException;
 
 class BrowseContentDeleteControllerTest {
   @Test
+  void dockerDeletionDelegatesNormalizedBrowsePathAfterAdministratorAuthorization() {
+    Fixture fixture = fixture(true, AccessDecision.allow());
+    RepositoryRecord repository = repository(1L, "docker", RepositoryFormat.DOCKER, RepositoryType.HOSTED);
+    DockerBrowseDeleteService docker = mock(DockerBrowseDeleteService.class);
+    fixture.controller.setDockerDeleteSupport(docker);
+    when(fixture.repositoryDao.findByName("docker")).thenReturn(Optional.of(repository));
+    var expected = new BrowseContentDeleteController.BrowseDeleteResult(
+        "docker", "docker", "hello-world/manifests/latest", 1);
+    when(docker.delete(repository, "hello-world/manifests/latest", "docker")).thenReturn(expected);
+    assertEquals(expected, fixture.controller.delete(
+        "docker", "/hello-world/manifests/latest/", "docker", new MockHttpServletRequest()));
+    verify(fixture.assetDao, never()).findAssetByPath(anyLong(), any());
+    verify(fixture.assetDao, never()).deleteAssetById(anyLong());
+  }
+
+  @Test
   void rHostedDeletionResolvesBrowseCoordinateAndDelegatesToProtocolService() {
     Fixture fixture = fixture(true, AccessDecision.allow());
     RepositoryRecord repository =

--- a/server/src/test/java/com/github/klboke/kkrepo/server/browse/DockerBrowseDeleteServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/browse/DockerBrowseDeleteServiceTest.java
@@ -48,7 +48,7 @@ class DockerBrowseDeleteServiceTest {
       assertEquals("docker", result.repository());
       assertEquals("docker", result.sourceRepository());
       assertEquals(1, result.deletedAssets());
-      verify(manifests).deleteReference(runtime, "team/app", reference);
+      verify(manifests).deleteBrowseReference(runtime, "team/app", reference);
     }
   }
 
@@ -58,7 +58,7 @@ class DockerBrowseDeleteServiceTest {
     when(repositories.findByName(proxy.name())).thenReturn(Optional.of(proxy));
     assertEquals(proxy.name(), service.delete(
         proxy, "hello-world/manifests/latest", "  " + proxy.name() + " ").sourceRepository());
-    verify(manifests).deleteReference(runtime, "hello-world", "latest");
+    verify(manifests).deleteBrowseReference(runtime, "hello-world", "latest");
   }
 
   @Test
@@ -70,7 +70,7 @@ class DockerBrowseDeleteServiceTest {
     assertEquals(group.name(), result.repository());
     assertEquals(proxy.name(), result.sourceRepository());
     verify(docker, never()).findManifestByReference(eq(hosted.id()), anyString(), anyString());
-    verify(manifests).deleteReference(runtime, "hello-world", "latest");
+    verify(manifests).deleteBrowseReference(runtime, "hello-world", "latest");
   }
 
   @Test
@@ -97,7 +97,7 @@ class DockerBrowseDeleteServiceTest {
     for (String image : List.of("team", "team/manifests", "team/manifests/child")) {
       RepositoryRuntime runtime = referenceExists(hosted, image, "latest");
       assertEquals(1, service.delete(hosted, image + "/manifests/latest", null).deletedAssets());
-      verify(manifests).deleteReference(runtime, image, "latest");
+      verify(manifests).deleteBrowseReference(runtime, image, "latest");
     }
   }
 
@@ -108,6 +108,14 @@ class DockerBrowseDeleteServiceTest {
     }
     when(repositories.listMembers(group.id())).thenReturn(List.of());
     status(HttpStatus.NOT_FOUND, () -> service.delete(group, "missing/manifests/latest", null));
+    verifyNoInteractions(manifests);
+  }
+
+  @Test
+  void deletedDigestCannotBeDeletedAgainWhileItsTagsRetainTheBody() {
+    DockerManifestRecord manifest = mock(DockerManifestRecord.class);
+    when(docker.findManifestByReference(hosted.id(), "team/app", DIGEST)).thenReturn(Optional.of(manifest));
+    status(HttpStatus.NOT_FOUND, () -> service.delete(hosted, "team/app/manifests/" + DIGEST, null));
     verifyNoInteractions(manifests);
   }
 
@@ -142,10 +150,11 @@ class DockerBrowseDeleteServiceTest {
   }
 
   private RepositoryRuntime referenceExists(RepositoryRecord repository, String image, String value) {
-    when(docker.findManifestByReference(repository.id(), image, value))
-        .thenReturn(Optional.of(mock(DockerManifestRecord.class)));
+    DockerManifestRecord manifest = mock(DockerManifestRecord.class);
+    when(manifest.hasDigestReference()).thenReturn(true);
+    when(docker.findManifestByReference(repository.id(), image, value)).thenReturn(Optional.of(manifest));
     RepositoryRuntime runtime = runtime(repository);
-    when(manifests.deleteReference(runtime, image, value)).thenReturn(1);
+    when(manifests.deleteBrowseReference(runtime, image, value)).thenReturn(1);
     return runtime;
   }
 

--- a/server/src/test/java/com/github/klboke/kkrepo/server/browse/DockerBrowseDeleteServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/browse/DockerBrowseDeleteServiceTest.java
@@ -1,0 +1,211 @@
+package com.github.klboke.kkrepo.server.browse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.github.klboke.kkrepo.core.RepositoryFormat;
+import com.github.klboke.kkrepo.core.RepositoryType;
+import com.github.klboke.kkrepo.persistence.jdbc.api.DockerRegistryDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.RepositoryDao;
+import com.github.klboke.kkrepo.persistence.jdbc.api.model.RepositoryRecord;
+import com.github.klboke.kkrepo.persistence.jdbc.api.model.docker.DockerManifestRecord;
+import com.github.klboke.kkrepo.server.docker.DockerManifestStore;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+class DockerBrowseDeleteServiceTest {
+  private static final String DIGEST = "sha256:" + "a".repeat(64);
+  private final RepositoryDao repositories = mock(RepositoryDao.class);
+  private final DockerRegistryDao docker = mock(DockerRegistryDao.class);
+  private final RepositoryRuntimeRegistry runtimes = mock(RepositoryRuntimeRegistry.class);
+  private final DockerManifestStore manifests = mock(DockerManifestStore.class);
+  private final DockerBrowseDeleteService service =
+      new DockerBrowseDeleteService(repositories, docker, runtimes, manifests);
+  private final RepositoryRecord hosted = repository(1, "docker", RepositoryType.HOSTED);
+  private final RepositoryRecord proxy = repository(2, "docker-proxy", RepositoryType.PROXY);
+  private final RepositoryRecord group = repository(3, "docker-group", RepositoryType.GROUP);
+
+  @Test
+  void tagsAndDigestsPreserveTheirReferenceIdentity() {
+    for (String reference : List.of("latest", "1.0.0", DIGEST)) {
+      RepositoryRuntime runtime = referenceExists(hosted, "team/app", reference);
+      var result = service.delete(hosted, "team/app/manifests/" + reference, null);
+      assertEquals("docker", result.repository());
+      assertEquals("docker", result.sourceRepository());
+      assertEquals(1, result.deletedAssets());
+      verify(manifests).deleteReference(runtime, "team/app", reference);
+    }
+  }
+
+  @Test
+  void proxyDeletionOnlyUsesLocalRegistryState() {
+    RepositoryRuntime runtime = referenceExists(proxy, "hello-world", "latest");
+    when(repositories.findByName(proxy.name())).thenReturn(Optional.of(proxy));
+    assertEquals(proxy.name(), service.delete(
+        proxy, "hello-world/manifests/latest", "  " + proxy.name() + " ").sourceRepository());
+    verify(manifests).deleteReference(runtime, "hello-world", "latest");
+  }
+
+  @Test
+  void groupDeletionHonorsExplicitSourceEvenWhenAnotherMemberHasTheSameTag() {
+    when(repositories.listMembers(group.id())).thenReturn(List.of(hosted, proxy));
+    when(repositories.findByName(proxy.name())).thenReturn(Optional.of(proxy));
+    RepositoryRuntime runtime = referenceExists(proxy, "hello-world", "latest");
+    var result = service.delete(group, "hello-world/manifests/latest", proxy.name());
+    assertEquals(group.name(), result.repository());
+    assertEquals(proxy.name(), result.sourceRepository());
+    verify(docker, never()).findManifestByReference(eq(hosted.id()), anyString(), anyString());
+    verify(manifests).deleteReference(runtime, "hello-world", "latest");
+  }
+
+  @Test
+  void groupWithoutSourceSelectsFirstMatchingMember() {
+    when(repositories.listMembers(group.id())).thenReturn(List.of(hosted, proxy));
+    referenceExists(proxy, "hello-world", "latest");
+    assertEquals(proxy.name(), service.delete(
+        group, "hello-world/manifests/latest", " ").sourceRepository());
+    referenceExists(hosted, "hello-world", "latest");
+    assertEquals(hosted.name(), service.delete(
+        group, "hello-world/manifests/latest", null).sourceRepository());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"team", "team/app"})
+  void directoryDeletionDeduplicatesDigestsAndKeepsLiteralSubtree(String path) {
+    when(docker.listBrowseImages(hosted.id(), path)).thenReturn(List.of(
+        image("team/app"), image("team/app/child"), image("teamb/app")));
+    when(docker.listBrowseReferences(hosted.id(), "team/app"))
+        .thenReturn(List.of(reference("latest"), reference("1.0.0"), reference(DIGEST)));
+    when(docker.listBrowseReferences(hosted.id(), "team/app/child"))
+        .thenReturn(List.of(reference(DIGEST)));
+    RepositoryRuntime runtime = runtime(hosted);
+    when(manifests.deleteReference(eq(runtime), anyString(), eq(DIGEST))).thenReturn(1);
+    assertEquals(2, service.delete(hosted, path, null).deletedAssets());
+    verify(manifests).deleteReference(runtime, "team/app", DIGEST);
+    verify(manifests).deleteReference(runtime, "team/app/child", DIGEST);
+    verify(docker, never()).listBrowseReferences(hosted.id(), "teamb/app");
+  }
+
+  @Test
+  void sqlWildcardMatchesCannotBroadenDirectoryDeletion() {
+    when(docker.listBrowseImages(hosted.id(), "team_app"))
+        .thenReturn(List.of(image("team_app"), image("teamXapp")));
+    when(docker.listBrowseReferences(hosted.id(), "team_app"))
+        .thenReturn(List.of(reference(DIGEST)));
+    RepositoryRuntime runtime = runtime(hosted);
+    when(manifests.deleteReference(runtime, "team_app", DIGEST)).thenReturn(1);
+    assertEquals(1, service.delete(hosted, "team_app", null).deletedAssets());
+    verify(docker, never()).listBrowseReferences(hosted.id(), "teamXapp");
+  }
+
+  @Test
+  void manifestsDirectoryDeletesOnlyTheExactImage() {
+    when(docker.imageExists(hosted.id(), "team/app")).thenReturn(true);
+    when(docker.listBrowseReferences(hosted.id(), "team/app"))
+        .thenReturn(List.of(reference("latest"), reference(DIGEST)));
+    RepositoryRuntime runtime = runtime(hosted);
+    when(manifests.deleteReference(runtime, "team/app", DIGEST)).thenReturn(1);
+    assertEquals(1, service.delete(hosted, "team/app/manifests", null).deletedAssets());
+    verify(docker, never()).listBrowseImages(anyLong(), anyString());
+    verify(manifests).deleteReference(runtime, "team/app", DIGEST);
+  }
+
+  @Test
+  void intermediateManifestsSegmentCanBelongToAnImageName() {
+    String path = "team/manifests/app/child";
+    when(docker.listBrowseImages(hosted.id(), path)).thenReturn(List.of(image(path)));
+    when(docker.listBrowseReferences(hosted.id(), path)).thenReturn(List.of(reference(DIGEST)));
+    RepositoryRuntime runtime = runtime(hosted);
+    when(manifests.deleteReference(runtime, path, DIGEST)).thenReturn(1);
+    assertEquals(1, service.delete(hosted, path, null).deletedAssets());
+  }
+
+  @Test
+  void missingPathsAndReferencesReturn404WithoutMutation() {
+    for (String path : List.of("missing", "missing/manifests", "missing/manifests/latest")) {
+      status(HttpStatus.NOT_FOUND, () -> service.delete(hosted, path, null));
+    }
+    when(repositories.listMembers(group.id())).thenReturn(List.of());
+    status(HttpStatus.NOT_FOUND, () -> service.delete(group, "missing", null));
+    verifyNoInteractions(manifests);
+  }
+
+  @Test
+  void invalidPathsReturn400WithoutMutation() {
+    for (String path : List.of("", "Team/app", "team/app/manifests/bad tag")) {
+      status(HttpStatus.BAD_REQUEST, () -> service.delete(hosted, path, null));
+    }
+    verifyNoInteractions(manifests);
+  }
+
+  @Test
+  void sourceMustExistAndBelongToRequestedRepository() {
+    status(HttpStatus.NOT_FOUND, () -> service.delete(hosted, "team/app", "missing"));
+    when(repositories.findByName(proxy.name())).thenReturn(Optional.of(proxy));
+    status(HttpStatus.BAD_REQUEST, () -> service.delete(hosted, "team/app", proxy.name()));
+    when(repositories.listMembers(group.id())).thenReturn(List.of(hosted));
+    status(HttpStatus.BAD_REQUEST, () -> service.delete(group, "team/app", proxy.name()));
+    verifyNoInteractions(docker, manifests);
+  }
+
+  @Test
+  void unavailableRuntimeAndConcurrentDeletionFailWithoutFallbackToAnotherMember() {
+    when(docker.findManifestByReference(hosted.id(), "team/app", "latest"))
+        .thenReturn(Optional.of(mock(DockerManifestRecord.class)));
+    status(HttpStatus.CONFLICT, () -> service.delete(hosted, "team/app/manifests/latest", null));
+    verifyNoInteractions(manifests);
+    runtime(hosted);
+    when(repositories.listMembers(group.id())).thenReturn(List.of(hosted, proxy));
+    status(HttpStatus.NOT_FOUND, () -> service.delete(group, "team/app/manifests/latest", null));
+    verify(docker, never()).findManifestByReference(eq(proxy.id()), anyString(), anyString());
+  }
+
+  private RepositoryRuntime referenceExists(RepositoryRecord repository, String image, String value) {
+    when(docker.findManifestByReference(repository.id(), image, value))
+        .thenReturn(Optional.of(mock(DockerManifestRecord.class)));
+    RepositoryRuntime runtime = runtime(repository);
+    when(manifests.deleteReference(runtime, image, value)).thenReturn(1);
+    return runtime;
+  }
+
+  private RepositoryRuntime runtime(RepositoryRecord repository) {
+    RepositoryRuntime runtime = mock(RepositoryRuntime.class);
+    when(runtimes.resolveById(repository.id())).thenReturn(Optional.of(runtime));
+    return runtime;
+  }
+
+  private static RepositoryRecord repository(long id, String name, RepositoryType type) {
+    return new RepositoryRecord(id, name, RepositoryFormat.DOCKER, type, name,
+        true, 7L, null, null, null, null, "ALLOW", true, Map.of());
+  }
+
+  private static DockerRegistryDao.BrowseImageRow image(String name) {
+    return new DockerRegistryDao.BrowseImageRow(name, Instant.EPOCH, 1L, "application/json");
+  }
+
+  private static DockerRegistryDao.BrowseReferenceRow reference(String value) {
+    return new DockerRegistryDao.BrowseReferenceRow(value, DIGEST, 11L, 1L,
+        "application/json", Instant.EPOCH);
+  }
+
+  private static void status(HttpStatus expected, Runnable action) {
+    assertEquals(expected, assertThrows(ResponseStatusException.class, action::run).getStatusCode());
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/browse/DockerBrowseDeleteServiceTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/browse/DockerBrowseDeleteServiceTest.java
@@ -2,7 +2,6 @@ package com.github.klboke.kkrepo.server.browse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -20,7 +19,6 @@ import com.github.klboke.kkrepo.persistence.jdbc.api.model.docker.DockerManifest
 import com.github.klboke.kkrepo.server.docker.DockerManifestStore;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntime;
 import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
-import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -87,69 +85,35 @@ class DockerBrowseDeleteServiceTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"team", "team/app"})
-  void directoryDeletionDeduplicatesDigestsAndKeepsLiteralSubtree(String path) {
-    when(docker.listBrowseImages(hosted.id(), path)).thenReturn(List.of(
-        image("team/app"), image("team/app/child"), image("teamb/app")));
-    when(docker.listBrowseReferences(hosted.id(), "team/app"))
-        .thenReturn(List.of(reference("latest"), reference("1.0.0"), reference(DIGEST)));
-    when(docker.listBrowseReferences(hosted.id(), "team/app/child"))
-        .thenReturn(List.of(reference(DIGEST)));
-    RepositoryRuntime runtime = runtime(hosted);
-    when(manifests.deleteReference(eq(runtime), anyString(), eq(DIGEST))).thenReturn(1);
-    assertEquals(2, service.delete(hosted, path, null).deletedAssets());
-    verify(manifests).deleteReference(runtime, "team/app", DIGEST);
-    verify(manifests).deleteReference(runtime, "team/app/child", DIGEST);
-    verify(docker, never()).listBrowseReferences(hosted.id(), "teamb/app");
+  @ValueSource(strings = {"team", "team/manifests", "team/app/manifests",
+      "team/manifests/child/manifests", "team/app/manifests/latest/child"})
+  void directoryPathsCannotBeReinterpretedAsAnotherImage(String path) {
+    status(HttpStatus.BAD_REQUEST, () -> service.delete(hosted, path, null));
+    verifyNoInteractions(docker, manifests);
   }
 
   @Test
-  void sqlWildcardMatchesCannotBroadenDirectoryDeletion() {
-    when(docker.listBrowseImages(hosted.id(), "team_app"))
-        .thenReturn(List.of(image("team_app"), image("teamXapp")));
-    when(docker.listBrowseReferences(hosted.id(), "team_app"))
-        .thenReturn(List.of(reference(DIGEST)));
-    RepositoryRuntime runtime = runtime(hosted);
-    when(manifests.deleteReference(runtime, "team_app", DIGEST)).thenReturn(1);
-    assertEquals(1, service.delete(hosted, "team_app", null).deletedAssets());
-    verify(docker, never()).listBrowseReferences(hosted.id(), "teamXapp");
-  }
-
-  @Test
-  void manifestsDirectoryDeletesOnlyTheExactImage() {
-    when(docker.imageExists(hosted.id(), "team/app")).thenReturn(true);
-    when(docker.listBrowseReferences(hosted.id(), "team/app"))
-        .thenReturn(List.of(reference("latest"), reference(DIGEST)));
-    RepositoryRuntime runtime = runtime(hosted);
-    when(manifests.deleteReference(runtime, "team/app", DIGEST)).thenReturn(1);
-    assertEquals(1, service.delete(hosted, "team/app/manifests", null).deletedAssets());
-    verify(docker, never()).listBrowseImages(anyLong(), anyString());
-    verify(manifests).deleteReference(runtime, "team/app", DIGEST);
-  }
-
-  @Test
-  void intermediateManifestsSegmentCanBelongToAnImageName() {
-    String path = "team/manifests/app/child";
-    when(docker.listBrowseImages(hosted.id(), path)).thenReturn(List.of(image(path)));
-    when(docker.listBrowseReferences(hosted.id(), path)).thenReturn(List.of(reference(DIGEST)));
-    RepositoryRuntime runtime = runtime(hosted);
-    when(manifests.deleteReference(runtime, path, DIGEST)).thenReturn(1);
-    assertEquals(1, service.delete(hosted, path, null).deletedAssets());
+  void imageNamesEndingInManifestsRetainTheirIdentity() {
+    for (String image : List.of("team", "team/manifests", "team/manifests/child")) {
+      RepositoryRuntime runtime = referenceExists(hosted, image, "latest");
+      assertEquals(1, service.delete(hosted, image + "/manifests/latest", null).deletedAssets());
+      verify(manifests).deleteReference(runtime, image, "latest");
+    }
   }
 
   @Test
   void missingPathsAndReferencesReturn404WithoutMutation() {
-    for (String path : List.of("missing", "missing/manifests", "missing/manifests/latest")) {
+    for (String path : List.of("missing/manifests/latest", "missing/manifests/" + DIGEST)) {
       status(HttpStatus.NOT_FOUND, () -> service.delete(hosted, path, null));
     }
     when(repositories.listMembers(group.id())).thenReturn(List.of());
-    status(HttpStatus.NOT_FOUND, () -> service.delete(group, "missing", null));
+    status(HttpStatus.NOT_FOUND, () -> service.delete(group, "missing/manifests/latest", null));
     verifyNoInteractions(manifests);
   }
 
   @Test
   void invalidPathsReturn400WithoutMutation() {
-    for (String path : List.of("", "Team/app", "team/app/manifests/bad tag")) {
+    for (String path : List.of("", "Team/app/manifests/latest", "team/app/manifests/", "team/app/manifests/bad tag")) {
       status(HttpStatus.BAD_REQUEST, () -> service.delete(hosted, path, null));
     }
     verifyNoInteractions(manifests);
@@ -157,11 +121,11 @@ class DockerBrowseDeleteServiceTest {
 
   @Test
   void sourceMustExistAndBelongToRequestedRepository() {
-    status(HttpStatus.NOT_FOUND, () -> service.delete(hosted, "team/app", "missing"));
+    status(HttpStatus.NOT_FOUND, () -> service.delete(hosted, "team/app/manifests/latest", "missing"));
     when(repositories.findByName(proxy.name())).thenReturn(Optional.of(proxy));
-    status(HttpStatus.BAD_REQUEST, () -> service.delete(hosted, "team/app", proxy.name()));
+    status(HttpStatus.BAD_REQUEST, () -> service.delete(hosted, "team/app/manifests/latest", proxy.name()));
     when(repositories.listMembers(group.id())).thenReturn(List.of(hosted));
-    status(HttpStatus.BAD_REQUEST, () -> service.delete(group, "team/app", proxy.name()));
+    status(HttpStatus.BAD_REQUEST, () -> service.delete(group, "team/app/manifests/latest", proxy.name()));
     verifyNoInteractions(docker, manifests);
   }
 
@@ -194,15 +158,6 @@ class DockerBrowseDeleteServiceTest {
   private static RepositoryRecord repository(long id, String name, RepositoryType type) {
     return new RepositoryRecord(id, name, RepositoryFormat.DOCKER, type, name,
         true, 7L, null, null, null, null, "ALLOW", true, Map.of());
-  }
-
-  private static DockerRegistryDao.BrowseImageRow image(String name) {
-    return new DockerRegistryDao.BrowseImageRow(name, Instant.EPOCH, 1L, "application/json");
-  }
-
-  private static DockerRegistryDao.BrowseReferenceRow reference(String value) {
-    return new DockerRegistryDao.BrowseReferenceRow(value, DIGEST, 11L, 1L,
-        "application/json", Instant.EPOCH);
   }
 
   private static void status(HttpStatus expected, Runnable action) {

--- a/server/src/test/java/com/github/klboke/kkrepo/server/config/DatabaseServerSmokeTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/config/DatabaseServerSmokeTest.java
@@ -284,6 +284,8 @@ class DatabaseServerSmokeTest {
         null, null, 0, 10));
     assertEquals(1, audit.total());
     assertEquals("admin", audit.items().getFirst().actorUserId());
+
+    DockerBrowseDeleteSmokeChecks.exercise(first, second);
   }
 
   private static CleanupRunService.RunView awaitCleanupRun(

--- a/server/src/test/java/com/github/klboke/kkrepo/server/config/DockerBrowseDeleteSmokeChecks.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/config/DockerBrowseDeleteSmokeChecks.java
@@ -1,0 +1,129 @@
+package com.github.klboke.kkrepo.server.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.klboke.kkrepo.persistence.jdbc.api.AssetDao;
+import com.github.klboke.kkrepo.protocol.docker.DockerConstants;
+import com.github.klboke.kkrepo.protocol.docker.DockerDigest;
+import com.github.klboke.kkrepo.server.docker.DockerBlobStore;
+import com.github.klboke.kkrepo.server.docker.DockerManifestStore;
+import com.github.klboke.kkrepo.server.maven.BlobStorageRegistry;
+import com.github.klboke.kkrepo.server.maven.RepositoryRuntimeRegistry;
+import com.github.klboke.kkrepo.server.repositories.RepositoryCommands.CreateCommand;
+import com.github.klboke.kkrepo.server.repositories.RepositoryCommands.DockerSettings;
+import com.github.klboke.kkrepo.server.repositories.RepositoryCommands.GroupSettings;
+import com.github.klboke.kkrepo.server.repositories.RepositoryCommands.HostedSettings;
+import com.github.klboke.kkrepo.server.repositories.RepositoryService;
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
+import org.springframework.boot.web.server.context.WebServerApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+
+/** Runs through real HTTP, JDBC, transactions and sibling replicas in both database smoke jobs. */
+final class DockerBrowseDeleteSmokeChecks {
+  private static final HttpClient HTTP = HttpClient.newHttpClient();
+
+  private DockerBrowseDeleteSmokeChecks() {}
+
+  static void exercise(ConfigurableApplicationContext first, ConfigurableApplicationContext second)
+      throws Exception {
+    RepositoryService repositories = first.getBean(RepositoryService.class);
+    repositories.create(new CreateCommand("smoke-docker", "docker-hosted", true, "smoke-file", true,
+        new HostedSettings("ALLOW", null, null), null, null,
+        new DockerSettings(false, null, null), null, null));
+    repositories.create(new CreateCommand("smoke-docker-group", "docker-group", true, "smoke-file", true,
+        null, null, null, new DockerSettings(false, null, null), null,
+        new GroupSettings(List.of("smoke-docker"))));
+    var runtime = first.getBean(RepositoryRuntimeRegistry.class).resolve("smoke-docker").orElseThrow();
+    var blobs = first.getBean(DockerBlobStore.class);
+    byte[] config = "{}".getBytes(StandardCharsets.UTF_8);
+    byte[] layer = "shared-docker-layer".getBytes(StandardCharsets.UTF_8);
+    DockerDigest configDigest = DockerDigest.sha256(config);
+    DockerDigest layerDigest = DockerDigest.sha256(layer);
+    for (byte[] bytes : List.of(config, layer)) {
+      blobs.putBlob(runtime, DockerDigest.sha256(bytes), new ByteArrayInputStream(bytes), bytes.length,
+          "application/octet-stream", "admin", "127.0.0.1");
+    }
+    byte[] body = ("""
+        {"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json",
+         "config":{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"%s","size":%d},
+         "layers":[{"mediaType":"application/vnd.oci.image.layer.v1.tar","digest":"%s","size":%d}]}
+        """).formatted(configDigest.value(), config.length, layerDigest.value(), layer.length)
+        .getBytes(StandardCharsets.UTF_8);
+    var manifests = first.getBean(DockerManifestStore.class);
+    for (String image : List.of("team/app", "team/other", "outside/app")) {
+      manifests.putManifest(runtime, image, "latest", body, DockerConstants.MEDIA_TYPE_OCI_MANIFEST,
+          "admin", "127.0.0.1", true);
+    }
+    var app = manifests.putManifest(runtime, "team/app", "1.0.0", body,
+        DockerConstants.MEDIA_TYPE_OCI_MANIFEST, "admin", "127.0.0.1", true);
+    second.getBean(BlobStorageRegistry.class).refreshAll();
+
+    HttpResponse<String> browse = request(second, "GET",
+        "/internal/browse/smoke-docker?path=team/app/manifests");
+    assertEquals(200, browse.statusCode(), browse.body());
+    assertTrue(browse.body().contains("team/app/manifests/latest"), browse.body());
+    assertManifest(second, "smoke-docker-group", "team/app", "latest", 200);
+    assertManifest(second, "smoke-docker-group", "team/app", "1.0.0", 200);
+
+    delete(first, "smoke-docker", "team/app/manifests/latest", "");
+    assertManifest(second, "smoke-docker", "team/app", "latest", 404);
+    assertManifest(second, "smoke-docker-group", "team/app", "latest", 404);
+    assertManifest(second, "smoke-docker", "team/app", "1.0.0", 200);
+    assertManifest(second, "smoke-docker", "team/app", app.manifest().digest(), 200);
+
+    delete(first, "smoke-docker-group", "team/app/manifests/" + app.manifest().digest(),
+        "&source=smoke-docker");
+    assertManifest(second, "smoke-docker", "team/app", "1.0.0", 404);
+    assertManifest(second, "smoke-docker-group", "team/app", "1.0.0", 404);
+    assertManifest(second, "smoke-docker", "team/app", app.manifest().digest(), 404);
+    assertManifest(second, "smoke-docker", "team/other", "latest", 200);
+    assertTrue(second.getBean(AssetDao.class).findBlobById(app.blob().id()).isPresent(),
+        "the manifest body is still shared by another image");
+    assertEquals(200, request(second, "GET", "/v2/smoke-docker/team/other/blobs/" + layerDigest.value())
+        .statusCode(), "shared layers remain downloadable");
+
+    delete(first, "smoke-docker", "team", "");
+    assertManifest(second, "smoke-docker", "team/other", "latest", 404);
+    assertManifest(second, "smoke-docker", "outside/app", "latest", 200);
+    delete(first, "smoke-docker", "outside/app/manifests", "");
+    assertManifest(second, "smoke-docker", "outside/app", "latest", 404);
+    assertEquals(404, request(first, "DELETE",
+        "/internal/browse/smoke-docker?path=outside/app/manifests/latest").statusCode());
+  }
+
+  private static void delete(ConfigurableApplicationContext context, String repository,
+      String path, String source) throws Exception {
+    HttpResponse<String> deleted = request(context, "DELETE", "/internal/browse/" + repository
+        + "?path=" + URLEncoder.encode(path, StandardCharsets.UTF_8) + source);
+    assertEquals(200, deleted.statusCode(), deleted.body());
+  }
+
+  private static void assertManifest(ConfigurableApplicationContext context, String repository,
+      String image, String reference, int status) throws Exception {
+    HttpResponse<String> response = request(context, "GET",
+        "/v2/" + repository + "/" + image + "/manifests/" + reference);
+    assertEquals(status, response.statusCode(), response.body());
+  }
+
+  private static HttpResponse<String> request(ConfigurableApplicationContext context,
+      String method, String path) throws Exception {
+    int port = ((WebServerApplicationContext) context).getWebServer().getPort();
+    HttpRequest request = HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + path))
+        .timeout(Duration.ofSeconds(20))
+        .header("Authorization", "Basic " + Base64.getEncoder().encodeToString(
+            "admin:SmokeAdmin1234!".getBytes(StandardCharsets.UTF_8)))
+        .header("Accept", DockerConstants.MEDIA_TYPE_OCI_MANIFEST + ", application/json")
+        .method(method, HttpRequest.BodyPublishers.noBody()).build();
+    return HTTP.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+}

--- a/server/src/test/java/com/github/klboke/kkrepo/server/config/DockerBrowseDeleteSmokeChecks.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/config/DockerBrowseDeleteSmokeChecks.java
@@ -1,6 +1,7 @@
 package com.github.klboke.kkrepo.server.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.klboke.kkrepo.persistence.jdbc.api.AssetDao;
@@ -83,9 +84,29 @@ final class DockerBrowseDeleteSmokeChecks {
 
     delete(first, "smoke-docker-group", "team/app/manifests/" + app.manifest().digest(),
         "&source=smoke-docker");
-    assertManifest(second, "smoke-docker", "team/app", "1.0.0", 404);
-    assertManifest(second, "smoke-docker-group", "team/app", "1.0.0", 404);
+    assertManifest(second, "smoke-docker", "team/app", "1.0.0", 200);
+    assertManifest(second, "smoke-docker-group", "team/app", "1.0.0", 200);
+    HttpResponse<String> remaining = request(second, "GET",
+        "/internal/browse/smoke-docker-group?path=team/app/manifests");
+    assertEquals(200, remaining.statusCode(), remaining.body());
+    assertFalse(remaining.body().contains(app.manifest().digest()), remaining.body());
+    assertTrue(remaining.body().contains("team/app/manifests/1.0.0"), remaining.body());
+    assertEquals(404, request(second, "DELETE", "/internal/browse/smoke-docker?path="
+        + URLEncoder.encode("team/app/manifests/" + app.manifest().digest(), StandardCharsets.UTF_8))
+        .statusCode());
+
+    // A subsequent push reintroduces the deleted digest reference without replacing other tags.
+    manifests.putManifest(runtime, "team/app", "2.0.0", body,
+        DockerConstants.MEDIA_TYPE_OCI_MANIFEST, "admin", "127.0.0.1", true);
+    assertTrue(request(second, "GET", "/internal/browse/smoke-docker?path=team/app/manifests")
+        .body().contains(app.manifest().digest()));
+    delete(first, "smoke-docker", "team/app/manifests/" + app.manifest().digest(), "");
+    delete(first, "smoke-docker", "team/app/manifests/1.0.0", "");
+    assertManifest(second, "smoke-docker-group", "team/app", "2.0.0", 200);
+    delete(first, "smoke-docker", "team/app/manifests/2.0.0", "");
+    assertManifest(second, "smoke-docker-group", "team/app", "2.0.0", 404);
     assertManifest(second, "smoke-docker", "team/app", app.manifest().digest(), 404);
+    assertTrue(second.getBean(AssetDao.class).findAssetById(app.asset().id()).isEmpty());
     assertManifest(second, "smoke-docker", "team/other", "latest", 200);
     assertTrue(second.getBean(AssetDao.class).findBlobById(app.blob().id()).isPresent(),
         "the manifest body is still shared by another image");

--- a/server/src/test/java/com/github/klboke/kkrepo/server/config/DockerBrowseDeleteSmokeChecks.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/config/DockerBrowseDeleteSmokeChecks.java
@@ -60,7 +60,7 @@ final class DockerBrowseDeleteSmokeChecks {
         """).formatted(configDigest.value(), config.length, layerDigest.value(), layer.length)
         .getBytes(StandardCharsets.UTF_8);
     var manifests = first.getBean(DockerManifestStore.class);
-    for (String image : List.of("team/app", "team/other", "outside/app")) {
+    for (String image : List.of("team/app", "team/other", "team", "team/manifests")) {
       manifests.putManifest(runtime, image, "latest", body, DockerConstants.MEDIA_TYPE_OCI_MANIFEST,
           "admin", "127.0.0.1", true);
     }
@@ -92,13 +92,18 @@ final class DockerBrowseDeleteSmokeChecks {
     assertEquals(200, request(second, "GET", "/v2/smoke-docker/team/other/blobs/" + layerDigest.value())
         .statusCode(), "shared layers remain downloadable");
 
-    delete(first, "smoke-docker", "team", "");
-    assertManifest(second, "smoke-docker", "team/other", "latest", 404);
-    assertManifest(second, "smoke-docker", "outside/app", "latest", 200);
-    delete(first, "smoke-docker", "outside/app/manifests", "");
-    assertManifest(second, "smoke-docker", "outside/app", "latest", 404);
+    for (String directory : List.of("team", "team/manifests", "team/other/manifests")) {
+      assertEquals(400, request(first, "DELETE",
+          "/internal/browse/smoke-docker?path=" + directory).statusCode());
+    }
+    assertManifest(second, "smoke-docker", "team/other", "latest", 200);
+    assertManifest(second, "smoke-docker", "team", "latest", 200);
+    assertManifest(second, "smoke-docker", "team/manifests", "latest", 200);
+    delete(first, "smoke-docker", "team/manifests/manifests/latest", "");
+    assertManifest(second, "smoke-docker", "team/manifests", "latest", 404);
+    assertManifest(second, "smoke-docker", "team", "latest", 200);
     assertEquals(404, request(first, "DELETE",
-        "/internal/browse/smoke-docker?path=outside/app/manifests/latest").statusCode());
+        "/internal/browse/smoke-docker?path=team/manifests/manifests/latest").statusCode());
   }
 
   private static void delete(ConfigurableApplicationContext context, String repository,

--- a/server/src/test/java/com/github/klboke/kkrepo/server/docker/DockerManifestStoreTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/docker/DockerManifestStoreTest.java
@@ -380,6 +380,43 @@ class DockerManifestStoreTest {
   }
 
   @Test
+  void browseDigestDeletionRetainsAssetsAndInvalidatesSiblingCaches() {
+    AssetDao assets = mock(AssetDao.class);
+    DockerRegistryDao docker = mock(DockerRegistryDao.class);
+    var cache = mock(com.github.klboke.kkrepo.server.cache.GroupMemberAssetCache.class);
+    RepositoryRuntime runtime = runtime("ALLOW");
+    DockerManifestStore store = new DockerManifestStore(assets, docker, mock(DockerBlobStore.class),
+        mock(DockerManifestParser.class), null, null, cache, null);
+    String digest = "sha256:" + "a".repeat(64);
+    when(docker.deleteBrowseReference(runtime.id(), "team/app", digest))
+        .thenReturn(new DockerRegistryDao.DeletedManifest(1, null, null));
+
+    assertEquals(1, store.deleteBrowseReference(runtime, "team/app", digest));
+
+    verify(docker, never()).deleteManifest(anyLong(), anyString(), anyString());
+    org.mockito.Mockito.verifyNoInteractions(assets);
+    verify(cache).invalidateMemberAfterCommit(runtime.id());
+  }
+
+  @Test
+  void browseLastReferenceDeletionReleasesAssetsAndMissingReferenceDoesNothing() {
+    AssetDao assets = mock(AssetDao.class);
+    DockerRegistryDao docker = mock(DockerRegistryDao.class);
+    RepositoryRuntime runtime = runtime("ALLOW");
+    DockerManifestStore store = new DockerManifestStore(assets, docker, mock(DockerBlobStore.class),
+        mock(DockerManifestParser.class), null, null);
+    when(docker.deleteBrowseReference(runtime.id(), "team/app", "latest"))
+        .thenReturn(DockerRegistryDao.DeletedManifest.notFound())
+        .thenReturn(new DockerRegistryDao.DeletedManifest(1, 200L, 300L));
+
+    assertEquals(0, store.deleteBrowseReference(runtime, "team/app", "latest"));
+    org.mockito.Mockito.verifyNoInteractions(assets);
+    assertEquals(1, store.deleteBrowseReference(runtime, "team/app", "latest"));
+    verify(assets).deleteAssetById(200L);
+    verify(assets).markBlobDeletedIfUnreferenced(300L, "docker manifest deleted");
+  }
+
+  @Test
   void hostedReferrersIncludeStoredManifestAnnotations() {
     DockerManifestStore manifestStore = mock(DockerManifestStore.class);
     DockerHostedService hosted = new DockerHostedService(

--- a/server/src/test/java/com/github/klboke/kkrepo/server/support/dao/DockerRegistryDaoAdapter.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/support/dao/DockerRegistryDaoAdapter.java
@@ -39,6 +39,11 @@ public class DockerRegistryDaoAdapter implements DockerRegistryDao {
   }
 
   @Override
+  public DeletedManifest deleteBrowseReference(long arg0, String arg1, String arg2) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public int deleteTag(long arg0, String arg1, String arg2) {
     throw new UnsupportedOperationException();
   }


### PR DESCRIPTION
Docker Browse exposed paths such as `hello-world/manifests/latest`, but its delete endpoint looked them up as generic asset paths. Administrators therefore received 404 even when the image existed.

This adds administrative deletion for the tag and digest leaves already exposed by Browse. Each delete removes only the selected reference, matching Nexus Browse: deleting a digest entry preserves existing tags and their downloadable manifest content. The asset and blob reference are released after the last tag/digest reference is removed; shared blobs remain protected. Registry V2 digest deletion keeps its existing behavior of removing the manifest and its tags.

Digest-reference deletion is stored in the manifest's database attributes and applied to Browse listing, details, and repeated deletion. Manifest row locks coordinate concurrent deletion and publishing across replicas, and a subsequent push restores the digest entry. Group requests affect only the selected source member; proxy deletion affects local cached content. Directory paths are rejected, including ambiguous image names ending in `/manifests`.

Validation:
- 92 focused Browse/Docker and HTTP smoke tests passed on MySQL and PostgreSQL across two application replicas. They cover retained tags after digest deletion, group reads, repeated deletion, republishing, final-reference cleanup, directory rejection, and shared manifest/layer content.
- Six shared persistence contract tests passed on both databases for transaction rollback, concurrent digest deletion, reference listing/detail visibility, final-reference cleanup, and republishing.
- The live Nexus Repository Community 3.94.0-12 black-box test passed using `coreui_Browse.read` -> `coreui_Component.readAsset` -> `coreui_Component.deleteAsset`. It compares retained tag status and manifest bytes after digest deletion, verifies missing administrative entries, and deletes the final tag on both systems. See `compat-test/docker-browse-delete-mapping.md` for the captured UI contracts.

- Latest commit `54e9bb63`: CI and all CodeQL analyses passed. Codecov patch coverage is 100%; project coverage is 85.98%. All review threads are resolved.

Fixes #285.
