### PR TITLE
Honor trusted forwarded headers in UI redirects

### DIFF
--- a/server/src/main/java/com/github/klboke/kkrepo/server/AdminUiController.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/AdminUiController.java
@@ -1,6 +1,7 @@
 package com.github.klboke.kkrepo.server;
 
 import com.github.klboke.kkrepo.server.security.AuthenticatedSubject;
+import com.github.klboke.kkrepo.server.security.ForwardedHeaderPolicy;
 import com.github.klboke.kkrepo.server.security.SecurityAuthenticationService;
 import com.github.klboke.kkrepo.server.security.SecurityManagementService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -14,42 +15,52 @@ import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 public class AdminUiController {
-  private static final String BROWSE_WELCOME = "redirect:/browse/#browse/welcome";
-  private static final String AUTH_REQUIRED_WELCOME = "redirect:/browse/?login=1#browse/welcome";
+  private static final String BROWSE_WELCOME = "/browse/#browse/welcome";
+  private static final String AUTH_REQUIRED_WELCOME = "/browse/?login=1#browse/welcome";
   private static final Resource ADMIN_INDEX =
       new ClassPathResource("META-INF/resources/admin/index.html");
 
   private final SecurityAuthenticationService authenticationService;
   private final SecurityManagementService securityService;
+  private final ForwardedHeaderPolicy forwardedHeaderPolicy;
 
   public AdminUiController(
       SecurityAuthenticationService authenticationService,
-      SecurityManagementService securityService) {
+      SecurityManagementService securityService,
+      ForwardedHeaderPolicy forwardedHeaderPolicy) {
     this.authenticationService = authenticationService;
     this.securityService = securityService;
+    this.forwardedHeaderPolicy = forwardedHeaderPolicy;
   }
 
   @GetMapping("/")
-  public String index() {
-    return BROWSE_WELCOME;
+  public String index(HttpServletRequest request) {
+    return redirect(request, BROWSE_WELCOME);
   }
 
   @GetMapping({"/admin", "/admin/", "/admin/index.html"})
   public Object admin(HttpServletRequest request) {
     AuthenticatedSubject subject = authenticationService.authenticate(request).orElse(null);
     if (subject == null) {
-      return AUTH_REQUIRED_WELCOME;
+      return redirect(request, AUTH_REQUIRED_WELCOME);
     }
     boolean allowed = securityService.decide(subject.permissionSubject(), "nexus:*").allowed()
         || java.util.List.of("read", "create", "update", "delete").stream().anyMatch(action ->
             securityService.decide(subject.permissionSubject(), "nexus:selectors:" + action).allowed());
     if (!allowed) {
-      return BROWSE_WELCOME;
+      return redirect(request, BROWSE_WELCOME);
     }
     request.setAttribute(AuthenticatedSubject.REQUEST_ATTRIBUTE, subject);
     return ResponseEntity.ok()
         .contentType(MediaType.TEXT_HTML)
         .cacheControl(CacheControl.noCache())
         .body(ADMIN_INDEX);
+  }
+
+  private String redirect(HttpServletRequest request, String path) {
+    return "redirect:"
+        + forwardedHeaderPolicy.serverBaseUrl(request)
+        + request.getContextPath()
+        + path;
   }
 }

--- a/server/src/main/java/com/github/klboke/kkrepo/server/AdminUiController.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/AdminUiController.java
@@ -58,6 +58,9 @@ public class AdminUiController {
   }
 
   private String redirect(HttpServletRequest request, String path) {
+    if (!forwardedHeaderPolicy.trusted(request)) {
+      return "redirect:" + path;
+    }
     return "redirect:"
         + forwardedHeaderPolicy.serverBaseUrl(request)
         + request.getContextPath()

--- a/server/src/main/java/com/github/klboke/kkrepo/server/security/ForwardedHeaderPolicy.java
+++ b/server/src/main/java/com/github/klboke/kkrepo/server/security/ForwardedHeaderPolicy.java
@@ -37,7 +37,8 @@ public class ForwardedHeaderPolicy {
     }
     String portHeader = trustedForwarded ? firstHeader(request, "X-Forwarded-Port", null) : null;
     String authority = host;
-    if (!host.contains(":")) {
+    boolean bracketedIpv6WithoutPort = host.startsWith("[") && host.endsWith("]");
+    if (!host.contains(":") || bracketedIpv6WithoutPort) {
       int port = parsePort(portHeader, request.getServerPort());
       boolean standard = ("http".equalsIgnoreCase(scheme) && port == 80)
           || ("https".equalsIgnoreCase(scheme) && port == 443);

--- a/server/src/test/java/com/github/klboke/kkrepo/server/AdminUiControllerTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/AdminUiControllerTest.java
@@ -67,6 +67,34 @@ class AdminUiControllerTest {
   }
 
   @Test
+  void rootRedirectPreservesTrustedIpv6ForwardedPort() throws Exception {
+    AdminUiController controller = new AdminUiController(
+        new StubAuthenticationService(Optional.empty()),
+        new StubSecurityService(AccessDecision.deny("missing")),
+        new ForwardedHeaderPolicy("10.0.0.1"));
+
+    var response = MockMvcBuilders.standaloneSetup(controller).build()
+        .perform(get("/")
+            .with(request -> {
+              request.setScheme("http");
+              request.setServerName("kkrepo.internal");
+              request.setServerPort(8080);
+              request.setRemoteAddr("10.0.0.1");
+              return request;
+            })
+            .header("X-Forwarded-Proto", "https")
+            .header("X-Forwarded-Host", "[2001:db8::1]")
+            .header("X-Forwarded-Port", "8443"))
+        .andReturn()
+        .getResponse();
+
+    assertEquals(HttpStatus.FOUND.value(), response.getStatus());
+    assertEquals(
+        "https://[2001:db8::1]:8443/browse/#browse/welcome",
+        response.getHeader("Location"));
+  }
+
+  @Test
   void rootRedirectIgnoresUntrustedForwardedOrigin() throws Exception {
     AdminUiController controller = new AdminUiController(
         new StubAuthenticationService(Optional.empty()),

--- a/server/src/test/java/com/github/klboke/kkrepo/server/AdminUiControllerTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/AdminUiControllerTest.java
@@ -73,6 +73,18 @@ class AdminUiControllerTest {
         new StubSecurityService(AccessDecision.deny("missing")),
         new ForwardedHeaderPolicy("10.0.0.1"));
 
+    MockHttpServletRequest directRequest = new MockHttpServletRequest();
+    directRequest.setScheme("http");
+    directRequest.setServerName("kkrepo.internal");
+    directRequest.setServerPort(8080);
+    directRequest.setRemoteAddr("192.0.2.10");
+    directRequest.setContextPath("/kkrepo");
+    directRequest.addHeader("X-Forwarded-Proto", "https");
+    directRequest.addHeader("X-Forwarded-Host", "attacker.example.com");
+    directRequest.addHeader("X-Forwarded-Port", "443");
+
+    assertEquals("redirect:/browse/#browse/welcome", controller.index(directRequest));
+
     var response = MockMvcBuilders.standaloneSetup(controller).build()
         .perform(get("/")
             .with(request -> {
@@ -89,8 +101,21 @@ class AdminUiControllerTest {
         .getResponse();
 
     assertEquals(HttpStatus.FOUND.value(), response.getStatus());
-    assertEquals(
-        "http://kkrepo.internal:8080/browse/#browse/welcome", response.getHeader("Location"));
+    assertEquals("/browse/#browse/welcome", response.getHeader("Location"));
+  }
+
+  @Test
+  void rootRedirectRemainsRelativeForDirectIpv6Request() {
+    AdminUiController controller = new AdminUiController(
+        new StubAuthenticationService(Optional.empty()),
+        new StubSecurityService(AccessDecision.deny("missing")),
+        new ForwardedHeaderPolicy("10.0.0.1"));
+    MockHttpServletRequest directRequest = new MockHttpServletRequest();
+    directRequest.setServerName("2001:db8::1");
+    directRequest.setRemoteAddr("2001:db8::2");
+    directRequest.setContextPath("/kkrepo");
+
+    assertEquals("redirect:/browse/#browse/welcome", controller.index(directRequest));
   }
 
   @Test
@@ -100,8 +125,7 @@ class AdminUiControllerTest {
         new StubSecurityService(AccessDecision.allow()),
         new ForwardedHeaderPolicy(""));
 
-    assertEquals(
-        "redirect:http://localhost/browse/?login=1#browse/welcome", controller.admin(request()));
+    assertEquals("redirect:/browse/?login=1#browse/welcome", controller.admin(request()));
   }
 
   @Test
@@ -111,7 +135,7 @@ class AdminUiControllerTest {
         new StubSecurityService(AccessDecision.deny("missing nexus:*")),
         new ForwardedHeaderPolicy(""));
 
-    assertEquals("redirect:http://localhost/browse/#browse/welcome", controller.admin(request()));
+    assertEquals("redirect:/browse/#browse/welcome", controller.admin(request()));
   }
 
   @Test

--- a/server/src/test/java/com/github/klboke/kkrepo/server/AdminUiControllerTest.java
+++ b/server/src/test/java/com/github/klboke/kkrepo/server/AdminUiControllerTest.java
@@ -3,19 +3,18 @@ package com.github.klboke.kkrepo.server;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.klboke.kkrepo.auth.AccessDecision;
 import com.github.klboke.kkrepo.auth.PermissionSubject;
 import com.github.klboke.kkrepo.persistence.jdbc.api.SecurityDao;
 import com.github.klboke.kkrepo.server.security.AuthenticatedSubject;
+import com.github.klboke.kkrepo.server.security.ForwardedHeaderPolicy;
 import com.github.klboke.kkrepo.server.security.SecurityAuthenticationService;
 import com.github.klboke.kkrepo.server.security.SecurityManagementService;
 import com.github.klboke.kkrepo.server.support.dao.SecurityDaoAdapter;
 import jakarta.servlet.http.HttpServletRequest;
-import java.lang.reflect.Proxy;
-import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -23,6 +22,8 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 class AdminUiControllerTest {
   @Test
@@ -33,35 +34,84 @@ class AdminUiControllerTest {
         org.mockito.ArgumentMatchers.anyString())).thenReturn(AccessDecision.deny("missing"));
     org.mockito.Mockito.when(security.decide(subject.permissionSubject(), "nexus:selectors:read"))
         .thenReturn(AccessDecision.allow());
-    var controller = new AdminUiController(new StubAuthenticationService(Optional.of(subject)), security);
+    var controller = new AdminUiController(
+        new StubAuthenticationService(Optional.of(subject)), security, new ForwardedHeaderPolicy(""));
     assertInstanceOf(ResponseEntity.class, controller.admin(request()));
   }
 
   @Test
-  void rootRedirectsToBrowseWelcome() {
+  void rootRedirectUsesTrustedForwardedOrigin() throws Exception {
     AdminUiController controller = new AdminUiController(
         new StubAuthenticationService(Optional.empty()),
-        new StubSecurityService(AccessDecision.deny("missing")));
+        new StubSecurityService(AccessDecision.deny("missing")),
+        new ForwardedHeaderPolicy("10.0.0.1"));
 
-    assertEquals("redirect:/browse/#browse/welcome", controller.index());
+    var response = MockMvcBuilders.standaloneSetup(controller).build()
+        .perform(get("/")
+            .with(request -> {
+              request.setScheme("http");
+              request.setServerName("kkrepo.internal");
+              request.setServerPort(8080);
+              request.setRemoteAddr("10.0.0.1");
+              return request;
+            })
+            .header("X-Forwarded-Proto", "https")
+            .header("X-Forwarded-Host", "nexus.example.com")
+            .header("X-Forwarded-Port", "443"))
+        .andReturn()
+        .getResponse();
+
+    assertEquals(HttpStatus.FOUND.value(), response.getStatus());
+    assertEquals(
+        "https://nexus.example.com/browse/#browse/welcome", response.getHeader("Location"));
+  }
+
+  @Test
+  void rootRedirectIgnoresUntrustedForwardedOrigin() throws Exception {
+    AdminUiController controller = new AdminUiController(
+        new StubAuthenticationService(Optional.empty()),
+        new StubSecurityService(AccessDecision.deny("missing")),
+        new ForwardedHeaderPolicy("10.0.0.1"));
+
+    var response = MockMvcBuilders.standaloneSetup(controller).build()
+        .perform(get("/")
+            .with(request -> {
+              request.setScheme("http");
+              request.setServerName("kkrepo.internal");
+              request.setServerPort(8080);
+              request.setRemoteAddr("192.0.2.10");
+              return request;
+            })
+            .header("X-Forwarded-Proto", "https")
+            .header("X-Forwarded-Host", "attacker.example.com")
+            .header("X-Forwarded-Port", "443"))
+        .andReturn()
+        .getResponse();
+
+    assertEquals(HttpStatus.FOUND.value(), response.getStatus());
+    assertEquals(
+        "http://kkrepo.internal:8080/browse/#browse/welcome", response.getHeader("Location"));
   }
 
   @Test
   void adminRedirectsWhenSessionIsMissing() {
     AdminUiController controller = new AdminUiController(
         new StubAuthenticationService(Optional.empty()),
-        new StubSecurityService(AccessDecision.allow()));
+        new StubSecurityService(AccessDecision.allow()),
+        new ForwardedHeaderPolicy(""));
 
-    assertEquals("redirect:/browse/?login=1#browse/welcome", controller.admin(request()));
+    assertEquals(
+        "redirect:http://localhost/browse/?login=1#browse/welcome", controller.admin(request()));
   }
 
   @Test
   void adminRedirectsWhenSubjectIsNotAdministrator() {
     AdminUiController controller = new AdminUiController(
         new StubAuthenticationService(Optional.of(subject("alice"))),
-        new StubSecurityService(AccessDecision.deny("missing nexus:*")));
+        new StubSecurityService(AccessDecision.deny("missing nexus:*")),
+        new ForwardedHeaderPolicy(""));
 
-    assertEquals("redirect:/browse/#browse/welcome", controller.admin(request()));
+    assertEquals("redirect:http://localhost/browse/#browse/welcome", controller.admin(request()));
   }
 
   @Test
@@ -70,7 +120,8 @@ class AdminUiControllerTest {
     HttpServletRequest request = request();
     AdminUiController controller = new AdminUiController(
         new StubAuthenticationService(Optional.of(subject)),
-        new StubSecurityService(AccessDecision.allow()));
+        new StubSecurityService(AccessDecision.allow()),
+        new ForwardedHeaderPolicy(""));
 
     Object result = controller.admin(request);
 
@@ -92,32 +143,7 @@ class AdminUiControllerTest {
   }
 
   private static HttpServletRequest request() {
-    Map<String, Object> attributes = new LinkedHashMap<>();
-    return (HttpServletRequest) Proxy.newProxyInstance(
-        AdminUiControllerTest.class.getClassLoader(),
-        new Class<?>[] {HttpServletRequest.class},
-        (proxy, invoked, args) -> switch (invoked.getName()) {
-          case "getAttribute" -> attributes.get(String.valueOf(args[0]));
-          case "setAttribute" -> {
-            attributes.put(String.valueOf(args[0]), args[1]);
-            yield null;
-          }
-          case "toString" -> "AdminUiControllerTest request";
-          default -> primitiveDefault(invoked.getReturnType());
-        });
-  }
-
-  private static Object primitiveDefault(Class<?> type) {
-    if (boolean.class.equals(type)) {
-      return false;
-    }
-    if (int.class.equals(type) || long.class.equals(type) || short.class.equals(type) || byte.class.equals(type)) {
-      return 0;
-    }
-    if (char.class.equals(type)) {
-      return '\0';
-    }
-    return null;
+    return new MockHttpServletRequest();
   }
 
   private static class StubAuthenticationService extends SecurityAuthenticationService {


### PR DESCRIPTION
## Summary

- build root and admin UI redirects from the existing trusted forwarded-header policy
- preserve the configured servlet context path
- cover trusted HTTPS proxy headers and reject untrusted forwarded origins

## Testing

- `mvn -pl server -am -Dtest=AdminUiControllerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl server -am test`

Fixes #290
