### PR TITLE
Release kkRepo 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable public changes to kkrepo are documented in this file.
 
 This project follows a pragmatic release process. Stable releases call out migration impact, compatibility changes, operational notes, and any known behavior changes in their release section.
 
+## 1.0.1 - 2026-09-10
+
+### Added
+
+- Nexus-compatible Helm group repositories with ordered index aggregation, chart and provenance fallback across hosted, proxy, and nested group members, blob-backed metadata caching, database-fenced multi-replica invalidation, migration, and real Helm client coverage. (#272)
+- Content Selector management and preview in Admin, including expression validation, permission-aware stored-asset previews, privilege-reference inspection, repository-scoped privilege creation, bounded compiled-expression caching, and conservative SQL candidate filtering before full authorization checks. (#283)
+- OIDC ID-token verification supports `ES256` with EC P-256 JWKs, strict JOSE key/algorithm checks, and sanitized validation diagnostics while retaining the existing RSA path. (#267)
+
+### Changed
+
+- Quickstart now includes a readiness sidecar that supports `docker compose up --wait` for JVM and Native runtimes with either MySQL or PostgreSQL, while preserving scanner network isolation. (#286)
+- Quickstart defaults, Dockerfile packaging, deployment documentation, Helm application version, runtime checks, and the optional scanner profile now use `1.0.1`.
+- The AWS SDK, Alibaba Cloud OSS SDK, zstd-jni, GraalVM Native Build Tools, Maven Compiler and Surefire plugins, Java setup action, and Swift setup action were refreshed. (#273, #274, #275, #276, #278, #279, #280, #281, #282)
+- CI runs the Maven reactor in parallel, keeps database smoke scenarios in their dedicated jobs, publishes their coverage separately, and avoids diagnostic circuit-state reads when PyPI DEBUG logging is disabled. (#267)
+
+### Fixed
+
+- Legacy npm login and logout responses are fully materialized so their JSON bodies match `Content-Length` and no longer terminate early through generic streaming response handling. (#270, #271)
+- Docker tag and digest leaves exposed by Browse can be deleted administratively with Nexus-compatible reference semantics, database row locking across replicas, and correct final-reference blob cleanup. (#287)
+- Helm scanner byte-limit values are rendered as strings so large integer settings are not converted to scientific notation before Spring configuration binding. (#268)
+- PyPI proxy failures now retain the original upstream diagnostic at WARN while repeated circuit-open requests stay at DEBUG, without changing Auto Block behavior. (#267)
+
+### Compatibility And Validation
+
+- Helm group behavior is covered by Nexus 3.94 comparison, official Helm metadata validation, MySQL/PostgreSQL persistence contracts, durable multi-replica coordination, and real Helm client pulls through hosted and proxy members. (#272)
+- Content Selector management is covered by Nexus 3.94 comparison, both database backends, two-replica convergence, permission isolation, large candidate sets, browser verification, and the full JVM/Native E2E matrix. (#283)
+- Docker Browse deletion is covered against Nexus 3.94 and across MySQL/PostgreSQL with two application replicas; quickstart readiness is exercised across JVM/Native and MySQL/PostgreSQL. (#286, #287)
+- OIDC, npm, PyPI, scanner configuration, dependency, and CI changes retain targeted unit, integration, smoke, coverage, CodeQL, and client validation. (#267, #268, #270, #271, #273, #274, #275, #276, #278, #279, #280, #281, #282)
+
+### Upgrade Notes
+
+- Existing `1.0.0` MySQL and PostgreSQL deployments can upgrade in place through Flyway V51-V53. Back up the relational database and blob store together, allow migrations to complete before serving traffic, and do not run mixed application versions after the new schema is applied.
+- V51 adds a database-clock-fenced, one-time Helm proxy legacy-cache upgrade. V52 adds generation-safe acknowledgements for durable repository index markers. V53 isolates Helm group invalidation work in a dedicated queue that older repository-index workers cannot claim during a rolling upgrade.
+- Helm group repositories are opt-in and are not created automatically. Existing Content Selector expressions remain usable; new or changed expressions are validated before persistence, and delegated management requires explicit privileges.
+
 ## 1.0.0 - 2026-08-27
 
 ### Added
@@ -35,8 +70,8 @@ This project follows a pragmatic release process. Stable releases call out migra
 
 ### Upgrade Notes
 
-- Existing `0.9.0` MySQL and PostgreSQL deployments can upgrade in place through Flyway V49-V53. Back up the relational database and blob store together, allow migrations to complete before serving traffic, and do not run mixed application versions after the new schema is applied.
-- V49 adds R / CRAN package, publication, snapshot, group-binding, proxy, tombstone, migration, and lease state. V50 adds the shared default UI theme setting. V51 adds a database-clock-fenced, one-time Helm proxy legacy-cache upgrade: only never-reconfigured repositories can adopt pre-migration cache rows, and later writes or configuration changes force a rebuild. V52 adds generation-safe acknowledgements for durable repository index markers. V53 isolates Helm group invalidation work in a dedicated queue that older repository-index workers cannot claim during a rolling upgrade.
+- Existing `0.9.0` MySQL and PostgreSQL deployments can upgrade in place through Flyway V49-V50. Back up the relational database and blob store together, allow migrations to complete before serving traffic, and do not run mixed application versions after the new schema is applied.
+- V49 adds R / CRAN package, publication, snapshot, group-binding, proxy, tombstone, migration, and lease state. V50 adds the shared default UI theme setting and preserves the existing kkRepo design for upgraded installations.
 - New R / CRAN repositories are not created automatically. Existing PyPI proxies retain `/simple` when no remote index path is configured, and existing Go proxy/group repositories keep their current behavior until a hosted member is explicitly created or added.
 
 ## 0.9.0 - 2026-08-20

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:25-jre-jammy
 
 WORKDIR /app
 
-ARG JAR_FILE=server/target/kkrepo-server-1.0.0.jar
+ARG JAR_FILE=server/target/kkrepo-server-1.0.1.jar
 
 RUN groupadd --system kkrepo \
     && useradd --system --gid kkrepo --home-dir /app --shell /usr/sbin/nologin kkrepo

--- a/deploy/helm/kkrepo/Chart.yaml
+++ b/deploy/helm/kkrepo/Chart.yaml
@@ -3,5 +3,5 @@ name: kkrepo
 description: Multi-replica kkRepo artifact repository with an external MySQL or PostgreSQL database
 type: application
 version: 0.2.0
-appVersion: "1.0.0"
+appVersion: "1.0.1"
 kubeVersion: ">=1.27.0-0"

--- a/docker-compose.quickstart-postgresql.yml
+++ b/docker-compose.quickstart-postgresql.yml
@@ -41,7 +41,7 @@ services:
     network_mode: none
 
   kkrepo:
-    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-1.0.0}
+    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-1.0.1}
     depends_on:
       postgresql:
         condition: service_healthy
@@ -93,7 +93,7 @@ services:
     restart: unless-stopped
 
   scanner:
-    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-1.0.0}
+    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-1.0.1}
     profiles: ["security-scanning"]
     environment:
       KKREPO_SCANNER_SERVICE_CREDENTIAL: ${KKREPO_SECURITY_SCANNING_SERVICE_CREDENTIAL:-}
@@ -123,7 +123,7 @@ services:
     restart: unless-stopped
 
   scanner-database-updater:
-    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-1.0.0}
+    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-1.0.1}
     profiles: ["security-scanning"]
     entrypoint: ["/bin/sh", "-ec"]
     command:

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -42,7 +42,7 @@ services:
     network_mode: none
 
   kkrepo:
-    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-1.0.0}
+    image: ghcr.io/klboke/kkrepo:${KKREPO_IMAGE_TAG:-1.0.1}
     depends_on:
       mysql:
         condition: service_healthy
@@ -94,7 +94,7 @@ services:
     restart: unless-stopped
 
   scanner:
-    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-1.0.0}
+    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-1.0.1}
     profiles: ["security-scanning"]
     environment:
       KKREPO_SCANNER_SERVICE_CREDENTIAL: ${KKREPO_SECURITY_SCANNING_SERVICE_CREDENTIAL:-}
@@ -124,7 +124,7 @@ services:
     restart: unless-stopped
 
   scanner-database-updater:
-    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-1.0.0}
+    image: ghcr.io/klboke/kkrepo-scanner:${KKREPO_SCANNER_IMAGE_TAG:-1.0.1}
     profiles: ["security-scanning"]
     entrypoint: ["/bin/sh", "-ec"]
     command:

--- a/docs/en/build-deployment-guide.md
+++ b/docs/en/build-deployment-guide.md
@@ -40,7 +40,7 @@ curl -fsSL https://raw.githubusercontent.com/klboke/kkrepo/main/scripts/quicksta
   | KKREPO_RUNTIME=native KKREPO_DATABASE_TYPE=postgresql bash
 ```
 
-`KKREPO_RUNTIME=jvm` selects `ghcr.io/klboke/kkrepo:1.0.0`, while `KKREPO_RUNTIME=native` selects `ghcr.io/klboke/kkrepo:1.0.0-native`. Both are published for Linux `amd64` and `arm64`. An explicit `KKREPO_IMAGE_TAG` overrides the runtime's default tag.
+`KKREPO_RUNTIME=jvm` selects `ghcr.io/klboke/kkrepo:1.0.1`, while `KKREPO_RUNTIME=native` selects `ghcr.io/klboke/kkrepo:1.0.1-native`. Both are published for Linux `amd64` and `arm64`. An explicit `KKREPO_IMAGE_TAG` overrides the runtime's default tag.
 
 The script prints each step and:
 
@@ -61,7 +61,7 @@ bash quickstart.sh
 
 By default, it starts:
 
-- The JVM runtime from `ghcr.io/klboke/kkrepo:1.0.0`
+- The JVM runtime from `ghcr.io/klboke/kkrepo:1.0.1`
 - MySQL 8.0
 - A `kkrepo-health` sidecar that continuously probes application readiness
 - Persistent MySQL and File blob storage volumes for local trials
@@ -164,7 +164,7 @@ Note: a normal `server` module jar does not contain a Spring Boot executable ent
 Pull the latest public release image:
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:1.0.0
+docker pull ghcr.io/klboke/kkrepo:1.0.1
 ```
 
 You can also use `latest` to follow the latest public release:
@@ -176,7 +176,7 @@ docker pull ghcr.io/klboke/kkrepo:latest
 The Native image is published separately:
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:1.0.0-native
+docker pull ghcr.io/klboke/kkrepo:1.0.1-native
 docker pull ghcr.io/klboke/kkrepo:native-latest
 ```
 

--- a/docs/zh/build-deployment-guide.md
+++ b/docs/zh/build-deployment-guide.md
@@ -40,7 +40,7 @@ curl -fsSL https://raw.githubusercontent.com/klboke/kkrepo/main/scripts/quicksta
   | KKREPO_RUNTIME=native KKREPO_DATABASE_TYPE=postgresql bash
 ```
 
-`KKREPO_RUNTIME=jvm` 选择 `ghcr.io/klboke/kkrepo:1.0.0`，`KKREPO_RUNTIME=native` 选择 `ghcr.io/klboke/kkrepo:1.0.0-native`。两种镜像均发布 Linux `amd64` 和 `arm64` 架构。显式设置 `KKREPO_IMAGE_TAG` 时，会覆盖对应运行时的默认 tag。
+`KKREPO_RUNTIME=jvm` 选择 `ghcr.io/klboke/kkrepo:1.0.1`，`KKREPO_RUNTIME=native` 选择 `ghcr.io/klboke/kkrepo:1.0.1-native`。两种镜像均发布 Linux `amd64` 和 `arm64` 架构。显式设置 `KKREPO_IMAGE_TAG` 时，会覆盖对应运行时的默认 tag。
 
 该脚本会逐步打印日志并执行：
 
@@ -61,7 +61,7 @@ bash quickstart.sh
 
 默认会启动：
 
-- `ghcr.io/klboke/kkrepo:1.0.0` 中的 JVM 运行时
+- `ghcr.io/klboke/kkrepo:1.0.1` 中的 JVM 运行时
 - MySQL 8.0
 - 持续探测应用就绪状态的 `kkrepo-health` sidecar
 - 用于本地试用的持久化 MySQL volume 和 File blob storage volume
@@ -164,7 +164,7 @@ server/target/kkrepo-server-<version>.jar
 拉取最新公开发行镜像：
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:1.0.0
+docker pull ghcr.io/klboke/kkrepo:1.0.1
 ```
 
 也可以使用 `latest` 跟随最新公开发行版本：
@@ -176,7 +176,7 @@ docker pull ghcr.io/klboke/kkrepo:latest
 Native 镜像使用独立 tag：
 
 ```bash
-docker pull ghcr.io/klboke/kkrepo:1.0.0-native
+docker pull ghcr.io/klboke/kkrepo:1.0.1-native
 docker pull ghcr.io/klboke/kkrepo:native-latest
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
   </modules>
 
   <properties>
-    <revision>1.0.0</revision>
+    <revision>1.0.1</revision>
     <java.version>25</java.version>
     <spring.boot.version>4.1.1</spring.boot.version>
     <native-build-tools-plugin.version>1.1.11</native-build-tools-plugin.version>

--- a/scripts/ci/test-quickstart-runtime.sh
+++ b/scripts/ci/test-quickstart-runtime.sh
@@ -58,13 +58,13 @@ run_quickstart() {
 
 run_quickstart default-jvm
 grep -qx 'KKREPO_RUNTIME=jvm' "$TMP_ROOT/default-jvm/.env"
-grep -qx 'KKREPO_IMAGE_TAG=1.0.0' "$TMP_ROOT/default-jvm/.env"
-grep -qx 'jvm|1.0.0' "$TMP_ROOT/default-jvm.log"
+grep -qx 'KKREPO_IMAGE_TAG=1.0.1' "$TMP_ROOT/default-jvm/.env"
+grep -qx 'jvm|1.0.1' "$TMP_ROOT/default-jvm.log"
 
 run_quickstart native KKREPO_RUNTIME=native
 grep -qx 'KKREPO_RUNTIME=native' "$TMP_ROOT/native/.env"
-grep -qx 'KKREPO_IMAGE_TAG=1.0.0-native' "$TMP_ROOT/native/.env"
-grep -qx 'native|1.0.0-native' "$TMP_ROOT/native.log"
+grep -qx 'KKREPO_IMAGE_TAG=1.0.1-native' "$TMP_ROOT/native/.env"
+grep -qx 'native|1.0.1-native' "$TMP_ROOT/native.log"
 
 mkdir -p "$TMP_ROOT/existing-jvm"
 # Simulate a persisted v0.8.0 JVM quickstart before explicitly switching runtimes.
@@ -73,7 +73,7 @@ KKREPO_RUNTIME=jvm
 KKREPO_IMAGE_TAG=0.8.0
 EOF
 run_quickstart existing-jvm KKREPO_RUNTIME=native
-grep -qx 'native|1.0.0-native' "$TMP_ROOT/existing-jvm.log"
+grep -qx 'native|1.0.1-native' "$TMP_ROOT/existing-jvm.log"
 
 run_quickstart custom-native \
   KKREPO_RUNTIME=native \

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -186,10 +186,10 @@ fi
 KKREPO_RUNTIME="${KKREPO_RUNTIME:-jvm}"
 case "$KKREPO_RUNTIME" in
   jvm)
-    DEFAULT_IMAGE_TAG="1.0.0"
+    DEFAULT_IMAGE_TAG="1.0.1"
     ;;
   native)
-    DEFAULT_IMAGE_TAG="1.0.0-native"
+    DEFAULT_IMAGE_TAG="1.0.1-native"
     ;;
   *)
     fail "KKREPO_RUNTIME must be jvm or native, got: $KKREPO_RUNTIME"


### PR DESCRIPTION
## Summary

- bump the Maven revision, JVM Docker build input, Helm app version, quickstart JVM/Native/scanner defaults, runtime regression expectations, and bilingual deployment guides to `1.0.1`
- add the `1.0.1` changelog covering all 17 commits merged after `v1.0.0`, including Helm group repositories, Content Selector management, ES256 OIDC validation, Docker Browse deletion, npm response fixes, quickstart readiness, and dependency updates
- move Flyway V51-V53 upgrade guidance from the historical `1.0.0` section into `1.0.1`, matching the schemas actually added after the `v1.0.0` tag

## Validation

- [x] `mvn -B -ntp -N validate`
- [x] `mvn -pl server -am -Dtest=CacheAbstractionBoundaryTest -Dsurefire.failIfNoSpecifiedTests=false test` — 2 tests passed; all 34 reactor modules succeeded
- [x] `helm lint deploy/helm/kkrepo`
- [x] both quickstart Compose files validate with and without the `security-scanning` profile
- [x] `bash scripts/ci/test-quickstart-runtime.sh`
- [x] `bash scripts/ci/test-quickstart-data-permissions.sh` — JVM/Native × MySQL/PostgreSQL passed
- [x] `bash scripts/ci/check-flyway-parity.sh` — MySQL/PostgreSQL aligned at V53
- [x] `bash scripts/ci/check-compose-scanner-isolation.sh`
- [x] `git diff --check`

## Release plan

After merge, dispatch `Release Packages` from the exact merged `main` commit, publish the multi-architecture JVM image and rolling aliases, create GitHub Release `v1.0.1` with the complete archive/checksum set, then re-download and run the public images and bundles across the release runtime matrix.

## Compatibility and design checklist

- [x] This PR changes release metadata and documentation only; protocol behavior and compatibility coverage are inherited from the individually reviewed merged changes listed in the changelog.
- [x] No application state, cache, lock, session, permission, or migration implementation changes are introduced by this PR.
- [x] The cache abstraction boundary remains exception-free.